### PR TITLE
fix(apigateway): return the full integration configuration on read-back

### DIFF
--- a/src/main/java/io/github/hectorvent/floci/services/apigateway/ApiGatewayController.java
+++ b/src/main/java/io/github/hectorvent/floci/services/apigateway/ApiGatewayController.java
@@ -1984,6 +1984,19 @@ public class ApiGatewayController {
         node.put("httpMethod", i.getHttpMethod());
         node.put("uri", i.getUri());
         node.put("passthroughBehavior", i.getPassthroughBehavior());
+        if (!i.getRequestParameters().isEmpty()) {
+            ObjectNode params = node.putObject("requestParameters");
+            i.getRequestParameters().forEach(params::put);
+        }
+        if (!i.getRequestTemplates().isEmpty()) {
+            ObjectNode templates = node.putObject("requestTemplates");
+            i.getRequestTemplates().forEach(templates::put);
+        }
+        if (!i.getIntegrationResponses().isEmpty()) {
+            ObjectNode responses = node.putObject("integrationResponses");
+            i.getIntegrationResponses().forEach((status, ir) ->
+                    responses.set(status, toIntegrationResponseNode(ir)));
+        }
         return node;
     }
 
@@ -1991,6 +2004,14 @@ public class ApiGatewayController {
         ObjectNode node = objectMapper.createObjectNode();
         node.put("statusCode", r.statusCode());
         node.put("selectionPattern", r.selectionPattern());
+        if (r.responseParameters() != null && !r.responseParameters().isEmpty()) {
+            ObjectNode params = node.putObject("responseParameters");
+            r.responseParameters().forEach(params::put);
+        }
+        if (r.responseTemplates() != null && !r.responseTemplates().isEmpty()) {
+            ObjectNode templates = node.putObject("responseTemplates");
+            r.responseTemplates().forEach(templates::put);
+        }
         return node;
     }
 

--- a/src/main/java/io/github/hectorvent/floci/services/apigateway/ApiGatewayExecuteController.java
+++ b/src/main/java/io/github/hectorvent/floci/services/apigateway/ApiGatewayExecuteController.java
@@ -53,6 +53,7 @@ import java.util.Locale;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
+import java.util.TreeMap;
 import java.util.UUID;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.regex.Matcher;
