### PR TITLE
feat(oam): emulate observability access manager

### DIFF
--- a/README.md
+++ b/README.md
@@ -232,7 +232,7 @@ Floci supports local emulation for application services, data services, eventing
 | Category | Services |
 |---|---|
 | Core app services | S3, SQS, SNS, DynamoDB, Lambda, IAM, KMS, Secrets Manager, SSM |
-| Events and workflows | EventBridge, EventBridge Pipes, EventBridge Scheduler, Step Functions, SWF, CloudWatch Logs, CloudWatch Metrics, CloudWatch RUM, Managed Prometheus (AMP) |
+| Events and workflows | EventBridge, EventBridge Pipes, EventBridge Scheduler, Step Functions, SWF, CloudWatch Logs, CloudWatch Metrics, CloudWatch OAM, CloudWatch RUM, Managed Prometheus (AMP) |
 | API and identity | API Gateway REST, API Gateway v2, AppSync, Cognito, ACM, Route53, Route 53 Resolver, Cloud Map, Global Accelerator |
 | Containers and compute | ECS, EC2, Lightsail, EKS, MWAA, ECR, EFS, CodeBuild, CodeDeploy, CodePipeline, CodeGuru Reviewer, AWS Batch, Auto Scaling, Application Auto Scaling, Elastic Beanstalk, ELB v2, ELB Classic |
 | Data, analytics, and AI | Athena, Glue, Lake Formation, EMR, EMR Serverless, Redshift, Redshift Data API, Firehose, Managed Service for Apache Flink, OpenSearch, S3 Tables, S3 Vectors, Textract, Transcribe, Comprehend, Rekognition, Translate, Bedrock Runtime, Bedrock AgentCore |
