### PR TITLE
fix(scheduler): forward MessageAttributes in universal sqs target

### DIFF
--- a/src/main/java/io/github/hectorvent/floci/services/scheduler/ScheduleInvoker.java
+++ b/src/main/java/io/github/hectorvent/floci/services/scheduler/ScheduleInvoker.java
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.github.hectorvent.floci.config.EmulatorConfig;
 import io.github.hectorvent.floci.core.common.AwsArnUtils;
+import io.github.hectorvent.floci.core.common.AwsException;
 import io.github.hectorvent.floci.services.ecs.EcsService;
 import io.github.hectorvent.floci.services.ecs.model.LaunchType;
 import io.github.hectorvent.floci.services.eventbridge.EventBridgeService;
@@ -20,7 +21,7 @@ import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
 import org.jboss.logging.Logger;
 
-import java.nio.charset.StandardCharsets;
+import java.util.Base64;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -198,15 +199,25 @@ public class ScheduleInvoker {
         }
         attrsNode.fields().forEachRemaining(entry -> {
             JsonNode valueNode = entry.getValue();
-            String binaryValue = valueNode.path("BinaryValue").asText(null);
-            String dataType = valueNode.path("DataType")
-                    .asText(binaryValue != null ? "Binary" : "String");
-            if (binaryValue != null) {
+            String dataType = valueNode.path("DataType").asText(null);
+            String stringValue = valueNode.path("StringValue").asText(null);
+            String binaryValueBase64 = valueNode.path("BinaryValue").asText(null);
+            if (dataType == null) {
+                return;
+            }
+            if (binaryValueBase64 != null) {
+                byte[] binaryValue;
+                try {
+                    binaryValue = Base64.getDecoder().decode(binaryValueBase64);
+                } catch (IllegalArgumentException e) {
+                    throw new AwsException("InvalidParameterValue",
+                            "Invalid binary value for message attribute '" + entry.getKey()
+                                    + "': not valid base64.", 400);
+                }
+                attributes.put(entry.getKey(), new MessageAttributeValue(binaryValue, dataType));
+            } else if (stringValue != null) {
                 attributes.put(entry.getKey(), new MessageAttributeValue(
-                        binaryValue.getBytes(StandardCharsets.UTF_8), dataType));
-            } else {
-                attributes.put(entry.getKey(), new MessageAttributeValue(
-                        valueNode.path("StringValue").asText(null), dataType));
+                        stringValue, dataType));
             }
         });
         return attributes;

--- a/src/main/java/io/github/hectorvent/floci/services/scheduler/ScheduleInvoker.java
+++ b/src/main/java/io/github/hectorvent/floci/services/scheduler/ScheduleInvoker.java
@@ -20,6 +20,7 @@ import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
 import org.jboss.logging.Logger;
 
+import java.nio.charset.StandardCharsets;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -180,11 +181,35 @@ public class ScheduleInvoker {
                 String body = text(params, "MessageBody");
                 String messageGroupId = text(params, "MessageGroupId");
                 String messageDeduplicationId = text(params, "MessageDeduplicationId");
-                sqsService.sendMessage(queueUrl, body, 0, messageGroupId, messageDeduplicationId, region);
+                Map<String, MessageAttributeValue> messageAttributes =
+                        parseUniversalSqsMessageAttributes(params.path("MessageAttributes"));
+                sqsService.sendMessage(queueUrl, body, 0, messageGroupId, messageDeduplicationId,
+                        messageAttributes, region);
                 LOG.debugv("Scheduler delivered to SQS (universal target): {0}", queueUrl);
             }
             default -> LOG.warnv("Scheduler: unsupported universal target action: {0}", serviceAction);
         }
