### PR TITLE
fix(resourceexplorer2): reject invalid pagination tokens

### DIFF
--- a/src/main/java/io/github/hectorvent/floci/services/resourceexplorer2/ResourceExplorer2Service.java
+++ b/src/main/java/io/github/hectorvent/floci/services/resourceexplorer2/ResourceExplorer2Service.java
@@ -999,10 +999,14 @@ public class ResourceExplorer2Service {
             return 0;
         }
         try {
-            return Integer.parseInt(new String(Base64.getDecoder().decode(token)));
+            int offset = Integer.parseInt(new String(Base64.getDecoder().decode(token)));
+            if (offset < 0) {
+                throw new IllegalArgumentException("negative offset");
+            }
+            return offset;
         } catch (Exception e) {
-            LOG.debugf("Invalid NextToken '%s', restarting from offset 0: %s", token, e.getMessage());
-            return 0;
+            throw new AwsException("ValidationException",
+                    "NextToken is invalid or has expired.", 400);
         }
     }
 

--- a/src/test/java/io/github/hectorvent/floci/services/resourceexplorer2/ResourceExplorer2IntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/resourceexplorer2/ResourceExplorer2IntegrationTest.java
@@ -427,6 +427,19 @@ class ResourceExplorer2IntegrationTest {
         }
 
         @Test
+        void listResourcesInvalidNextTokenReturnsValidationError() {
+            given()
+                .header("Authorization", AUTH)
+                .contentType("application/json")
+                .body("{\"NextToken\":\"!!!not-base64!!!\"}")
+            .when()
+                .post("/ListResources")
+            .then()
+                .statusCode(400)
+                .body("__type", equalTo("ValidationException"));
+        }
+
+        @Test
         void listResourcesInvalidFilterReturns400() {
             given()
                 .header("Authorization", AUTH)

--- a/src/test/java/io/github/hectorvent/floci/services/resourceexplorer2/ResourceExplorer2PaginationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/resourceexplorer2/ResourceExplorer2PaginationTest.java
@@ -7,6 +7,7 @@ import java.util.Base64;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 /**
  * Unit tests for the pure pagination math behind ListResources/Search:
@@ -63,9 +64,15 @@ class ResourceExplorer2PaginationTest {
     }
 
     @Test
-    void garbageTokenDecodesToZeroOffset() {
-        var b = ResourceExplorer2Service.pageBounds(50, 10, "!!!not-base64!!!", CAP);
-        assertEquals(0, b.start());
+    void garbageTokenIsRejected() {
+        assertThrows(io.github.hectorvent.floci.core.common.AwsException.class,
+                () -> ResourceExplorer2Service.pageBounds(50, 10, "!!!not-base64!!!", CAP));
+    }
+
+    @Test
+    void negativeTokenOffsetIsRejected() {
+        assertThrows(io.github.hectorvent.floci.core.common.AwsException.class,
+                () -> ResourceExplorer2Service.pageBounds(50, 10, token(-1), CAP));
     }
 
     @Test


### PR DESCRIPTION
## Summary

Makes Resource Explorer pagination reject malformed or negative `NextToken` values instead of silently treating them as offset zero.

This aligns the existing Resource Explorer implementation with AWS validation behavior and prevents invalid pagination tokens from replaying the first page.

Closes #1795

## Type of change

- [x] Bug fix (`fix:`)
- [ ] New feature (`feat:`)
- [ ] Breaking change (`feat!:` or `fix!:`)
- [ ] Docs / chore

## AWS Compatibility

Reviewed against the AWS Resource Explorer 2 `ListResources` API contract, including `NextToken`, `MaxResults`, and `ValidationException` behavior.

Focused unit and integration pagination tests pass.

## Checklist

- [ ] `./mvnw test` passes locally
- [x] New or updated integration test added
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
