### PR TITLE
fix(cloudhsmv2): tighten backup and tag fidelity

### DIFF
--- a/src/main/java/io/github/hectorvent/floci/services/cloudhsmv2/CloudHsmV2Service.java
+++ b/src/main/java/io/github/hectorvent/floci/services/cloudhsmv2/CloudHsmV2Service.java
@@ -140,7 +140,7 @@ public class CloudHsmV2Service {
             }
         }
         cluster.setSubnetMapping(subnetMapping);
-        cluster.setSourceBackupId(sourceBackupId);
+        cluster.setSourceBackupId(sourceBackup != null ? sourceBackup.getBackupId() : null);
         cluster.setSecurityGroup("sg-" + generateShortId());
         cluster.setCreateTimestamp(Instant.now());
         cluster.setBackupPolicy(DEFAULT_BACKUP_POLICY);
@@ -188,6 +188,11 @@ public class CloudHsmV2Service {
             LOG.warnv("Failed to generate emulated hardware certs: {0}", e.getMessage());
         }
 
+        if (sourceBackup != null && sourceBackup.getClusterCertificate() != null) {
+            certs.setClusterCertificate(sourceBackup.getClusterCertificate());
+            certs.setClusterCsr(null);
+            cluster.setState(ClusterState.INITIALIZED);
+        }
         cluster.setCertificates(certs);
 
         String storageKey = regionKey(region, clusterId);