+    }
+
+    private static Map<String, MessageAttributeValue> parseUniversalSqsMessageAttributes(JsonNode attrsNode) {
+        Map<String, MessageAttributeValue> attributes = new HashMap<>();
+        if (attrsNode == null || !attrsNode.isObject()) {
+            return attributes;
+        }
+        attrsNode.fields().forEachRemaining(entry -> {
+            JsonNode valueNode = entry.getValue();
+            String binaryValue = valueNode.path("BinaryValue").asText(null);
+            String dataType = valueNode.path("DataType")
+                    .asText(binaryValue != null ? "Binary" : "String");
+            if (binaryValue != null) {
+                attributes.put(entry.getKey(), new MessageAttributeValue(
+                        binaryValue.getBytes(StandardCharsets.UTF_8), dataType));
+            } else {
+                attributes.put(entry.getKey(), new MessageAttributeValue(
+                        valueNode.path("StringValue").asText(null), dataType));
+            }
+        });
+        return attributes;
     }
 
     private static String text(JsonNode node, String field) {

--- a/src/test/java/io/github/hectorvent/floci/services/scheduler/ScheduleInvokerTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/scheduler/ScheduleInvokerTest.java
@@ -163,9 +163,9 @@ class ScheduleInvokerTest {
     }
 
     @Test
-    void universalSqsSendMessageForwardsStringAndRawBinaryMessageAttributes() {
+    void universalSqsSendMessageForwardsStringAndBase64BinaryMessageAttributes() {
         String queueUrl = "http://localhost:4566/000000000000/q.fifo";
-        String rawBinaryValue = "raw-\u00e9";
+        String binaryValueBase64 = "aGVsbG8=";
         Target target = new Target();
         target.setArn("arn:aws:scheduler:::aws-sdk:sqs:sendMessage");
         target.setRoleArn("arn:aws:iam::000000000000:role/x");
@@ -176,7 +176,7 @@ class ScheduleInvokerTest {
                 + "\"MessageAttributes\":{"
                 + "\"StringAttr\":{\"DataType\":\"String.Custom\",\"StringValue\":\"value\"},"
                 + "\"BinaryAttr\":{\"DataType\":\"Binary.Custom\",\"BinaryValue\":\""
-                + rawBinaryValue + "\"}}}");
+                + binaryValueBase64 + "\"}}}");
 
         invoker.invoke(target, "us-east-1");
 
@@ -196,8 +196,34 @@ class ScheduleInvokerTest {
         MessageAttributeValue binaryAttribute = attributes.get("BinaryAttr");
         assertNotNull(binaryAttribute);
         assertEquals("Binary.Custom", binaryAttribute.getDataType());
-        assertArrayEquals(rawBinaryValue.getBytes(StandardCharsets.UTF_8), binaryAttribute.getBinaryValue());
+        assertArrayEquals("hello".getBytes(StandardCharsets.UTF_8), binaryAttribute.getBinaryValue());
         assertNull(binaryAttribute.getStringValue());
+    }
+
+    @Test
+    void universalSqsSendMessageSkipsAttributesWithoutDataType() {
+        String queueUrl = "http://localhost:4566/000000000000/q.fifo";
+        Target target = new Target();
+        target.setArn("arn:aws:scheduler:::aws-sdk:sqs:sendMessage");
+        target.setRoleArn("arn:aws:iam::000000000000:role/x");
+        target.setInput("{\"QueueUrl\":\"" + queueUrl + "\","
+                + "\"MessageBody\":\"hi\","
+                + "\"MessageGroupId\":\"g1\","
+                + "\"MessageDeduplicationId\":\"dedup-1\","
+                + "\"MessageAttributes\":{"
+                + "\"MissingType\":{\"StringValue\":\"ignored\"},"
+                + "\"Valid\":{\"DataType\":\"String\",\"StringValue\":\"value\"}"
+                + "}}");
+
+        invoker.invoke(target, "us-east-1");
+
+        ArgumentCaptor<Map<String, MessageAttributeValue>> attributesCaptor = ArgumentCaptor.captor();
+        verify(sqsService).sendMessage(eq(queueUrl), eq("hi"), eq(0), eq("g1"), eq("dedup-1"),
+                attributesCaptor.capture(), eq("us-east-1"));
+
+        Map<String, MessageAttributeValue> attributes = attributesCaptor.getValue();
+        assertEquals(1, attributes.size());
+        assertEquals("value", attributes.get("Valid").getStringValue());
     }
 
     @Test

--- a/src/test/java/io/github/hectorvent/floci/services/scheduler/ScheduleInvokerTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/scheduler/ScheduleInvokerTest.java
@@ -20,10 +20,14 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
 
+import java.nio.charset.StandardCharsets;
 import java.util.List;
 import java.util.Map;
 
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.anyString;
@@ -143,17 +147,57 @@ class ScheduleInvokerTest {
     }
 
     @Test
-    void universalSqsSendMessageReadsQueueUrlBodyAndGroupIdFromInput() {
+    void universalSqsSendMessageReadsQueueUrlBodyAndFifoIdsFromInputWithoutAttributes() {
         Target target = new Target();
         target.setArn("arn:aws:scheduler:::aws-sdk:sqs:sendMessage");
         target.setRoleArn("arn:aws:iam::000000000000:role/x");
         target.setInput("{\"QueueUrl\":\"http://localhost:4566/000000000000/q.fifo\","
-                + "\"MessageBody\":\"hi\",\"MessageGroupId\":\"g1\"}");
+                + "\"MessageBody\":\"hi\",\"MessageGroupId\":\"g1\","
+                + "\"MessageDeduplicationId\":\"dedup-1\"}");
 
         invoker.invoke(target, "us-east-1");
 
         verify(sqsService).sendMessage(eq("http://localhost:4566/000000000000/q.fifo"),
-                eq("hi"), eq(0), eq("g1"), isNull(), eq("us-east-1"));
+                eq("hi"), eq(0), eq("g1"), eq("dedup-1"),
+                argThat(attrs -> attrs == null || attrs.isEmpty()), eq("us-east-1"));
+    }
+
+    @Test
+    void universalSqsSendMessageForwardsStringAndRawBinaryMessageAttributes() {
+        String queueUrl = "http://localhost:4566/000000000000/q.fifo";
+        String rawBinaryValue = "raw-\u00e9";
+        Target target = new Target();
+        target.setArn("arn:aws:scheduler:::aws-sdk:sqs:sendMessage");
+        target.setRoleArn("arn:aws:iam::000000000000:role/x");
+        target.setInput("{\"QueueUrl\":\"" + queueUrl + "\","
+                + "\"MessageBody\":\"hi\","
+                + "\"MessageGroupId\":\"g1\","
+                + "\"MessageDeduplicationId\":\"dedup-1\","
+                + "\"MessageAttributes\":{"
+                + "\"StringAttr\":{\"DataType\":\"String.Custom\",\"StringValue\":\"value\"},"
+                + "\"BinaryAttr\":{\"DataType\":\"Binary.Custom\",\"BinaryValue\":\""
+                + rawBinaryValue + "\"}}}");
+
+        invoker.invoke(target, "us-east-1");
+
+        ArgumentCaptor<Map<String, MessageAttributeValue>> attributesCaptor = ArgumentCaptor.captor();
+        verify(sqsService).sendMessage(eq(queueUrl), eq("hi"), eq(0), eq("g1"), eq("dedup-1"),
+                attributesCaptor.capture(), eq("us-east-1"));
+
+        Map<String, MessageAttributeValue> attributes = attributesCaptor.getValue();
+        assertEquals(2, attributes.size());
+
+        MessageAttributeValue stringAttribute = attributes.get("StringAttr");
+        assertNotNull(stringAttribute);
+        assertEquals("String.Custom", stringAttribute.getDataType());
+        assertEquals("value", stringAttribute.getStringValue());
+        assertNull(stringAttribute.getBinaryValue());
+
+        MessageAttributeValue binaryAttribute = attributes.get("BinaryAttr");
+        assertNotNull(binaryAttribute);
+        assertEquals("Binary.Custom", binaryAttribute.getDataType());
+        assertArrayEquals(rawBinaryValue.getBytes(StandardCharsets.UTF_8), binaryAttribute.getBinaryValue());
+        assertNull(binaryAttribute.getStringValue());
     }
 
     @Test


### PR DESCRIPTION
## Summary

Fixes universal EventBridge Scheduler SQS delivery so MessageAttributes reach the queue. This is needed because Floci stored the attributes in Target.Input but discarded them during dispatch, causing consumers that rely on message metadata to reject scheduled messages and retry indefinitely.

Adds regression coverage for string and raw UTF-8 binary attributes, including FIFO identifiers.

## Type of change

- [x] Bug fix (`fix:`)
- [ ] New feature (`feat:`)
- [ ] Breaking change (`feat!:` or `fix!:`)
- [ ] Docs / chore

## AWS Compatibility

Universal arn:aws:scheduler:::aws-sdk:sqs:sendMessage targets previously dropped MessageAttributes because Floci used an overload without attribute support.

The fix preserves string values, converts raw binary values to UTF-8 bytes, preserves custom data type suffixes, and leaves direct SQS/SNS parsing unchanged.

## Checklist

- [ ] `./mvnw test` passes locally
- [ ] New or updated integration test added
- [ ] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)

<!-- First PR here? Your CI checks wait for a maintainer to approve them before they run — that's GitHub's gate on first-time contributors, not a problem with your PR. -->
<!-- Questions, or want feedback on an approach before going further? Join us on Slack: https://join.slack.com/t/floci/shared_invite/zt-3tjn02s3q-A00kEjJ1cZxsg_imTfy6Cw -->