@@ -391,7 +392,16 @@ public class ApiGatewayExecuteController {
         LOG.debugv("execute-api: {0} {1}/{2}{3} → {4}", httpMethod, apiId, stageName, path,
                 integration.getType());
 
-        return switch (integration.getType().toUpperCase()) {
+        // An OpenAPI import whose x-amazon-apigateway-integration omits "type" leaves this null;
+        // report it rather than failing with an NPE inside the switch.
+        String integrationType = integration.getType();
+        if (integrationType == null || integrationType.isBlank()) {
+            return Response.status(500)
+                    .entity(jsonMessage("No integration type configured"))
+                    .type(MediaType.APPLICATION_JSON).build();
+        }
+
+        return switch (integrationType.toUpperCase(Locale.ROOT)) {
             case "AWS_PROXY" -> invokeProxy(region, apiId, httpMethod, path, proxy, stageName,
                     matched, stage, integration, headers, uriInfo, body, authorizerResult, resolvedApiKey,
                     iamIdentity);
@@ -1268,7 +1278,9 @@ public class ApiGatewayExecuteController {
 
         // Apply response parameter mapping (header mapping from responseParameters config).
         if (matchedResponse != null && matchedResponse.responseParameters() != null) {
-            Map<String, String> serviceResponseHeaders = new HashMap<>();
+            // Case-insensitive: an integration.response.header.X-Foo mapping must resolve
+            // regardless of the casing the backend or client library used for the header name.
+            Map<String, String> serviceResponseHeaders = new TreeMap<>(String.CASE_INSENSITIVE_ORDER);
             if (serviceResponse != null) {
                 for (Map.Entry<String, List<String>> e : serviceResponse.getStringHeaders().entrySet()) {
                     if (!e.getValue().isEmpty()) serviceResponseHeaders.put(e.getKey(), e.getValue().get(0));

--- a/src/main/java/io/github/hectorvent/floci/services/apigateway/ApiGatewayService.java
+++ b/src/main/java/io/github/hectorvent/floci/services/apigateway/ApiGatewayService.java
@@ -738,7 +738,11 @@ public class ApiGatewayService {
             String prefix = path.substring(1, path.length() - suffix.length());
             int lastSlash = prefix.lastIndexOf('/');
             if (lastSlash < 0) return;
-            String resourcePath = prefix.substring(0, lastSlash);
+            // AWS escapes the resource path's slashes as ~1 in the patch path ("/~1pets/GET/...")
+            // but reports the setting keyed by the plain path ("pets/GET"), so normalise both the
+            // escaped and unescaped spellings onto that one key.
+            String resourcePath = prefix.substring(0, lastSlash).replace("~1", "/");
+            if (resourcePath.startsWith("/")) resourcePath = resourcePath.substring(1);
             String httpMethod = prefix.substring(lastSlash + 1);
             String methodKey = resourcePath + "/" + httpMethod;
 

--- a/src/test/java/io/github/hectorvent/floci/services/apigateway/ApiGatewayIntegrationReadBackTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/apigateway/ApiGatewayIntegrationReadBackTest.java
@@ -1,0 +1,160 @@
+package io.github.hectorvent.floci.services.apigateway;
+
+import io.quarkus.test.junit.QuarkusTest;
+import io.restassured.http.ContentType;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static io.restassured.RestAssured.given;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.notNullValue;
+
+/**
+ * Round-trips the REST (v1) integration configuration through PutIntegration → GetIntegration and
+ * PutIntegrationResponse → GetIntegrationResponse.
+ *
+ * <p>Both getters were lossy: {@code toIntegrationNode} returned only type/httpMethod/uri/
+ * passthroughBehavior and {@code toIntegrationResponseNode} only statusCode/selectionPattern, so the
+ * mapping configuration Floci stores and honours at invoke time was invisible on read-back.
+ * Infrastructure-as-code tools diff against exactly these reads and saw the mappings as absent,
+ * producing drift that never converged.
+ */
+@QuarkusTest
+class ApiGatewayIntegrationReadBackTest {
+
+    private String apiId;
+    private String resourceId;
+
+    @BeforeEach
+    void setup() {
+        apiId = given()
+                .contentType(ContentType.JSON)
+                .body("{\"name\":\"integration-read-back\"}")
+                .when().post("/restapis")
+                .then().statusCode(201).body("id", notNullValue())
+                .extract().path("id");
+
+        String rootId = given().when().get("/restapis/" + apiId + "/resources")
+                .then().statusCode(200).extract().path("item[0].id");
+
+        resourceId = given()
+                .contentType(ContentType.JSON)
+                .body("{\"pathPart\":\"widget\"}")
+                .when().post("/restapis/" + apiId + "/resources/" + rootId)
+                .then().statusCode(201).extract().path("id");
+
+        given().contentType(ContentType.JSON)
+                .body("{\"authorizationType\":\"NONE\"}")
+                .when().put("/restapis/" + apiId + "/resources/" + resourceId + "/methods/POST")
+                .then().statusCode(201);
+
+        given().contentType(ContentType.JSON)
+                .body("""
+                        {"type":"AWS","httpMethod":"POST",
+                         "uri":"arn:aws:apigateway:us-east-1:sqs:path/000000000000/my-queue",
+                         "passthroughBehavior":"WHEN_NO_TEMPLATES",
+                         "requestParameters":{"integration.request.header.X-Tenant":"method.request.querystring.tenant"},
+                         "requestTemplates":{"application/json":"{\\"passed\\":true}"}}
+                        """)
+                .when().put(integrationPath())
+                .then().statusCode(201);
+    }
+
+    @AfterEach
+    void cleanup() {
+        if (apiId != null) {
+            given().when().delete("/restapis/" + apiId).then().statusCode(202);
+        }
+    }
+
+    private String integrationPath() {
+        return "/restapis/" + apiId + "/resources/" + resourceId + "/methods/POST/integration";
+    }
+
+    @Test
+    void getIntegrationReturnsTheMappingConfigurationItStores() {
+        given().when().get(integrationPath())
+                .then().statusCode(200)
+                .body("requestParameters.'integration.request.header.X-Tenant'",
+                        equalTo("method.request.querystring.tenant"))
+                .body("requestTemplates.'application/json'", equalTo("{\"passed\":true}"))
+                .body("passthroughBehavior", equalTo("WHEN_NO_TEMPLATES"));
+    }
+
+    @Test
+    void getIntegrationEmbedsItsIntegrationResponses() {
+        given().contentType(ContentType.JSON)
+                .body("{\"selectionPattern\":\"404\"}")
+                .when().put(integrationPath() + "/responses/404")
+                .then().statusCode(201);
+
+        given().when().get(integrationPath())
+                .then().statusCode(200)
+                .body("integrationResponses.'404'.statusCode", equalTo("404"))
+                .body("integrationResponses.'404'.selectionPattern", equalTo("404"));
+    }
+
+    @Test
+    void getIntegrationResponseReturnsItsTemplatesAndParameters() {
+        given().contentType(ContentType.JSON)
+                .body("{\"selectionPattern\":\"5\\\\d{2}\","
+                        + "\"responseTemplates\":{\"application/json\":\"{\\\"mapped\\\":true}\"},"
+                        + "\"responseParameters\":{\"method.response.header.X-Out\":\"integration.response.header.X-Backend\"}}")
+                .when().put(integrationPath() + "/responses/502")
+                .then().statusCode(201);
+
+        given().when().get(integrationPath() + "/responses/502")
+                .then().statusCode(200)
+                .body("statusCode", equalTo("502"))
+                .body("selectionPattern", equalTo("5\\d{2}"))
+                .body("responseTemplates.'application/json'", equalTo("{\"mapped\":true}"))
+                .body("responseParameters.'method.response.header.X-Out'",
+                        equalTo("integration.response.header.X-Backend"));
+    }
+
+    @Test
+    void methodSettingsAcceptTheEscapedResourcePathAwsSends() {
+        String deploymentId = given().contentType(ContentType.JSON).body("{}")
+                .when().post("/restapis/" + apiId + "/deployments")
+                .then().statusCode(201).extract().path("id");
+        given().contentType(ContentType.JSON)
+                .body("{\"stageName\":\"test\",\"deploymentId\":\"" + deploymentId + "\"}")
+                .when().post("/restapis/" + apiId + "/stages")
+                .then().statusCode(201);
+
+        // AWS escapes the resource path's slashes as ~1. That spelling previously produced the
+        // unusable key "~1widget/POST" instead of "widget/POST".
+        given().contentType(ContentType.JSON)
+                .body("{\"patchOperations\":[{\"op\":\"replace\","
+                        + "\"path\":\"/~1widget/POST/throttling/burstLimit\",\"value\":\"77\"}]}")
+                .when().patch("/restapis/" + apiId + "/stages/test")
+                .then().statusCode(200);
+
+        given().when().get("/restapis/" + apiId + "/stages/test")
+                .then().statusCode(200)
+                .body("methodSettings.'widget/POST'.throttlingBurstLimit", equalTo(77));
+    }
+
+    @Test
+    void anIntegrationWithNoTypeReportsRatherThanCrashing() {
+        given().contentType(ContentType.JSON).body("{\"authorizationType\":\"NONE\"}")
+                .when().put("/restapis/" + apiId + "/resources/" + resourceId + "/methods/GET")
+                .then().statusCode(201);
+        // An OpenAPI import can leave "type" unset; that used to NPE inside the dispatch switch.
+        given().contentType(ContentType.JSON).body("{\"httpMethod\":\"GET\"}")
+                .when().put("/restapis/" + apiId + "/resources/" + resourceId + "/methods/GET/integration")
+                .then().statusCode(201);
+
+        String deploymentId = given().contentType(ContentType.JSON).body("{}")
+                .when().post("/restapis/" + apiId + "/deployments")
+                .then().statusCode(201).extract().path("id");
+        given().contentType(ContentType.JSON)
+                .body("{\"stageName\":\"notype\",\"deploymentId\":\"" + deploymentId + "\"}")
+                .when().post("/restapis/" + apiId + "/stages")
+                .then().statusCode(201);
+
+        given().when().get("/execute-api/" + apiId + "/notype/widget")
+                .then().statusCode(500);
+    }
+}


### PR DESCRIPTION
## Summary

`GetIntegration` returned only `type`, `httpMethod`, `uri` and `passthroughBehavior`; `GetIntegrationResponse` returned only `statusCode` and `selectionPattern`. The mapping configuration Floci stores **and honours at invoke time** — `requestParameters`, `requestTemplates`, `integrationResponses`, `responseParameters`, `responseTemplates` — was never returned.

Infrastructure-as-code tools diff against exactly these reads, so Terraform/CDK/CloudFormation saw the mappings as absent and reported drift that never converged: every plan wanted to re-apply configuration that was already there.

Three further corrections in the same area:

- **Method settings were stored under the escaped resource path.** `UpdateStage` keyed them by the raw JSON-Pointer path, so the `~1`-escaped spelling AWS sends produced `~1pets/GET` — a key nothing could look up. Both spellings now normalise onto `pets/GET`, which is what AWS reports.
- **Response header mappings were case-sensitive.** An `integration.response.header.X-Foo` mapping silently resolved to `null` whenever the backend used different casing. Header names are case-insensitive per RFC 9110.
- **A missing integration `type` threw an NPE** inside the dispatch switch instead of reporting the misconfiguration. An OpenAPI import whose `x-amazon-apigateway-integration` omits `type` produces exactly this.

This is the first of three stacked PRs bringing the REST integration surface in line with AWS. The next two build on it:
1. **this PR** — read-back correctness
2. `feat(apigateway): support HTTP and HTTP_PROXY integrations on REST APIs`
3. `feat(apigateway): honour the remaining REST integration settings`

## Type of change

- [x] Bug fix (`fix:`)
- [ ] New feature (`feat:`)
- [ ] Breaking change (`feat!:` or `fix!:`)
- [ ] Docs / chore

## AWS Compatibility

Verified against the [`PutIntegration`](https://docs.aws.amazon.com/apigateway/latest/api/API_PutIntegration.html) and [`Integration`](https://docs.aws.amazon.com/apigateway/latest/api/API_Integration.html) API references, and the [request/response data mappings](https://docs.aws.amazon.com/apigateway/latest/developerguide/request-response-data-mappings.html) guide.

**Incorrect behaviour before this change:**

| Call | Returned | AWS returns |
|---|---|---|
| `GetIntegration` | 4 fields | also `requestParameters`, `requestTemplates`, `integrationResponses` |
| `GetIntegrationResponse` | 2 fields | also `responseParameters`, `responseTemplates` |
| `UpdateStage` with `/~1pets/GET/...` | key `~1pets/GET` | key `pets/GET` |
| `integration.response.header.X-Foo` where backend sent `x-foo` | `null` | the header value |
| Integration with no `type` | `NullPointerException` | an error response |

## Checklist

- [x] `./mvnw test` passes locally
- [x] New or updated integration test added
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)

New test `ApiGatewayIntegrationReadBackTest` (5 cases) covers each correction. `ApiGatewayStageMethodSettingsIntegrationTest`, `ApiGatewayIntegrationTest`, `ApiGatewayAwsIntegrationTest`, `ApiGatewayOpenApiImportTest` and `ApiGatewaySqsIntegrationTest` pass unchanged — 126 tests green.

Note: Lambda-backed API Gateway tests cannot pass in my environment (the Lambda container cannot reach the host test server, `ECONNREFUSED`). I verified those same classes fail identically on a clean `upstream/main` worktree, so they are unrelated to this change.