@@ -436,15 +441,23 @@ public class CloudHsmV2Service {
         }
         if (resourceId.startsWith("backup-")) {
             Backup backup = getBackup(resourceId, region);
-            if (tags != null && !tags.isEmpty()) {
-                backup.getTagList().putAll(tags);
+            Map<String, String> merged = new LinkedHashMap<>(backup.getTagList());
+            merged.putAll(tags);
+            if (merged.size() > 50) {
+                throw new AwsException("CloudHsmResourceLimitExceededException",
+                        "The resource cannot have more than 50 tags.", 400);
             }
+            backup.setTagList(merged);
             backups.put(regionKey(region, resourceId), backup);
         } else {
             Cluster cluster = getCluster(resourceId, region);
-            if (tags != null && !tags.isEmpty()) {
-                cluster.getTagList().putAll(tags);
+            Map<String, String> merged = new LinkedHashMap<>(cluster.getTagList());
+            merged.putAll(tags);
+            if (merged.size() > 50) {
+                throw new AwsException("CloudHsmResourceLimitExceededException",
+                        "The resource cannot have more than 50 tags.", 400);
             }
+            cluster.setTagList(merged);
             clusters.put(regionKey(region, resourceId), cluster);
         }
     }
@@ -595,6 +608,9 @@ public class CloudHsmV2Service {
         backup.setNeverExpires("False");
         backup.setMode(cluster.getMode());
         backup.setHsmType(cluster.getHsmType());
+        if (cluster.getCertificates() != null) {
+            backup.setClusterCertificate(cluster.getCertificates().getClusterCertificate());
+        }
         backups.put(regionKey(region, backup.getBackupId()), backup);
     }
 
@@ -673,6 +689,7 @@ public class CloudHsmV2Service {
         copy.setSourceCluster(source.getClusterId());
         copy.setMode(source.getMode());
         copy.setHsmType(source.getHsmType());
+        copy.setClusterCertificate(source.getClusterCertificate());
         copy.setNeverExpires(source.getNeverExpires());
         backups.put(regionKey(destinationRegion, copy.getBackupId()), copy);
         return copy;
@@ -681,6 +698,10 @@ public class CloudHsmV2Service {
     // ──────────────────────────── Resource Policies ────────────────────────────
 
     public void putResourcePolicy(String resourceArn, String policy, String region) {
+        if (policy != null && (policy.isEmpty() || policy.length() > 20_000)) {
+            throw new AwsException("CloudHsmInvalidRequestException",
+                    "Policy must be between 1 and 20000 characters.", 400);
+        }
         String id = resourcePolicyBackupId(resourceArn);
         Backup backup = getBackup(id, region);
         if (!"READY".equals(backup.getBackupState())) {

--- a/src/main/java/io/github/hectorvent/floci/services/cloudhsmv2/CloudHsmV2Service.java
+++ b/src/main/java/io/github/hectorvent/floci/services/cloudhsmv2/CloudHsmV2Service.java
@@ -681,45 +681,36 @@ public class CloudHsmV2Service {
     // ──────────────────────────── Resource Policies ────────────────────────────
 
     public void putResourcePolicy(String resourceArn, String policy, String region) {
-        String id = extractId(resourceArn);
-        if (id.startsWith("backup-")) {
-            Backup backup = getBackup(id, region);
-            if (!"READY".equals(backup.getBackupState())) {
-                throw new AwsException("CloudHsmInvalidRequestException", "Backup must be READY to apply a policy", 400);
-            }
-            backup.setResourcePolicy(policy);
-            backups.put(regionKey(region, id), backup);
-        } else {
-            Cluster cluster = getCluster(id, region);
-            cluster.setResourcePolicy(policy);
-            clusters.put(regionKey(region, id), cluster);
+        String id = resourcePolicyBackupId(resourceArn);
+        Backup backup = getBackup(id, region);
+        if (!"READY".equals(backup.getBackupState())) {
+            throw new AwsException("CloudHsmInvalidRequestException",
+                    "Backup must be READY to apply a policy", 400);
         }
+        backup.setResourcePolicy(policy);
+        backups.put(regionKey(region, id), backup);
     }
 
     public String getResourcePolicy(String resourceArn, String region) {
-        String id = extractId(resourceArn);
-        if (id.startsWith("backup-")) {
-            return getBackup(id, region).getResourcePolicy();
-        } else {
-            return getCluster(id, region).getResourcePolicy();
-        }
+        return getBackup(resourcePolicyBackupId(resourceArn), region).getResourcePolicy();
     }
 
     public String deleteResourcePolicy(String resourceArn, String region) {
-        String id = extractId(resourceArn);
-        String oldPolicy = null;
-        if (id.startsWith("backup-")) {
-            Backup backup = getBackup(id, region);
-            oldPolicy = backup.getResourcePolicy();
-            backup.setResourcePolicy(null);
-            backups.put(regionKey(region, id), backup);
-        } else {
-            Cluster cluster = getCluster(id, region);
-            oldPolicy = cluster.getResourcePolicy();
-            cluster.setResourcePolicy(null);
-            clusters.put(regionKey(region, id), cluster);
-        }
+        String id = resourcePolicyBackupId(resourceArn);
+        Backup backup = getBackup(id, region);
+        String oldPolicy = backup.getResourcePolicy();
+        backup.setResourcePolicy(null);
+        backups.put(regionKey(region, id), backup);
         return oldPolicy;
+    }
+
+    private String resourcePolicyBackupId(String resourceArn) {
+        String id = extractId(resourceArn);
+        if (!id.startsWith("backup-")) {
+            throw new AwsException("CloudHsmInvalidRequestException",
+                    "AWS CloudHSM resource policies are supported only for backups.", 400);
+        }
+        return id;
     }
 
     private String extractId(String arn) {

--- a/src/main/java/io/github/hectorvent/floci/services/cloudhsmv2/CloudHsmV2Service.java
+++ b/src/main/java/io/github/hectorvent/floci/services/cloudhsmv2/CloudHsmV2Service.java
@@ -432,7 +432,7 @@ public class CloudHsmV2Service {
 
     // ──────────────────────────── TagResource ────────────────────────────
 
-    public void tagResource(String resourceId, Map<String, String> tags, String region) {
+    public synchronized void tagResource(String resourceId, Map<String, String> tags, String region) {
         if (resourceId == null || resourceId.isBlank()) {
             throw new AwsException("CloudHsmInvalidRequestException", "ResourceId is required.", 400);
         }
@@ -462,7 +462,7 @@ public class CloudHsmV2Service {
         }
     }
 
-    public void untagResource(String resourceId, List<String> tagKeys, String region) {
+    public synchronized void untagResource(String resourceId, List<String> tagKeys, String region) {
         if (resourceId == null || resourceId.isBlank()) {
             throw new AwsException("CloudHsmInvalidRequestException", "ResourceId is required.", 400);
         }

--- a/src/main/java/io/github/hectorvent/floci/services/cloudhsmv2/model/Backup.java
+++ b/src/main/java/io/github/hectorvent/floci/services/cloudhsmv2/model/Backup.java
@@ -26,6 +26,7 @@ public class Backup {
     private Map<String, String> tagList = new LinkedHashMap<>();
     private String mode;
     private String hsmType;
+    private String clusterCertificate;
 
     public String getBackupId() {
         return backupId;
@@ -137,5 +138,13 @@ public class Backup {
 
     public void setHsmType(String hsmType) {
         this.hsmType = hsmType;
+    }
+
+    public String getClusterCertificate() {
+        return clusterCertificate;
+    }
+
+    public void setClusterCertificate(String clusterCertificate) {
+        this.clusterCertificate = clusterCertificate;
     }
 }

--- a/src/test/java/io/github/hectorvent/floci/services/cloudhsmv2/CloudHsmV2IntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/cloudhsmv2/CloudHsmV2IntegrationTest.java
@@ -909,6 +909,32 @@ class CloudHsmV2IntegrationTest {
             .body("__type", equalTo("CloudHsmResourceNotFoundException"));
     }
 
+    @Test
+    @Order(55)
+    void tagResourceEnforcesFiftyTagTotalLimit() {
+        String clusterId = given()
+            .header("X-Amz-Target", TARGET_PREFIX + "CreateCluster")
+            .contentType(CONTENT_TYPE)
+            .body("{\"HsmType\":\"hsm1.medium\",\"SubnetIds\":[\"subnet-abcdef99\"]}")
+        .when().post("/")
+        .then().statusCode(200).extract().jsonPath().getString("Cluster.ClusterId");
+
+        StringBuilder firstTags = new StringBuilder("[");
+        for (int i = 0; i < 50; i++) {
+            if (i > 0) firstTags.append(',');
+            firstTags.append("{\"Key\":\"k").append(i).append("\",\"Value\":\"v\"}");
+        }
+        firstTags.append(']');
+        given().header("X-Amz-Target", TARGET_PREFIX + "TagResource").contentType(CONTENT_TYPE)
+            .body("{\"ResourceId\":\"" + clusterId + "\",\"TagList\":" + firstTags + "}")
+        .when().post("/").then().statusCode(200);
+
+        given().header("X-Amz-Target", TARGET_PREFIX + "TagResource").contentType(CONTENT_TYPE)
+            .body("{\"ResourceId\":\"" + clusterId + "\",\"TagList\":[{\"Key\":\"overflow\",\"Value\":\"v\"}]}")
+        .when().post("/").then().statusCode(400)
+            .body("__type", equalTo("CloudHsmResourceLimitExceededException"));
+    }
+
     /** Escapes a PEM string as a JSON string value. */
     private static String jsonString(String pem) {
         if (pem == null) {

--- a/src/test/java/io/github/hectorvent/floci/services/cloudhsmv2/CloudHsmV2IntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/cloudhsmv2/CloudHsmV2IntegrationTest.java
@@ -707,6 +707,41 @@ class CloudHsmV2IntegrationTest {
 
     @Test
     @Order(54)
+    void resourcePoliciesRejectClustersBecauseAwsSupportsOnlyBackups() {
+        String clusterId = given()
+            .header("X-Amz-Target", TARGET_PREFIX + "CreateCluster")
+            .contentType(CONTENT_TYPE)
+            .body("""
+                {
+                    "HsmType": "hsm1.medium",
+                    "SubnetIds": ["subnet-policy01"]
+                }
+                """)
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200)
+            .extract().jsonPath().getString("Cluster.ClusterId");
+        String clusterArn = "arn:aws:cloudhsm:us-east-1:000000000000:cluster/" + clusterId;
+
+        given()
+            .header("X-Amz-Target", TARGET_PREFIX + "PutResourcePolicy")
+            .contentType(CONTENT_TYPE)
+            .body("""
+                {
+                    "ResourceArn": "%s",
+                    "Policy": "{}"
+                }
+                """.formatted(clusterArn))
+        .when()
+            .post("/")
+        .then()
+            .statusCode(400)
+            .body("__type", equalTo("CloudHsmInvalidRequestException"));
+    }
+
+    @Test
+    @Order(55)
     void deleteClusterWithHsmsFails() {
         // Create a cluster, add an HSM, then try to delete the cluster
         String tempClusterId = given()


### PR DESCRIPTION
## Summary

Tightens CloudHSM v2 behavior against the AWS contract already implemented on `main`.

This change restricts resource policies to backups, preserves the READY requirement, enforces the 50-tag limit on the resulting tag set, and improves restore-from-backup fidelity so restored clusters preserve backup-derived identity/certificate state rather than behaving like a fresh cluster.

Closes #1774

## Type of change

- [x] Bug fix (`fix:`)
- [ ] New feature (`feat:`)
- [ ] Breaking change (`feat!:` or `fix!:`)
- [ ] Docs / chore

## AWS Compatibility

Reviewed against the CloudHSM v2 `2017-04-28` API model and AWS CloudHSM documentation, including resource-policy scope, tagging quotas, and create-from-backup behavior.

Focused validation:
- complete `CloudHsmV2IntegrationTest`: 33 tests passing
- resource-policy and accumulated-tag-limit cases covered

## Checklist

- [ ] `./mvnw test` passes locally
- [x] New or updated integration test added
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
