### PR TITLE
fix(build): target compatible ARM64 native binaries

### DIFF
--- a/.github/workflows/build-images.yml
+++ b/.github/workflows/build-images.yml
@@ -231,8 +231,10 @@ jobs:
         # REST invokers for AwsQueryController.dispatch and AwsJson11Controller.handle are each the
         # single call site of a very large method; inlined, the method outgrows the aarch64
         # conditional-branch range and the build dies with BranchTargetOutOfBoundsException.
-        # The flag only exists on Mandrel, so it is passed here rather than in application.yml.
-        run: ./mvnw clean package -Dnative -DskipTests -B -Dquarkus.native.additional-build-args-append="-H:-AOTSingleCallsiteInline"
+        # Keep ARM64 portable across older cores (for example Raspberry Pi 4) instead of
+        # inheriting the CI host's optional AArch64 features such as LSE. The AOT flag only
+        # exists on Mandrel, so both native-image arguments stay scoped to this build.
+        run: ./mvnw clean package -Dnative -DskipTests -B -Dquarkus.native.additional-build-args-append="-march=compatibility,-H:-AOTSingleCallsiteInline"
 
       - uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
         with:

--- a/.github/workflows/compatibility.yml
+++ b/.github/workflows/compatibility.yml
@@ -180,8 +180,10 @@ jobs:
         # REST invokers for AwsQueryController.dispatch and AwsJson11Controller.handle are each the
         # single call site of a very large method; inlined, the method outgrows the aarch64
         # conditional-branch range and the build dies with BranchTargetOutOfBoundsException.
-        # The flag only exists on Mandrel, so it is passed here rather than in application.yml.
-        run: mvn clean package -Dnative -DskipTests -B -Dquarkus.native.additional-build-args-append="-Ob,-H:-AOTSingleCallsiteInline"
+        # Keep ARM64 portable across older cores (for example Raspberry Pi 4) instead of
+        # inheriting the CI host's optional AArch64 features such as LSE. The AOT flag only
+        # exists on Mandrel, so both native-image arguments stay scoped to this build.
+        run: mvn clean package -Dnative -DskipTests -B -Dquarkus.native.additional-build-args-append="-Ob,-march=compatibility,-H:-AOTSingleCallsiteInline"
 
       # Quarkus always writes GraalVM's build-output JSON next to the native source jar. Surfacing
       # it here gives every PR a size record for both architectures: code area, image heap, total

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -142,8 +142,10 @@ jobs:
         # REST invokers for AwsQueryController.dispatch and AwsJson11Controller.handle are each the
         # single call site of a very large method; inlined, the method outgrows the aarch64
         # conditional-branch range and the build dies with BranchTargetOutOfBoundsException.
-        # The flag only exists on Mandrel, so it is passed here rather than in application.yml.
-        run: mvn clean package -Dnative -DskipTests -B -Dquarkus.native.additional-build-args-append="-H:-AOTSingleCallsiteInline"
+        # Keep ARM64 portable across older cores (for example Raspberry Pi 4) instead of
+        # inheriting the CI host's optional AArch64 features such as LSE. The AOT flag only
+        # exists on Mandrel, so both native-image arguments stay scoped to this build.
+        run: mvn clean package -Dnative -DskipTests -B -Dquarkus.native.additional-build-args-append="-march=compatibility,-H:-AOTSingleCallsiteInline"
 
       - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -87,8 +87,10 @@ jobs:
         # REST invokers for AwsQueryController.dispatch and AwsJson11Controller.handle are each the
         # single call site of a very large method; inlined, the method outgrows the aarch64
         # conditional-branch range and the build dies with BranchTargetOutOfBoundsException.
-        # The flag only exists on Mandrel, so it is passed here rather than in application.yml.
-        run: mvn clean package -Dnative -DskipTests -B -Dquarkus.native.additional-build-args-append="-H:-AOTSingleCallsiteInline"
+        # Keep ARM64 portable across older cores (for example Raspberry Pi 4) instead of
+        # inheriting the CI host's optional AArch64 features such as LSE. The AOT flag only
+        # exists on Mandrel, so both native-image arguments stay scoped to this build.
+        run: mvn clean package -Dnative -DskipTests -B -Dquarkus.native.additional-build-args-append="-march=compatibility,-H:-AOTSingleCallsiteInline"
 
       - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:


### PR DESCRIPTION
## Summary

Builds ARM64 native binaries with GraalVM's compatibility architecture target so generated binaries do not require newer ARM LSE instructions unavailable on Raspberry Pi 4-class CPUs.

Applies the compatible target consistently to the ARM64 native build paths while keeping the existing x86-64-v2 target for AMD64.

Closes #1114

## Type of change

- [x] Bug fix (`fix:`)
- [ ] New feature (`feat:`)
- [ ] Breaking change (`feat!:` or `fix!:`)
- [ ] Docs / chore

## AWS Compatibility

Not an AWS protocol change. The incorrect behavior was that ARM64 native artifacts could be compiled for an instruction set newer than Raspberry Pi 4 supports, causing startup failures/restart loops.

Validation:
- workflow YAML parses successfully
- ARM64 native build invocations use `-march=compatibility`
- AMD64 remains `-march=x86-64-v2`

## Checklist

- [ ] `./mvnw test` passes locally
- [ ] New or updated integration test added
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