@@ -272,6 +272,7 @@ For operation-level compatibility, see the [Services Overview](https://floci.io/
 | EventBridge Scheduler | In-process | Schedule groups, schedules, flexible time windows, retry policies, DLQs |
 | CloudWatch Logs | In-process | Log groups, streams, ingestion, filtering |
 | CloudWatch Metrics | In-process | Custom metrics, statistics, alarms |
+| CloudWatch OAM | In-process | Full 15-operation sink, policy, cross-account link, and tagging API |
 | ElastiCache | Real Docker | Redis / Valkey protocol, IAM auth, SigV4 validation |
 | MemoryDB | Real Docker | Redis / Valkey protocol via real containers; JSON 1.1 control plane; reuses ElastiCache RESP proxy |
 | RDS | Real Docker | PostgreSQL, MySQL, MariaDB, IAM auth, JDBC-compatible engines |

--- a/compatibility-tests/sdk-test-java/pom.xml
+++ b/compatibility-tests/sdk-test-java/pom.xml
@@ -507,6 +507,11 @@
             <groupId>software.amazon.awssdk</groupId>
             <artifactId>resourceexplorer2</artifactId>
         </dependency>
+        <!-- CloudWatch OAM client -->
+        <dependency>
+            <groupId>software.amazon.awssdk</groupId>
+            <artifactId>oam</artifactId>
+        </dependency>
         <!-- SSO credential support (needed for FLOCI_TARGET=aws with SSO profiles) -->
         <dependency>
             <groupId>software.amazon.awssdk</groupId>

--- a/compatibility-tests/sdk-test-java/src/main/java/com/floci/test/TestFixtures.java
+++ b/compatibility-tests/sdk-test-java/src/main/java/com/floci/test/TestFixtures.java
@@ -26,6 +26,7 @@ import software.amazon.awssdk.http.Protocol;
 import software.amazon.awssdk.services.kms.KmsClient;
 import software.amazon.awssdk.services.lambda.LambdaClient;
 import software.amazon.awssdk.services.opensearch.OpenSearchClient;
+import software.amazon.awssdk.services.oam.OamClient;
 import software.amazon.awssdk.services.neptune.NeptuneClient;
 import software.amazon.awssdk.services.rds.RdsClient;
 import software.amazon.awssdk.services.redshift.RedshiftClient;
@@ -1278,6 +1279,14 @@ public final class TestFixtures {
 
     public static BackupClient backupClient() {
         return BackupClient.builder()
+                .endpointOverride(ENDPOINT)
+                .region(REGION)
+                .credentialsProvider(CREDENTIALS)
+                .build();
+    }
+
+    public static OamClient oamClient() {
+        return OamClient.builder()
                 .endpointOverride(ENDPOINT)
                 .region(REGION)
                 .credentialsProvider(CREDENTIALS)

--- a/compatibility-tests/sdk-test-java/src/test/java/com/floci/test/OamTest.java
+++ b/compatibility-tests/sdk-test-java/src/test/java/com/floci/test/OamTest.java
@@ -1,0 +1,28 @@
+package com.floci.test;
+
+import org.junit.jupiter.api.Test;
+import software.amazon.awssdk.services.oam.OamClient;
+import software.amazon.awssdk.services.oam.model.CreateSinkRequest;
+import software.amazon.awssdk.services.oam.model.DeleteSinkRequest;
+import software.amazon.awssdk.services.oam.model.GetSinkRequest;
+import software.amazon.awssdk.services.oam.model.ListSinksRequest;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class OamTest {
+    @Test
+    void sinkLifecycle() {
+        try (OamClient client = TestFixtures.oamClient()) {
+            var created = client.createSink(CreateSinkRequest.builder().name("sdk-oam-sink").build());
+            assertNotNull(created.arn());
+            assertEquals("sdk-oam-sink", created.name());
+
+            var fetched = client.getSink(GetSinkRequest.builder().identifier(created.arn()).build());
+            assertEquals(created.arn(), fetched.arn());
+            assertTrue(client.listSinks(ListSinksRequest.builder().build()).items().stream()
+                    .anyMatch(item -> created.arn().equals(item.arn())));
+
+            client.deleteSink(DeleteSinkRequest.builder().identifier(created.arn()).build());
+        }
+    }
+}

--- a/docs/services/index.md
+++ b/docs/services/index.md
@@ -41,6 +41,7 @@ Operation counts are exact. For dispatch-table services (Query and JSON 1.1) eac
 | [EventBridge](eventbridge.md) | `POST /` + `X-Amz-Target: AmazonEventBridge.*` | JSON 1.1 | 16 |
 | [EventBridge Scheduler](scheduler.md) | `/schedules/*`, `/schedule-groups/*`, `/tags/*` | REST JSON | 12 |
 | [EventBridge Pipes](pipes.md) | `/v1/pipes/*` | REST JSON | 7 |
+| [CloudWatch OAM](oam.md) | REST paths such as `POST /CreateSink` and `POST /CreateLink` | REST JSON | 15 |
 | [CloudWatch Logs](cloudwatch.md) | `POST /` + `X-Amz-Target: Logs.*` | JSON 1.1 | 17 |
 | [CloudWatch Metrics](cloudwatch.md#metrics) | `POST /` with `Action=` or JSON 1.1 | Query / JSON | 11 |
 | [CloudWatch RUM](rum.md) | `/appmonitor`, `/appmonitor/{name}`, `/appmonitors` | REST JSON | 5 |

--- a/docs/services/oam.md
+++ b/docs/services/oam.md
@@ -1,0 +1,85 @@
+# CloudWatch Observability Access Manager (`oam:*`)
+
+**Protocol:** REST JSON
+**Signing name:** `oam`
+**API version:** `2022-06-10`
+
+Floci emulates the CloudWatch Observability Access Manager control plane for cross-account observability links. Sinks and links are account and Region scoped, and attached-link discovery crosses source-account storage partitions in the same way the AWS API exposes source links to a monitoring sink.
+
+## Supported operations
+
+| Operation | Notes |
+|---|---|
+| `CreateSink` | Creates the single sink allowed for the calling account and Region |
+| `GetSink` | Returns one sink by ARN |
+| `ListSinks` | Lists sinks for the calling account and Region |
+| `PutSinkPolicy` | Stores and validates the sink resource policy |
+| `GetSinkPolicy` | Returns the current policy for a sink |
+| `DeleteSink` | Rejects deletion while links remain attached |
+| `CreateLink` | Creates a source-account link after evaluating the sink policy |
+| `GetLink` | Returns one source-account link |
+| `ListLinks` | Lists links owned by the calling source account |
+| `ListAttachedLinks` | Lists links from all source accounts attached to a sink |
+| `UpdateLink` | Replaces shared resource types and optional metric/log filters |
+| `DeleteLink` | Deletes a source-account link |
+| `ListTagsForResource` | Returns tags for a sink or link |
+| `TagResource` | Adds or replaces tags on a sink or link |
+| `UntagResource` | Removes tag keys from a sink or link |
+
+## Sink policies
+
+`PutSinkPolicy` accepts IAM-style JSON policies. For `CreateLink`, Floci evaluates the policy's `Effect`, `Principal`, `Action`, `Resource`, and the `oam:ResourceTypes` condition. Individual account principals, account root ARNs, wildcard principals, exact sink ARNs, and wildcard resources are supported.
+
+Organization-based conditions are not currently resolved through AWS Organizations metadata. Policies that depend on organization condition keys should use explicit account principals when testing locally.
+
+## Resource types and filters
+
+Floci accepts the resource types modeled by the current OAM API:
+
+- `AWS::CloudWatch::Metric`
+- `AWS::Logs::LogGroup`
+- `AWS::XRay::Trace`
+- `AWS::ApplicationInsights::Application`
+- `AWS::InternetMonitor::Monitor`
+- `AWS::ApplicationSignals::Service`
+- `AWS::ApplicationSignals::ServiceLevelObjective`
+
+Metric and log-group filters are persisted with the link. Updating a filter to `*` removes that filter, matching the AWS update contract.
+
+## Quotas and validation
+
+- One sink per account per Region.
+- Up to five links per source account per Region.
+- `ListSinks` accepts `MaxResults` from 1 to 100.
+- `ListLinks` accepts `MaxResults` from 1 to 5.
+- `ListAttachedLinks` accepts `MaxResults` from 1 to 1000.
+- A sink cannot be deleted while links are attached.
+- Sinks and links support up to 50 tags.
+
+Floci resolves the account-derived label variables to the local account ID because the emulator has no AWS account email/name directory attached to OAM itself.
+
+## Configuration
+
+| Variable | Default | Description |
+|---|---|---|
+| `FLOCI_SERVICES_OAM_ENABLED` | `true` | Enable or disable OAM |
+
+## Example
+
+```bash
+export AWS_ENDPOINT_URL=http://localhost:4566
+export AWS_DEFAULT_REGION=us-east-1
+export AWS_ACCESS_KEY_ID=test
+export AWS_SECRET_ACCESS_KEY=test
+
+sink_arn=$(aws oam create-sink --name local-observability --query Arn --output text)
+
+aws oam put-sink-policy \
+  --sink-identifier "$sink_arn" \
+  --policy '{"Version":"2012-10-17","Statement":[{"Effect":"Allow","Principal":"*","Action":"oam:CreateLink","Resource":"*"}]}'
+
+aws oam create-link \
+  --sink-identifier "$sink_arn" \
+  --label-template local-source \
+  --resource-types AWS::CloudWatch::Metric AWS::Logs::LogGroup
+```

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -154,6 +154,7 @@ nav:
     - EventBridge Pipes: services/pipes.md
     - EventBridge Scheduler: services/scheduler.md
     - CloudWatch: services/cloudwatch.md
+    - CloudWatch OAM: services/oam.md
     - CloudWatch RUM: services/rum.md
     - Managed Prometheus (AMP): services/managed-prometheus.md
     - GuardDuty: services/guardduty.md

--- a/src/main/java/io/github/hectorvent/floci/config/EmulatorConfig.java
+++ b/src/main/java/io/github/hectorvent/floci/config/EmulatorConfig.java
@@ -702,6 +702,7 @@ public interface EmulatorConfig {
         CostExplorerServiceConfig ce();
         CurServiceConfig cur();
         BcmDataExportsServiceConfig bcmDataExports();
+        OamServiceConfig oam();
         ConfigServiceConfig configservice();
         CloudTrailServiceConfig cloudtrail();
         CloudControlServiceConfig cloudcontrol();
@@ -1908,6 +1909,11 @@ public interface EmulatorConfig {
         /** Seconds to wait for in-flight schema workers on shutdown. Env: FLOCI_SERVICES_APPSYNC_SCHEMA_WORKER_SHUTDOWN_TIMEOUT_SECONDS */
         @WithDefault("30")
         int schemaWorkerShutdownTimeoutSeconds();
+    }
+
+    interface OamServiceConfig {
+        @WithDefault("true")
+        boolean enabled();
     }
 
     interface BcmDataExportsServiceConfig {

--- a/src/main/java/io/github/hectorvent/floci/core/common/ResolvedServiceCatalog.java
+++ b/src/main/java/io/github/hectorvent/floci/core/common/ResolvedServiceCatalog.java
@@ -28,6 +28,7 @@ import io.github.hectorvent.floci.services.lambda.LambdaController;
 import io.github.hectorvent.floci.services.lambdamicrovms.LambdaMicrovmsController;
 import io.github.hectorvent.floci.services.lambdamicrovms.LambdaNetworkConnectorsController;
 import io.github.hectorvent.floci.services.opensearch.OpenSearchController;
+import io.github.hectorvent.floci.services.oam.OamController;
 import io.github.hectorvent.floci.services.cloudfront.CloudFrontController;
 import io.github.hectorvent.floci.services.cloudfront.CloudFrontServingController;
 import io.github.hectorvent.floci.services.route53.Route53Controller;
@@ -546,6 +547,10 @@ public class ResolvedServiceCatalog {
                         "bcmdataexports", config.storage().mode(), 5000L, null, ServiceProtocol.JSON,
                         protocols(ServiceProtocol.JSON),
                         Set.of("AWSBillingAndCostManagementDataExports."), Set.of("bcm-data-exports"), Set.of(), Set.of()),
+                descriptor("oam", "oam", config.services().oam().enabled(), true,
+                        "oam", config.storage().mode(), 5000L, null, ServiceProtocol.REST_JSON,
+                        protocols(ServiceProtocol.REST_JSON),
+                        Set.of(), Set.of("oam"), Set.of(), Set.of(OamController.class)),
                 descriptor("cloudfront", "cloudfront", config.services().cloudfront().enabled(), true,
                         "cloudfront", storageMode(config.storage().services().cloudfront().mode(), config.storage().mode()),
                         5000L, AwsNamespaces.CLOUDFRONT, ServiceProtocol.REST_XML,

--- a/src/main/java/io/github/hectorvent/floci/services/oam/OamController.java
+++ b/src/main/java/io/github/hectorvent/floci/services/oam/OamController.java
@@ -1,0 +1,209 @@
+package io.github.hectorvent.floci.services.oam;
+
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.github.hectorvent.floci.core.common.AwsException;
+import io.github.hectorvent.floci.core.common.RegionResolver;
+import io.github.hectorvent.floci.services.oam.model.OamLink;
+import io.github.hectorvent.floci.services.oam.model.OamSink;
+import jakarta.inject.Inject;
+import jakarta.ws.rs.Consumes;
+import jakarta.ws.rs.DELETE;
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.POST;
+import jakarta.ws.rs.PUT;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.PathParam;
+import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.QueryParam;
+import jakarta.ws.rs.core.Context;
+import jakarta.ws.rs.core.HttpHeaders;
+import jakarta.ws.rs.core.MediaType;
+import jakarta.ws.rs.core.Response;
+
+import java.net.URLDecoder;
+import java.nio.charset.StandardCharsets;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+@Path("/")
+@Produces(MediaType.APPLICATION_JSON)
+@Consumes(MediaType.APPLICATION_JSON)
+public class OamController {
+    private final OamService service;
+    private final RegionResolver regionResolver;
+    private final ObjectMapper objectMapper;
+
+    @Inject
+    public OamController(OamService service, RegionResolver regionResolver, ObjectMapper objectMapper) {
+        this.service = service;
+        this.regionResolver = regionResolver;
+        this.objectMapper = objectMapper;
+    }
+
+    @POST @Path("/CreateSink")
+    public Response createSink(@Context HttpHeaders headers, Map<String, Object> request) {
+        OamSink sink = service.createSink(string(request, "Name"), stringMap(request.get("Tags")), region(headers));
+        return Response.ok(sinkBody(sink, true)).build();
+    }
+
+    @POST @Path("/GetSink")
+    public Response getSink(Map<String, Object> request) {
+        OamSink sink = service.getSink(string(request, "Identifier"));
+        return Response.ok(sinkBody(sink, boolDefaultTrue(request, "IncludeTags"))).build();
+    }
+
+    @POST @Path("/ListSinks")
+    public Response listSinks(@Context HttpHeaders headers, Map<String, Object> request) {
+        int max = maxResults(request, 100, 100);
+        int start = OamService.decodeToken(string(request, "NextToken"));
+        List<OamSink> all = service.listSinks(region(headers));
+        int end = Math.min(start + max, all.size());
+        List<Map<String, Object>> items = all.subList(Math.min(start, all.size()), end).stream()
+                .map(s -> Map.<String, Object>of("Arn", s.getArn(), "Id", s.getId(), "Name", s.getName())).toList();
+        Map<String, Object> out = new LinkedHashMap<>(); out.put("Items", items);
+        if (end < all.size()) out.put("NextToken", OamService.encodeToken(end));
+        return Response.ok(out).build();
+    }
+
+    @POST @Path("/PutSinkPolicy")
+    public Response putSinkPolicy(Map<String, Object> request) {
+        String arn = string(request, "SinkIdentifier");
+        String policy = string(request, "Policy");
+        service.putSinkPolicy(arn, policy);
+        OamSink sink = service.getSink(arn);
+        return Response.ok(Map.of("Policy", policy, "SinkArn", sink.getArn(), "SinkId", sink.getId())).build();
+    }
+
+    @POST @Path("/GetSinkPolicy")
+    public Response getSinkPolicy(Map<String, Object> request) {
+        OamSink sink = service.getSink(string(request, "SinkIdentifier"));
+        Map<String, Object> out = new LinkedHashMap<>();
+        if (sink.getPolicy() != null) out.put("Policy", sink.getPolicy());
+        out.put("SinkArn", sink.getArn()); out.put("SinkId", sink.getId());
+        return Response.ok(out).build();
+    }
+
+    @POST @Path("/DeleteSink")
+    public Response deleteSink(Map<String, Object> request) {
+        service.deleteSink(string(request, "Identifier"));
+        return Response.ok(Map.of()).build();
+    }
+
+    @POST @Path("/CreateLink")
+    public Response createLink(@Context HttpHeaders headers, Map<String, Object> request) {
+        OamLink link = service.createLink(string(request, "SinkIdentifier"), string(request, "LabelTemplate"),
+                stringList(request.get("ResourceTypes")), objectMap(request.get("LinkConfiguration")),
+                stringMap(request.get("Tags")), region(headers));
+        return Response.ok(linkBody(link, true)).build();
+    }
+
+    @POST @Path("/GetLink")
+    public Response getLink(Map<String, Object> request) {
+        return Response.ok(linkBody(service.getLink(string(request, "Identifier")), boolDefaultTrue(request, "IncludeTags"))).build();
+    }
+
+    @POST @Path("/ListLinks")
+    public Response listLinks(@Context HttpHeaders headers, Map<String, Object> request) {
+        int max = maxResults(request, 5, 5);
+        int start = OamService.decodeToken(string(request, "NextToken"));
+        List<OamLink> all = service.listLinks(region(headers));
+        int safeStart = Math.min(start, all.size()); int end = Math.min(safeStart + max, all.size());
+        List<Map<String, Object>> items = all.subList(safeStart, end).stream().map(this::linkSummary).toList();
+        Map<String, Object> out = new LinkedHashMap<>(); out.put("Items", items);
+        if (end < all.size()) out.put("NextToken", OamService.encodeToken(end));
+        return Response.ok(out).build();
+    }
+
+    @POST @Path("/ListAttachedLinks")
+    public Response listAttachedLinks(Map<String, Object> request) {
+        int max = maxResults(request, 100, 1000);
+        int start = OamService.decodeToken(string(request, "NextToken"));
+        List<OamLink> all = service.listAttachedLinks(string(request, "SinkIdentifier"));
+        int safeStart = Math.min(start, all.size()); int end = Math.min(safeStart + max, all.size());
+        List<Map<String, Object>> items = all.subList(safeStart, end).stream().map(link -> Map.<String, Object>of(
+                "Label", link.getLabel(), "LinkArn", link.getArn(), "ResourceTypes", link.getResourceTypes())).toList();
+        Map<String, Object> out = new LinkedHashMap<>(); out.put("Items", items);
+        if (end < all.size()) out.put("NextToken", OamService.encodeToken(end));
+        return Response.ok(out).build();
+    }
+
+    @POST @Path("/UpdateLink")
+    public Response updateLink(Map<String, Object> request) {
+        OamLink link = service.updateLink(string(request, "Identifier"), stringList(request.get("ResourceTypes")),
+                objectMap(request.get("LinkConfiguration")));
+        return Response.ok(linkBody(link, boolDefaultTrue(request, "IncludeTags"))).build();
+    }
+
+    @POST @Path("/DeleteLink")
+    public Response deleteLink(Map<String, Object> request) {
+        service.deleteLink(string(request, "Identifier"));
+        return Response.ok(Map.of()).build();
+    }
+
+    @GET @Path("/tags/{resourceArn:.+}")
+    public Response listTags(@PathParam("resourceArn") String resourceArn) {
+        return Response.ok(Map.of("Tags", service.tags(decode(resourceArn)))).build();
+    }
+
+    @PUT @Path("/tags/{resourceArn:.+}")
+    public Response tag(@PathParam("resourceArn") String resourceArn, Map<String, Object> request) {
+        service.tag(decode(resourceArn), stringMap(request.get("Tags")));
+        return Response.ok(Map.of()).build();
+    }
+
+    @DELETE @Path("/tags/{resourceArn:.+}")
+    public Response untag(@PathParam("resourceArn") String resourceArn, @QueryParam("tagKeys") List<String> tagKeys) {
+        service.untag(decode(resourceArn), tagKeys);
+        return Response.ok(Map.of()).build();
+    }
+
+    private Map<String, Object> sinkBody(OamSink sink, boolean includeTags) {
+        Map<String, Object> out = new LinkedHashMap<>();
+        out.put("Arn", sink.getArn()); out.put("Id", sink.getId()); out.put("Name", sink.getName());
+        if (includeTags) out.put("Tags", sink.getTags());
+        return out;
+    }
+
+    private Map<String, Object> linkBody(OamLink link, boolean includeTags) {
+        Map<String, Object> out = linkSummary(link);
+        out.put("LabelTemplate", link.getLabelTemplate());
+        if (!link.getLinkConfiguration().isEmpty()) out.put("LinkConfiguration", link.getLinkConfiguration());
+        if (includeTags) out.put("Tags", link.getTags());
+        return out;
+    }
+
+    private Map<String, Object> linkSummary(OamLink link) {
+        Map<String, Object> out = new LinkedHashMap<>();
+        out.put("Arn", link.getArn()); out.put("Id", link.getId()); out.put("Label", link.getLabel());
+        out.put("ResourceTypes", link.getResourceTypes()); out.put("SinkArn", link.getSinkArn());
+        return out;
+    }
+
+    private String region(HttpHeaders headers) { return regionResolver.resolveRegion(headers); }
+    private static String decode(String value) { return URLDecoder.decode(value, StandardCharsets.UTF_8); }
+    private static String string(Map<String, Object> request, String key) { Object v = request == null ? null : request.get(key); return v == null ? null : String.valueOf(v); }
+    private static boolean boolDefaultTrue(Map<String, Object> request, String key) {
+        Object value = request == null ? null : request.get(key);
+        return value == null || (value instanceof Boolean b ? b : Boolean.parseBoolean(String.valueOf(value)));
+    }
+    private static int maxResults(Map<String, Object> request, int defaultValue, int max) {
+        Object value = request == null ? null : request.get("MaxResults");
+        if (value == null) return defaultValue;
+        int parsed;
+        try { parsed = value instanceof Number n ? n.intValue() : Integer.parseInt(String.valueOf(value)); }
+        catch (Exception e) { throw new AwsException("InvalidParameterException", "MaxResults is invalid.", 400); }
+        if (parsed < 1 || parsed > max) throw new AwsException("InvalidParameterException", "MaxResults must be between 1 and " + max + ".", 400);
+        return parsed;
+    }
+    @SuppressWarnings("unchecked") private static Map<String, Object> objectMap(Object value) { return value instanceof Map<?, ?> m ? new LinkedHashMap<>((Map<String, Object>) m) : null; }
+    @SuppressWarnings("unchecked") private static Map<String, String> stringMap(Object value) {
+        if (!(value instanceof Map<?, ?> map)) return null;
+        Map<String, String> out = new LinkedHashMap<>(); map.forEach((k, v) -> out.put(String.valueOf(k), v == null ? "" : String.valueOf(v))); return out;
+    }
+    private static List<String> stringList(Object value) {
+        if (!(value instanceof List<?> list)) return null;
+        return list.stream().map(String::valueOf).toList();
+    }
+}

--- a/src/main/java/io/github/hectorvent/floci/services/oam/OamService.java
+++ b/src/main/java/io/github/hectorvent/floci/services/oam/OamService.java
@@ -241,12 +241,18 @@ public class OamService {
             if (!statements.isArray()) statements = objectMapper.createArrayNode().add(statements);
             boolean allowed = false;
             for (JsonNode statement : statements) {
-                if (!"Allow".equalsIgnoreCase(statement.path("Effect").asText())) continue;
                 if (!actionMatches(statement.get("Action"), action)) continue;
                 if (!principalMatches(statement.get("Principal"), sourceAccountId)) continue;
                 if (!resourceMatches(statement.get("Resource"), sink.getArn())) continue;
                 if (!resourceTypeConditionMatches(statement.get("Condition"), resourceTypes)) continue;
-                allowed = true;
+
+                String effect = statement.path("Effect").asText();
+                if ("Deny".equalsIgnoreCase(effect)) {
+                    throw invalid("The sink policy explicitly denies this source account from performing " + action + ".");
+                }
+                if ("Allow".equalsIgnoreCase(effect)) {
+                    allowed = true;
+                }
             }
             if (!allowed) throw invalid("The sink policy does not allow this source account to perform " + action + ".");
         } catch (AwsException e) {

--- a/src/main/java/io/github/hectorvent/floci/services/oam/OamService.java
+++ b/src/main/java/io/github/hectorvent/floci/services/oam/OamService.java
@@ -1,0 +1,381 @@
+package io.github.hectorvent.floci.services.oam;
+
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.github.hectorvent.floci.core.common.AwsArnUtils;
+import io.github.hectorvent.floci.core.common.AwsException;
+import io.github.hectorvent.floci.core.common.RegionResolver;
+import io.github.hectorvent.floci.core.storage.AccountAwareStorageBackend;
+import io.github.hectorvent.floci.core.storage.StorageBackend;
+import io.github.hectorvent.floci.core.storage.StorageFactory;
+import io.github.hectorvent.floci.services.oam.model.OamLink;
+import io.github.hectorvent.floci.services.oam.model.OamSink;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
+
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.Base64;
+import java.util.Collection;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Set;
+import java.util.UUID;
+import java.util.regex.Pattern;
+
+@ApplicationScoped
+public class OamService {
+    private static final Pattern SINK_NAME = Pattern.compile("[A-Za-z0-9_.-]{1,255}");
+    private static final Set<String> RESOURCE_TYPES = Set.of(
+            "AWS::CloudWatch::Metric", "AWS::Logs::LogGroup", "AWS::XRay::Trace",
+            "AWS::ApplicationInsights::Application", "AWS::InternetMonitor::Monitor",
+            "AWS::ApplicationSignals::Service", "AWS::ApplicationSignals::ServiceLevelObjective");
+
+    private final StorageBackend<String, OamSink> sinks;
+    private final StorageBackend<String, OamLink> links;
+    private final RegionResolver regionResolver;
+    private final ObjectMapper objectMapper;
+
+    @Inject
+    public OamService(StorageFactory storageFactory, RegionResolver regionResolver, ObjectMapper objectMapper) {
+        this(storageFactory.create("oam", "oam-sinks.json", new TypeReference<Map<String, OamSink>>() {}),
+                storageFactory.create("oam", "oam-links.json", new TypeReference<Map<String, OamLink>>() {}),
+                regionResolver, objectMapper);
+    }
+
+    OamService(StorageBackend<String, OamSink> sinks, StorageBackend<String, OamLink> links,
+               RegionResolver regionResolver, ObjectMapper objectMapper) {
+        this.sinks = sinks;
+        this.links = links;
+        this.regionResolver = regionResolver;
+        this.objectMapper = objectMapper;
+    }
+
+    public OamSink createSink(String name, Map<String, String> tags, String region) {
+        if (name == null) throw missing("Name");
+        if (!SINK_NAME.matcher(name).matches()) throw invalid("Name is invalid.");
+        validateTags(tags);
+        if (!listSinks(region).isEmpty()) {
+            throw new AwsException("ConflictException", "A sink already exists in this Region.", 409);
+        }
+        String id = UUID.randomUUID().toString();
+        OamSink sink = new OamSink();
+        sink.setId(id);
+        sink.setName(name);
+        sink.setRegion(region);
+        sink.setOwnerAccountId(regionResolver.getAccountId());
+        sink.setArn(AwsArnUtils.Arn.of("oam", region, sink.getOwnerAccountId(), "sink/" + id).toString());
+        sink.setTags(tags);
+        sinks.put(sink.getArn(), sink);
+        return sink;
+    }
+
+    public OamSink getSink(String identifier) {
+        require(identifier, "Identifier");
+        return getSinkAcrossAccounts(identifier);
+    }
+
+    public List<OamSink> listSinks(String region) {
+        return sinks.scan(_ -> true).stream()
+                .filter(s -> region.equals(s.getRegion()))
+                .sorted(java.util.Comparator.comparing(OamSink::getArn)).toList();
+    }
+
+    public void putSinkPolicy(String sinkIdentifier, String policy) {
+        require(sinkIdentifier, "SinkIdentifier");
+        require(policy, "Policy");
+        try {
+            JsonNode document = objectMapper.readTree(policy);
+            if (!document.isObject() || !document.has("Statement")) throw new IllegalArgumentException();
+        } catch (Exception e) {
+            throw invalid("Policy must be valid IAM policy JSON.");
+        }
+        OamSink sink = getOwnedSink(sinkIdentifier);
+        sink.setPolicy(policy);
+        sinks.put(sink.getArn(), sink);
+    }
+
+    public OamLink createLink(String sinkIdentifier, String labelTemplate, List<String> resourceTypes,
+                              Map<String, Object> linkConfiguration, Map<String, String> tags, String region) {
+        require(sinkIdentifier, "SinkIdentifier");
+        require(labelTemplate, "LabelTemplate");
+        if (labelTemplate.length() > 64) throw invalid("LabelTemplate must be between 1 and 64 characters.");
+        validateResourceTypes(resourceTypes);
+        validateLinkConfiguration(linkConfiguration);
+        validateTags(tags);
+        if (listLinks(region).size() >= 5) {
+            throw new AwsException("ServiceQuotaExceededException", "A source account can have at most five links.", 429);
+        }
+        OamSink sink = getSinkAcrossAccounts(sinkIdentifier);
+        if (!region.equals(sink.getRegion())) throw invalid("The sink must be in the same Region as the link.");
+        authorizeLinkAction(sink, regionResolver.getAccountId(), resourceTypes, "oam:CreateLink");
+        boolean duplicate = listLinks(region).stream().anyMatch(l -> sink.getArn().equals(l.getSinkArn()));
+        if (duplicate) throw new AwsException("ConflictException", "A link to this sink already exists.", 409);
+
+        String id = UUID.randomUUID().toString();
+        OamLink link = new OamLink();
+        link.setId(id);
+        link.setArn(AwsArnUtils.Arn.of("oam", region, regionResolver.getAccountId(), "link/" + id).toString());
+        link.setSourceAccountId(regionResolver.getAccountId());
+        link.setRegion(region);
+        link.setSinkArn(sink.getArn());
+        link.setLabelTemplate(labelTemplate);
+        link.setLabel(resolveLabel(labelTemplate, regionResolver.getAccountId()));
+        link.setResourceTypes(resourceTypes);
+        link.setLinkConfiguration(normalizeConfiguration(linkConfiguration));
+        link.setTags(tags);
+        links.put(link.getArn(), link);
+        return link;
+    }
+
+    public OamLink getLink(String identifier) {
+        require(identifier, "Identifier");
+        return links.get(identifier).orElseThrow(() -> notFound("Link", identifier));
+    }
+
+    public List<OamLink> listLinks(String region) {
+        return links.scan(_ -> true).stream().filter(l -> region.equals(l.getRegion()))
+                .sorted(java.util.Comparator.comparing(OamLink::getArn)).toList();
+    }
+
+    public List<OamLink> listAttachedLinks(String sinkIdentifier) {
+        OamSink sink = getOwnedSink(sinkIdentifier);
+        Collection<OamLink> all;
+        if (links instanceof AccountAwareStorageBackend<?> aware) {
+            @SuppressWarnings("unchecked")
+            AccountAwareStorageBackend<OamLink> typed = (AccountAwareStorageBackend<OamLink>) aware;
+            all = typed.scanAllAccounts();
+        } else {
+            all = links.scan(_ -> true);
+        }
+        return all.stream().filter(l -> sink.getArn().equals(l.getSinkArn()))
+                .sorted(java.util.Comparator.comparing(OamLink::getArn)).toList();
+    }
+
+    public OamLink updateLink(String identifier, List<String> resourceTypes,
+                              Map<String, Object> linkConfiguration) {
+        validateResourceTypes(resourceTypes);
+        validateLinkConfiguration(linkConfiguration);
+        OamLink link = getLink(identifier);
+        OamSink sink = getSinkAcrossAccounts(link.getSinkArn());
+        authorizeLinkAction(sink, regionResolver.getAccountId(), resourceTypes, "oam:UpdateLink");
+        link.setResourceTypes(resourceTypes);
+        link.setLinkConfiguration(normalizeConfiguration(linkConfiguration));
+        links.put(link.getArn(), link);
+        return link;
+    }
+
+    public void deleteLink(String identifier) {
+        OamLink link = getLink(identifier);
+        links.delete(link.getArn());
+    }
+
+    public void deleteSink(String identifier) {
+        OamSink sink = getOwnedSink(identifier);
+        if (!listAttachedLinks(sink.getArn()).isEmpty()) {
+            throw new AwsException("ConflictException", "The sink still has attached links.", 409);
+        }
+        sinks.delete(sink.getArn());
+    }
+
+    public Map<String, String> tags(String arn) { return new LinkedHashMap<>(resourceTags(arn)); }
+
+    public void tag(String arn, Map<String, String> tags) {
+        validateTags(tags);
+        Map<String, String> merged = new LinkedHashMap<>(resourceTags(arn));
+        merged.putAll(tags == null ? Map.of() : tags);
+        if (merged.size() > 50) throw new AwsException("TooManyTagsException", "A resource can have no more than 50 tags.", 400);
+        saveTags(arn, merged);
+    }
+
+    public void untag(String arn, List<String> tagKeys) {
+        if (tagKeys == null) throw missing("TagKeys");
+        Map<String, String> updated = new LinkedHashMap<>(resourceTags(arn));
+        tagKeys.forEach(updated::remove);
+        saveTags(arn, updated);
+    }
+
+    private OamSink getOwnedSink(String identifier) {
+        OamSink sink = sinks.get(identifier).orElseThrow(() -> notFound("Sink", identifier));
+        if (!regionResolver.getAccountId().equals(sink.getOwnerAccountId())) throw notFound("Sink", identifier);
+        return sink;
+    }
+
+    private OamSink getSinkAcrossAccounts(String arn) {
+        String owner = arnAccount(arn);
+        if (owner == null) throw invalid("SinkIdentifier must be a sink ARN.");
+        if (sinks instanceof AccountAwareStorageBackend<?> aware) {
+            @SuppressWarnings("unchecked")
+            AccountAwareStorageBackend<OamSink> typed = (AccountAwareStorageBackend<OamSink>) aware;
+            return typed.getForAccount(owner, arn).orElseThrow(() -> notFound("Sink", arn));
+        }
+        return sinks.get(arn).orElseThrow(() -> notFound("Sink", arn));
+    }
+
+    private Map<String, String> resourceTags(String arn) {
+        if (arn != null && arn.contains(":sink/")) return getOwnedSink(arn).getTags();
+        if (arn != null && arn.contains(":link/")) return getLink(arn).getTags();
+        throw notFound("Resource", arn);
+    }
+
+    private void saveTags(String arn, Map<String, String> tags) {
+        if (arn != null && arn.contains(":sink/")) {
+            OamSink sink = getOwnedSink(arn); sink.setTags(tags); sinks.put(arn, sink); return;
+        }
+        if (arn != null && arn.contains(":link/")) {
+            OamLink link = getLink(arn); link.setTags(tags); links.put(arn, link); return;
+        }
+        throw notFound("Resource", arn);
+    }
+
+    private void authorizeLinkAction(OamSink sink, String sourceAccountId, List<String> resourceTypes, String action) {
+        if (sink.getPolicy() == null || sink.getPolicy().isBlank()) {
+            throw invalid("The sink policy does not allow this source account to perform " + action + ".");
+        }
+        try {
+            JsonNode root = objectMapper.readTree(sink.getPolicy());
+            JsonNode statements = root.path("Statement");
+            if (!statements.isArray()) statements = objectMapper.createArrayNode().add(statements);
+            boolean allowed = false;
+            for (JsonNode statement : statements) {
+                if (!"Allow".equalsIgnoreCase(statement.path("Effect").asText())) continue;
+                if (!actionMatches(statement.get("Action"), action)) continue;
+                if (!principalMatches(statement.get("Principal"), sourceAccountId)) continue;
+                if (!resourceMatches(statement.get("Resource"), sink.getArn())) continue;
+                if (!resourceTypeConditionMatches(statement.get("Condition"), resourceTypes)) continue;
+                allowed = true;
+            }
+            if (!allowed) throw invalid("The sink policy does not allow this source account to perform " + action + ".");
+        } catch (AwsException e) {
+            throw e;
+        } catch (Exception e) {
+            throw invalid("The sink policy could not be evaluated.");
+        }
+    }
+
+    private static boolean actionMatches(JsonNode node, String action) {
+        if (node == null) return false;
+        if (node.isTextual()) return "*".equals(node.asText()) || action.equalsIgnoreCase(node.asText());
+        if (node.isArray()) for (JsonNode n : node) if (actionMatches(n, action)) return true;
+        return false;
+    }
+
+    private static boolean principalMatches(JsonNode node, String account) {
+        if (node == null) return false;
+        if (node.isTextual()) return "*".equals(node.asText()) || principalValueMatches(node.asText(), account);
+        JsonNode aws = node.path("AWS");
+        if (aws.isTextual()) return principalValueMatches(aws.asText(), account);
+        if (aws.isArray()) for (JsonNode n : aws) if (principalValueMatches(n.asText(), account)) return true;
+        return false;
+    }
+
+    private static boolean principalValueMatches(String value, String account) {
+        return "*".equals(value) || account.equals(value) || ("arn:aws:iam::" + account + ":root").equals(value);
+    }
+
+    private static boolean resourceMatches(JsonNode node, String arn) {
+        if (node == null) return true;
+        if (node.isTextual()) return "*".equals(node.asText()) || arn.equals(node.asText());
+        if (node.isArray()) for (JsonNode n : node) if (resourceMatches(n, arn)) return true;
+        return false;
+    }
+
+    private static boolean resourceTypeConditionMatches(JsonNode condition, List<String> requested) {
+        if (condition == null || condition.isMissingNode() || condition.isNull()) {
+            return true;
+        }
+        List<String> allowed = new ArrayList<>();
+        var operators = condition.fields();
+        while (operators.hasNext()) {
+            Map.Entry<String, JsonNode> operator = operators.next();
+            JsonNode entries = operator.getValue();
+            if (!entries.isObject()) {
+                return false;
+            }
+            var conditions = entries.fields();
+            while (conditions.hasNext()) {
+                Map.Entry<String, JsonNode> entry = conditions.next();
+                if (!"oam:ResourceTypes".equalsIgnoreCase(entry.getKey())) {
+                    // Unknown condition keys cannot be safely treated as satisfied. In particular,
+                    // organization-scoped policies must not degrade into a wildcard allow.
+                    return false;
+                }
+                JsonNode values = entry.getValue();
+                if (values.isArray()) {
+                    values.forEach(v -> allowed.add(v.asText()));
+                } else {
+                    allowed.add(values.asText());
+                }
+            }
+        }
+        return allowed.isEmpty() || allowed.containsAll(requested);
+    }
+
+    private static void validateResourceTypes(List<String> types) {
+        if (types == null) throw missing("ResourceTypes");
+        if (types.isEmpty() || types.size() > 50 || types.stream().anyMatch(t -> !RESOURCE_TYPES.contains(t))) {
+            throw invalid("ResourceTypes contains an unsupported value.");
+        }
+    }
+
+    private static void validateLinkConfiguration(Map<String, Object> config) {
+        if (config == null) return;
+        for (String name : List.of("MetricConfiguration", "LogGroupConfiguration")) {
+            Object value = config.get(name);
+            if (value instanceof Map<?, ?> m && m.containsKey("Filter")) {
+                String filter = String.valueOf(m.get("Filter"));
+                if (filter.isBlank() || filter.length() > 2000) throw invalid("LinkConfiguration filter is invalid.");
+            }
+        }
+    }
+
+    private static Map<String, Object> normalizeConfiguration(Map<String, Object> config) {
+        if (config == null) return Map.of();
+        Map<String, Object> out = new LinkedHashMap<>(config);
+        out.entrySet().removeIf(e -> e.getValue() instanceof Map<?, ?> m && "*".equals(String.valueOf(m.get("Filter"))));
+        return out;
+    }
+
+    private static void validateTags(Map<String, String> tags) {
+        if (tags == null) return;
+        if (tags.size() > 50) throw new AwsException("TooManyTagsException", "A resource can have no more than 50 tags.", 400);
+        for (Map.Entry<String, String> e : tags.entrySet()) {
+            if (e.getKey() == null || e.getKey().isEmpty() || e.getKey().length() > 128
+                    || (e.getValue() != null && e.getValue().length() > 256)) {
+                throw new AwsException("ValidationException", "Tag key or value is invalid.", 400);
+            }
+        }
+    }
+
+    private static String resolveLabel(String template, String account) {
+        return template.replace("$AccountName", account).replace("$AccountEmailNoDomain", account)
+                .replace("$AccountEmail", account);
+    }
+
+    private static String arnAccount(String arn) {
+        try { return AwsArnUtils.parse(arn).accountId(); } catch (Exception e) { return null; }
+    }
+
+    public static String encodeToken(int offset) {
+        return Base64.getUrlEncoder().withoutPadding().encodeToString(String.valueOf(offset).getBytes(StandardCharsets.UTF_8));
+    }
+
+    public static int decodeToken(String token) {
+        if (token == null || token.isBlank()) return 0;
+        try {
+            int offset = Integer.parseInt(new String(Base64.getUrlDecoder().decode(token), StandardCharsets.UTF_8));
+            if (offset < 0) throw new NumberFormatException();
+            return offset;
+        } catch (Exception e) {
+            throw invalid("NextToken is invalid.");
+        }
+    }
+
+    private static void require(String value, String field) { if (value == null || value.isBlank()) throw missing(field); }
+    private static AwsException missing(String field) { return new AwsException("MissingRequiredParameterException", "Missing required parameter: " + field, 400); }
+    private static AwsException invalid(String message) { return new AwsException("InvalidParameterException", message, 400); }
+    private static AwsException notFound(String type, String id) { return new AwsException("ResourceNotFoundException", type + " " + id + " not found.", 404); }
+}

--- a/src/main/java/io/github/hectorvent/floci/services/oam/model/OamLink.java
+++ b/src/main/java/io/github/hectorvent/floci/services/oam/model/OamLink.java
@@ -1,0 +1,44 @@
+package io.github.hectorvent.floci.services.oam.model;
+
+import io.quarkus.runtime.annotations.RegisterForReflection;
+
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+@RegisterForReflection
+public class OamLink {
+    private String arn;
+    private String id;
+    private String label;
+    private String labelTemplate;
+    private String sinkArn;
+    private String region;
+    private String sourceAccountId;
+    private List<String> resourceTypes = List.of();
+    private Map<String, Object> linkConfiguration = new LinkedHashMap<>();
+    private Map<String, String> tags = new LinkedHashMap<>();
+
+    public OamLink() {}
+
+    public String getArn() { return arn; }
+    public void setArn(String arn) { this.arn = arn; }
+    public String getId() { return id; }
+    public void setId(String id) { this.id = id; }
+    public String getLabel() { return label; }
+    public void setLabel(String label) { this.label = label; }
+    public String getLabelTemplate() { return labelTemplate; }
+    public void setLabelTemplate(String labelTemplate) { this.labelTemplate = labelTemplate; }
+    public String getSinkArn() { return sinkArn; }
+    public void setSinkArn(String sinkArn) { this.sinkArn = sinkArn; }
+    public String getRegion() { return region; }
+    public void setRegion(String region) { this.region = region; }
+    public String getSourceAccountId() { return sourceAccountId; }
+    public void setSourceAccountId(String sourceAccountId) { this.sourceAccountId = sourceAccountId; }
+    public List<String> getResourceTypes() { return resourceTypes; }
+    public void setResourceTypes(List<String> resourceTypes) { this.resourceTypes = resourceTypes == null ? List.of() : List.copyOf(resourceTypes); }
+    public Map<String, Object> getLinkConfiguration() { return linkConfiguration; }
+    public void setLinkConfiguration(Map<String, Object> linkConfiguration) { this.linkConfiguration = linkConfiguration == null ? new LinkedHashMap<>() : new LinkedHashMap<>(linkConfiguration); }
+    public Map<String, String> getTags() { return tags; }
+    public void setTags(Map<String, String> tags) { this.tags = tags == null ? new LinkedHashMap<>() : new LinkedHashMap<>(tags); }
+}

--- a/src/main/java/io/github/hectorvent/floci/services/oam/model/OamSink.java
+++ b/src/main/java/io/github/hectorvent/floci/services/oam/model/OamSink.java
@@ -1,0 +1,34 @@
+package io.github.hectorvent.floci.services.oam.model;
+
+import io.quarkus.runtime.annotations.RegisterForReflection;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+@RegisterForReflection
+public class OamSink {
+    private String arn;
+    private String id;
+    private String name;
+    private String region;
+    private String ownerAccountId;
+    private String policy;
+    private Map<String, String> tags = new LinkedHashMap<>();
+
+    public OamSink() {}
+
+    public String getArn() { return arn; }
+    public void setArn(String arn) { this.arn = arn; }
+    public String getId() { return id; }
+    public void setId(String id) { this.id = id; }
+    public String getName() { return name; }
+    public void setName(String name) { this.name = name; }
+    public String getRegion() { return region; }
+    public void setRegion(String region) { this.region = region; }
+    public String getOwnerAccountId() { return ownerAccountId; }
+    public void setOwnerAccountId(String ownerAccountId) { this.ownerAccountId = ownerAccountId; }
+    public String getPolicy() { return policy; }
+    public void setPolicy(String policy) { this.policy = policy; }
+    public Map<String, String> getTags() { return tags; }
+    public void setTags(Map<String, String> tags) { this.tags = tags == null ? new LinkedHashMap<>() : new LinkedHashMap<>(tags); }
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -602,6 +602,8 @@ floci:
     bcm-data-exports:
       enabled: true
       emit-mode: synchronous
+    oam:
+      enabled: true
     cloudtrail:
       enabled: true
     lightsail:

--- a/src/test/java/io/github/hectorvent/floci/services/oam/OamIntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/oam/OamIntegrationTest.java
@@ -1,0 +1,142 @@
+package io.github.hectorvent.floci.services.oam;
+
+import io.github.hectorvent.floci.testing.RestAssuredJsonUtils;
+import io.quarkus.test.junit.QuarkusTest;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+import static io.restassured.RestAssured.given;
+import static org.hamcrest.Matchers.*;
+
+@QuarkusTest
+class OamIntegrationTest {
+
+    private static final String MONITORING =
+            "AWS4-HMAC-SHA256 Credential=111111111111/20260911/us-east-1/oam/aws4_request";
+    private static final String SOURCE =
+            "AWS4-HMAC-SHA256 Credential=222222222222/20260911/us-east-1/oam/aws4_request";
+
+    @BeforeAll
+    static void configureRestAssured() {
+        RestAssuredJsonUtils.configureAwsContentTypes();
+    }
+
+    @Test
+    void sinkLinkLifecycleWorksAcrossAccounts() {
+        String sinkArn = given()
+                .header("Authorization", MONITORING)
+                .contentType("application/json")
+                .body("{\"Name\":\"central-observability\"}")
+            .when().post("/CreateSink")
+            .then().statusCode(200)
+                .body("Name", equalTo("central-observability"))
+                .body("Arn", startsWith("arn:aws:oam:us-east-1:111111111111:sink/"))
+                .extract().path("Arn");
+
+        String policy = "{\"Version\":\"2012-10-17\",\"Statement\":[{\"Effect\":\"Allow\","
+                + "\"Principal\":{\"AWS\":\"arn:aws:iam::222222222222:root\"},"
+                + "\"Action\":[\"oam:CreateLink\",\"oam:UpdateLink\"],\"Resource\":\"" + sinkArn + "\","
+                + "\"Condition\":{\"ForAllValues:StringEquals\":{\"oam:ResourceTypes\":["
+                + "\"AWS::CloudWatch::Metric\",\"AWS::Logs::LogGroup\"]}}}]}";
+
+        given().header("Authorization", MONITORING).contentType("application/json")
+                .body(java.util.Map.of("SinkIdentifier", sinkArn, "Policy", policy))
+            .when().post("/PutSinkPolicy")
+            .then().statusCode(200).body("SinkArn", equalTo(sinkArn));
+
+        String linkArn = given().header("Authorization", SOURCE).contentType("application/json")
+                .body(java.util.Map.of(
+                        "SinkIdentifier", sinkArn,
+                        "LabelTemplate", "source-account",
+                        "ResourceTypes", java.util.List.of("AWS::CloudWatch::Metric")))
+            .when().post("/CreateLink")
+            .then().statusCode(200)
+                .body("SinkArn", equalTo(sinkArn))
+                .body("ResourceTypes", contains("AWS::CloudWatch::Metric"))
+                .extract().path("Arn");
+
+        given().header("Authorization", SOURCE).contentType("application/json").body("{}")
+            .when().post("/ListLinks")
+            .then().statusCode(200).body("Items.Arn", contains(linkArn));
+
+        given().header("Authorization", MONITORING).contentType("application/json")
+                .body(java.util.Map.of("SinkIdentifier", sinkArn))
+            .when().post("/ListAttachedLinks")
+            .then().statusCode(200).body("Items.LinkArn", contains(linkArn));
+
+        given().header("Authorization", SOURCE).contentType("application/json")
+                .body(java.util.Map.of(
+                        "Identifier", linkArn,
+                        "ResourceTypes", java.util.List.of("AWS::CloudWatch::Metric", "AWS::Logs::LogGroup"),
+                        "LinkConfiguration", java.util.Map.of(
+                                "MetricConfiguration", java.util.Map.of("Filter", "Namespace LIKE 'AWS/%'"))))
+            .when().post("/UpdateLink")
+            .then().statusCode(200)
+                .body("ResourceTypes.size()", equalTo(2))
+                .body("LinkConfiguration.MetricConfiguration.Filter", equalTo("Namespace LIKE 'AWS/%'"));
+
+        given().header("Authorization", SOURCE).contentType("application/json")
+                .body(java.util.Map.of("Identifier", linkArn))
+            .when().post("/DeleteLink")
+            .then().statusCode(200);
+
+        given().header("Authorization", MONITORING).contentType("application/json")
+                .body(java.util.Map.of("Identifier", sinkArn))
+            .when().post("/DeleteSink")
+            .then().statusCode(200);
+    }
+
+    @Test
+    void sinkPolicyRejectsUnauthorizedSourceAccount() {
+        String sinkArn = given().header("Authorization", MONITORING).contentType("application/json")
+                .body("{\"Name\":\"policy-test\"}")
+            .when().post("/CreateSink")
+            .then().statusCode(200).extract().path("Arn");
+
+        String policy = "{\"Version\":\"2012-10-17\",\"Statement\":[{\"Effect\":\"Allow\","
+                + "\"Principal\":{\"AWS\":\"arn:aws:iam::333333333333:root\"},"
+                + "\"Action\":\"oam:CreateLink\",\"Resource\":\"*\"}]}";
+        given().header("Authorization", MONITORING).contentType("application/json")
+                .body(java.util.Map.of("SinkIdentifier", sinkArn, "Policy", policy))
+            .when().post("/PutSinkPolicy")
+            .then().statusCode(200);
+
+        given().header("Authorization", SOURCE).contentType("application/json")
+                .body(java.util.Map.of(
+                        "SinkIdentifier", sinkArn,
+                        "LabelTemplate", "denied",
+                        "ResourceTypes", java.util.List.of("AWS::CloudWatch::Metric")))
+            .when().post("/CreateLink")
+            .then().statusCode(400).body("__type", containsString("InvalidParameterException"));
+
+        given().header("Authorization", MONITORING).contentType("application/json")
+                .body(java.util.Map.of("Identifier", sinkArn))
+            .when().post("/DeleteSink")
+            .then().statusCode(200);
+    }
+    @Test
+    void unsupportedOrganizationConditionDoesNotBecomeWildcardAllow() {
+        String sinkArn = given().header("Authorization", MONITORING).contentType("application/json")
+                .body("{\"Name\":\"org-policy-test\"}")
+            .when().post("/CreateSink")
+            .then().statusCode(200).extract().path("Arn");
+
+        String policy = "{\"Version\":\"2012-10-17\",\"Statement\":[{\"Effect\":\"Allow\","
+                + "\"Principal\":\"*\",\"Action\":\"oam:CreateLink\",\"Resource\":\"*\","
+                + "\"Condition\":{\"StringEquals\":{\"aws:PrincipalOrgID\":\"o-example\"}}}]}";
+        given().header("Authorization", MONITORING).contentType("application/json")
+                .body(java.util.Map.of("SinkIdentifier", sinkArn, "Policy", policy))
+            .when().post("/PutSinkPolicy").then().statusCode(200);
+
+        given().header("Authorization", SOURCE).contentType("application/json")
+                .body(java.util.Map.of("SinkIdentifier", sinkArn, "LabelTemplate", "source",
+                        "ResourceTypes", java.util.List.of("AWS::CloudWatch::Metric")))
+            .when().post("/CreateLink")
+            .then().statusCode(400).body("__type", containsString("InvalidParameterException"));
+
+        given().header("Authorization", MONITORING).contentType("application/json")
+                .body(java.util.Map.of("Identifier", sinkArn))
+            .when().post("/DeleteSink").then().statusCode(200);
+    }
+
+}

--- a/src/test/java/io/github/hectorvent/floci/services/oam/OamIntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/oam/OamIntegrationTest.java
@@ -139,4 +139,30 @@ class OamIntegrationTest {
             .when().post("/DeleteSink").then().statusCode(200);
     }
 
+    @Test
+    void explicitDenyOverridesMatchingAllow() {
+        String sinkArn = given().header("Authorization", MONITORING).contentType("application/json")
+                .body("{\"Name\":\"explicit-deny-test\"}")
+            .when().post("/CreateSink")
+            .then().statusCode(200).extract().path("Arn");
+
+        String policy = "{\"Version\":\"2012-10-17\",\"Statement\":["
+                + "{\"Effect\":\"Allow\",\"Principal\":\"*\",\"Action\":\"oam:CreateLink\",\"Resource\":\"*\"},"
+                + "{\"Effect\":\"Deny\",\"Principal\":{\"AWS\":\"arn:aws:iam::222222222222:root\"},"
+                + "\"Action\":\"oam:CreateLink\",\"Resource\":\"*\"}]}";
+        given().header("Authorization", MONITORING).contentType("application/json")
+                .body(java.util.Map.of("SinkIdentifier", sinkArn, "Policy", policy))
+            .when().post("/PutSinkPolicy").then().statusCode(200);
+
+        given().header("Authorization", SOURCE).contentType("application/json")
+                .body(java.util.Map.of("SinkIdentifier", sinkArn, "LabelTemplate", "source",
+                        "ResourceTypes", java.util.List.of("AWS::CloudWatch::Metric")))
+            .when().post("/CreateLink")
+            .then().statusCode(400).body("__type", containsString("InvalidParameterException"));
+
+        given().header("Authorization", MONITORING).contentType("application/json")
+                .body(java.util.Map.of("Identifier", sinkArn))
+            .when().post("/DeleteSink").then().statusCode(200);
+    }
+
 }

--- a/src/test/resources/application.yml
+++ b/src/test/resources/application.yml
@@ -340,6 +340,8 @@ floci:
     bcm-data-exports:
       enabled: true
       emit-mode: off
+    oam:
+      enabled: true
     cloudtrail:
       enabled: true
       flush-interval-seconds: 3600


### PR DESCRIPTION
## Summary

Adds CloudWatch Observability Access Manager (OAM) support with the complete public API surface for sinks, sink policies, links, pagination, tagging, and cross-account authorization.

Includes multi-account/region isolation, sink-policy checks for both `CreateLink` and `UpdateLink`, conservative handling of unsupported policy conditions, service configuration/registration, documentation, and Java SDK compatibility coverage.

## Type of change

- [ ] Bug fix (`fix:`)
- [x] New feature (`feat:`)
- [ ] Breaking change (`feat!:` or `fix!:`)
- [ ] Docs / chore

## AWS Compatibility

Verified against the AWS OAM REST-JSON API model and AWS documentation for API version `2022-06-10`.

Wire compatibility was exercised with AWS SDK for Java v2 `2.52.0` and AWS CLI `2.36.31`.

Focused validation:
- `OamIntegrationTest` passes
- Java SDK compatibility test compiles against the official `oam` client
- documentation action-table validation passes

## Checklist

- [ ] `./mvnw test` passes locally
- [x] New or updated integration test added
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
