### PR TITLE
feat(rds): persist EngineMode and StorageEncrypted on DB clusters

### DIFF
--- a/src/main/java/io/github/hectorvent/floci/services/rds/RdsQueryHandler.java
+++ b/src/main/java/io/github/hectorvent/floci/services/rds/RdsQueryHandler.java
@@ -457,6 +457,8 @@ public class RdsQueryHandler {
         boolean multiAz = "true".equalsIgnoreCase(params.getFirst("MultiAZ"));
         boolean manageMasterUserPassword = "true".equalsIgnoreCase(params.getFirst("ManageMasterUserPassword"));
         String masterUserSecretKmsKeyId = params.getFirst("MasterUserSecretKmsKeyId");
+        String engineMode = params.getFirst("EngineMode");
+        boolean storageEncrypted = "true".equalsIgnoreCase(params.getFirst("StorageEncrypted"));
 
         if (engineVersion == null) {
             engineVersion = defaultEngineVersion(engine);
@@ -471,7 +473,7 @@ public class RdsQueryHandler {
                     masterPassword, databaseName, iamEnabled, paramGroupName,
                     dbSubnetGroupName, availabilityZone, multiAz, region,
                     serverlessV2Min, serverlessV2Max, serverlessV2SecondsUntilAutoPause,
-                    manageMasterUserPassword, masterUserSecretKmsKeyId);
+                    manageMasterUserPassword, masterUserSecretKmsKeyId, engineMode, storageEncrypted);
             String result = dbClusterXml(cluster);
             return Response.ok(AwsQueryResponse.envelope("CreateDBCluster", AwsNamespaces.RDS, result)).build();
         } catch (AwsException e) {
@@ -1529,6 +1531,7 @@ public class RdsQueryHandler {
                 .elem("Status", statusStr)
                 .elem("Engine", engineStr.toLowerCase())
                 .elem("EngineVersion", c.getEngineVersion())
+                .elem("EngineMode", c.getEngineMode() != null ? c.getEngineMode() : "provisioned")
                 .elem("MasterUsername", c.getMasterUsername());
         if (c.getDatabaseName() != null && !c.getDatabaseName().isBlank()) {
             xml.elem("DatabaseName", c.getDatabaseName());
@@ -1542,6 +1545,7 @@ public class RdsQueryHandler {
         }
         xml.elem("IAMDatabaseAuthenticationEnabled", c.isIamDatabaseAuthenticationEnabled())
            .elem("MultiAZ", c.isMultiAz())
+           .elem("StorageEncrypted", c.isStorageEncrypted())
            .elem("AvailabilityZone", c.getAvailabilityZone() != null ? c.getAvailabilityZone() : config.defaultAvailabilityZone())
            .elem("PreferredMaintenanceWindow", "mon:00:00-mon:03:00")
            .elem("PreferredBackupWindow", "04:00-06:00")

--- a/src/main/java/io/github/hectorvent/floci/services/rds/RdsService.java
+++ b/src/main/java/io/github/hectorvent/floci/services/rds/RdsService.java
@@ -1804,6 +1804,22 @@ public class RdsService implements Resettable, ResourceProvider {
                                      Double serverlessV2MinCapacity, Double serverlessV2MaxCapacity,
                                      Integer serverlessV2SecondsUntilAutoPause,
                                      boolean manageMasterUserPassword, String masterUserSecretKmsKeyId) {
+        return createDbCluster(id, engineParam, engineVersion, masterUsername, masterPassword,
+                databaseName, iamEnabled, paramGroupName, dbSubnetGroupName, availabilityZone,
+                multiAz, region, serverlessV2MinCapacity, serverlessV2MaxCapacity,
+                serverlessV2SecondsUntilAutoPause, manageMasterUserPassword, masterUserSecretKmsKeyId,
+                null, false);
+    }
+
+    public DbCluster createDbCluster(String id, String engineParam, String engineVersion,
+                                     String masterUsername, String masterPassword,
+                                     String databaseName, boolean iamEnabled,
+                                     String paramGroupName, String dbSubnetGroupName,
+                                     String availabilityZone, boolean multiAz, String region,
+                                     Double serverlessV2MinCapacity, Double serverlessV2MaxCapacity,
+                                     Integer serverlessV2SecondsUntilAutoPause,
+                                     boolean manageMasterUserPassword, String masterUserSecretKmsKeyId,
+                                     String engineMode, boolean storageEncrypted) {
         String provisioningKey = "cluster:" + currentAccountId() + ":"
                 + dbResourceKey(effectiveRegion(region), id);
         if (!provisioningIds.add(provisioningKey)) {
@@ -1814,7 +1830,8 @@ public class RdsService implements Resettable, ResourceProvider {
             return doCreateDbCluster(id, engineParam, engineVersion, masterUsername, masterPassword,
                     databaseName, iamEnabled, paramGroupName, dbSubnetGroupName, availabilityZone,
                     multiAz, region, serverlessV2MinCapacity, serverlessV2MaxCapacity,
-                    serverlessV2SecondsUntilAutoPause, manageMasterUserPassword, masterUserSecretKmsKeyId);
+                    serverlessV2SecondsUntilAutoPause, manageMasterUserPassword, masterUserSecretKmsKeyId,
+                    engineMode, storageEncrypted);
         } finally {
             provisioningIds.remove(provisioningKey);
         }
@@ -1827,7 +1844,8 @@ public class RdsService implements Resettable, ResourceProvider {
                                         String availabilityZone, boolean multiAz, String region,
                                         Double serverlessV2MinCapacity, Double serverlessV2MaxCapacity,
                                         Integer serverlessV2SecondsUntilAutoPause,
-                                        boolean manageMasterUserPassword, String masterUserSecretKmsKeyId) {
+                                        boolean manageMasterUserPassword, String masterUserSecretKmsKeyId,
+                                        String engineMode, boolean storageEncrypted) {
         String effectiveRegion = effectiveRegion(region);
         String clusterResourceId = "cluster-" + java.util.UUID.randomUUID().toString()
                 .replace("-", "").substring(0, 24).toUpperCase();
@@ -1859,6 +1877,8 @@ public class RdsService implements Resettable, ResourceProvider {
                 databaseName, DbInstanceStatus.AVAILABLE, endpoint, endpoint,
                 iamEnabled, new ArrayList<>(), paramGroupName, Instant.now(), proxyPort);
         cluster.setEngineIdentifier(effectiveEngineName(engineParam).toLowerCase(Locale.ROOT));
+        cluster.setEngineMode(engineMode != null && !engineMode.isBlank() ? engineMode : "provisioned");
+        cluster.setStorageEncrypted(storageEncrypted);
         cluster.setContainerStorageResourceId(clusterResourceId);
         if (!mock) {
             String image = imageForEngine(engine, engineVersion);
@@ -1992,7 +2012,7 @@ public class RdsService implements Resettable, ResourceProvider {
         }
     }
 
-    private static boolean isAuroraEngine(String engineIdentifier) {
+    static boolean isAuroraEngine(String engineIdentifier) {
         return engineIdentifier != null
                 && ("aurora-mysql".equalsIgnoreCase(engineIdentifier)
                 || "aurora-postgresql".equalsIgnoreCase(engineIdentifier));

--- a/src/main/java/io/github/hectorvent/floci/services/rds/model/DbCluster.java
+++ b/src/main/java/io/github/hectorvent/floci/services/rds/model/DbCluster.java
@@ -37,6 +37,8 @@ public class DbCluster {
     private Instant createdAt;
     private int proxyPort;
     private Map<String, String> tags = new LinkedHashMap<>();
+    private String engineMode;
+    private boolean storageEncrypted;
 
     private String dockerVolumeName;
     private String volumeId;
@@ -160,6 +162,12 @@ public class DbCluster {
 
     public Map<String, String> getTags() { return tags; }
     public void setTags(Map<String, String> tags) { this.tags = tags != null ? new LinkedHashMap<>(tags) : new LinkedHashMap<>(); }
+
+    public String getEngineMode() { return engineMode; }
+    public void setEngineMode(String engineMode) { this.engineMode = engineMode; }
+
+    public boolean isStorageEncrypted() { return storageEncrypted; }
+    public void setStorageEncrypted(boolean storageEncrypted) { this.storageEncrypted = storageEncrypted; }
 
     public String getDockerVolumeName() { return dockerVolumeName; }
     public void setDockerVolumeName(String dockerVolumeName) { this.dockerVolumeName = dockerVolumeName; }

--- a/src/test/java/io/github/hectorvent/floci/services/rds/RdsClusterEngineModeStorageEncryptedIntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/rds/RdsClusterEngineModeStorageEncryptedIntegrationTest.java
@@ -1,0 +1,110 @@
+package io.github.hectorvent.floci.services.rds;
+
+import io.quarkus.test.junit.QuarkusTest;
+import io.quarkus.test.junit.QuarkusTestProfile;
+import io.quarkus.test.junit.TestProfile;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.Map;
+
+import static io.restassured.RestAssured.given;
+import static io.restassured.http.ContentType.URLENC;
+import static org.hamcrest.Matchers.containsString;
+
+/**
+ * EngineMode and StorageEncrypted round-trip from CreateDBCluster to DescribeDBClusters for an
+ * Aurora-shaped DBCluster, so a caller no longer sees drift on these two fields (issue #2559).
+ * The "Aurora DB clusters only" restriction on EngineMode is scoped to the CreateDBCluster
+ * request parameter, not the DBCluster response member, so a Multi-AZ, non-Aurora cluster still
+ * reports EngineMode (defaulting to provisioned) in DescribeDBClusters, same as StorageEncrypted.
+ */
+@QuarkusTest
+@TestProfile(RdsClusterEngineModeStorageEncryptedIntegrationTest.NoContainersProfile.class)
+class RdsClusterEngineModeStorageEncryptedIntegrationTest {
+
+    public static class NoContainersProfile implements QuarkusTestProfile {
+        @Override
+        public Map<String, String> getConfigOverrides() {
+            return Map.of("floci.services.rds.mock", "true");
+        }
+    }
+
+    private static final String ID = "engine-mode-cluster";
+    private static final String NON_AURORA_ID = "engine-mode-non-aurora-cluster";
+
+    private static io.restassured.specification.RequestSpecification rds(String action) {
+        return given().header("Authorization",
+                        "AWS4-HMAC-SHA256 Credential=test/20260615/us-east-1/rds/aws4_request, "
+                        + "SignedHeaders=content-type;host, Signature=test")
+                .contentType(URLENC)
+                .formParam("Action", action)
+                .formParam("Version", "2014-10-31");
+    }
+
+    @AfterEach
+    void cleanUp() {
+        rds("DeleteDBCluster").formParam("DBClusterIdentifier", ID)
+                .formParam("SkipFinalSnapshot", "true").when().post("/");
+        rds("DeleteDBCluster").formParam("DBClusterIdentifier", NON_AURORA_ID)
+                .formParam("SkipFinalSnapshot", "true").when().post("/");
+    }
+
+    @Test
+    void engineModeAndStorageEncryptedRoundTripThroughDescribe() {
+        rds("CreateDBCluster")
+                .formParam("DBClusterIdentifier", ID)
+                .formParam("Engine", "aurora-postgresql")
+                .formParam("EngineVersion", "16.3")
+                .formParam("MasterUsername", "admin")
+                .formParam("MasterUserPassword", "secret99password")
+                .formParam("EngineMode", "serverless")
+                .formParam("StorageEncrypted", "true")
+                .when().post("/").then().statusCode(200)
+                .body(containsString("<EngineMode>serverless</EngineMode>"))
+                .body(containsString("<StorageEncrypted>true</StorageEncrypted>"));
+
+        rds("DescribeDBClusters").formParam("DBClusterIdentifier", ID)
+                .when().post("/").then().statusCode(200)
+                .body(containsString("<EngineMode>serverless</EngineMode>"))
+                .body(containsString("<StorageEncrypted>true</StorageEncrypted>"));
+    }
+
+    @Test
+    void engineModeDefaultsToProvisionedAndStorageEncryptedDefaultsToFalseWhenOmitted() {
+        rds("CreateDBCluster")
+                .formParam("DBClusterIdentifier", ID)
+                .formParam("Engine", "aurora-postgresql")
+                .formParam("EngineVersion", "16.3")
+                .formParam("MasterUsername", "admin")
+                .formParam("MasterUserPassword", "secret99password")
+                .when().post("/").then().statusCode(200)
+                .body(containsString("<EngineMode>provisioned</EngineMode>"))
+                .body(containsString("<StorageEncrypted>false</StorageEncrypted>"));
+
+        rds("DescribeDBClusters").formParam("DBClusterIdentifier", ID)
+                .when().post("/").then().statusCode(200)
+                .body(containsString("<EngineMode>provisioned</EngineMode>"))
+                .body(containsString("<StorageEncrypted>false</StorageEncrypted>"));
+    }
+
+    @Test
+    void engineModeStillEmittedForNonAuroraMultiAzCluster() {
+        rds("CreateDBCluster")
+                .formParam("DBClusterIdentifier", NON_AURORA_ID)
+                .formParam("Engine", "mysql")
+                .formParam("EngineVersion", "8.0.36")
+                .formParam("MasterUsername", "admin")
+                .formParam("MasterUserPassword", "secret99password")
+                .formParam("MultiAZ", "true")
+                .formParam("StorageEncrypted", "true")
+                .when().post("/").then().statusCode(200)
+                .body(containsString("<EngineMode>provisioned</EngineMode>"))
+                .body(containsString("<StorageEncrypted>true</StorageEncrypted>"));
+
+        rds("DescribeDBClusters").formParam("DBClusterIdentifier", NON_AURORA_ID)
+                .when().post("/").then().statusCode(200)
+                .body(containsString("<EngineMode>provisioned</EngineMode>"))
+                .body(containsString("<StorageEncrypted>true</StorageEncrypted>"));
+    }
+}

--- a/src/test/java/io/github/hectorvent/floci/services/rds/RdsQueryHandlerTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/rds/RdsQueryHandlerTest.java
@@ -293,7 +293,7 @@ class RdsQueryHandlerTest {
         when(service.createDbCluster(eq("mycluster"), eq("aurora-postgresql"), any(),
                 eq("omni_admin"), isNull(), eq("omni"), eq(false), isNull(),
                 isNull(), isNull(), eq(false), any(),
-                isNull(), isNull(), isNull(), eq(true), eq("kms-key-1")))
+                isNull(), isNull(), isNull(), eq(true), eq("kms-key-1"), isNull(), eq(false)))
                 .thenReturn(cluster);
 
         MultivaluedMap<String, String> p = params();
@@ -313,14 +313,15 @@ class RdsQueryHandlerTest {
         verify(service).createDbCluster(eq("mycluster"), eq("aurora-postgresql"), any(),
                 eq("omni_admin"), isNull(), eq("omni"), eq(false), isNull(),
                 isNull(), isNull(), eq(false), any(),
-                isNull(), isNull(), isNull(), eq(true), eq("kms-key-1"));
+                isNull(), isNull(), isNull(), eq(true), eq("kms-key-1"), isNull(), eq(false));
     }
 
     @Test
     void createDbClusterWithoutManagedSecretOmitsMasterUserSecretElement() {
         DbCluster cluster = makeCluster("mycluster");
         when(service.createDbCluster(any(), any(), any(), any(), any(), any(), anyBoolean(), any(),
-                any(), any(), anyBoolean(), any(), any(), any(), any(), eq(false), isNull()))
+                any(), any(), anyBoolean(), any(), any(), any(), any(), eq(false), isNull(),
+                any(), anyBoolean()))
                 .thenReturn(cluster);
 
         MultivaluedMap<String, String> p = params();


### PR DESCRIPTION
## Summary

Fixes #2559 (the safe half of it, see scope note below).

`CreateDBCluster` already accepted `EngineMode` and `StorageEncrypted` for Aurora-shaped `DBCluster`s, but `DbCluster` never stored either field, so `DescribeDBClusters` always reported the defaults regardless of what was requested. Terraform's `aws_rds_cluster` resource then saw permanent drift on every plan unless the user added `lifecycle.ignore_changes` for these two attributes.

This PR:
- Adds `engineMode` (String) and `storageEncrypted` (boolean) to `DbCluster`, following the existing `DbInstance.storageEncrypted` pattern.
- Parses `EngineMode` and `StorageEncrypted` in `CreateDBCluster` request handling (`RdsQueryHandler`) and threads them through `RdsService.createDbCluster`/`doCreateDbCluster`.
- Emits `<EngineMode>` and `<StorageEncrypted>` in the `DescribeDBClusters` (and `CreateDBCluster`/`ModifyDBCluster`-response) XML, matching AWS's element names and casing.
- Defaults `EngineMode` to `provisioned` when the caller omits it, matching what a live Aurora account reports for its default engine mode.

### Scope note

Issue #2559 described two independent problems and said "either is useful." This PR addresses only the `EngineMode`/`StorageEncrypted` persistence gap. The other half of the issue (the advertised endpoint port being the dynamic proxy port range 7001-7099 instead of the engine's real port, e.g. 5432) is intentionally **not** touched here: changing port-advertisement behavior affects live connectivity and needs its own design discussion, so it is left for a separate PR/issue.

## Type of change

- [ ] Bug fix (`fix:`)
- [x] New feature (`feat:`)
- [ ] Breaking change (`feat!:` or `fix!:`)
- [ ] Docs / chore

## AWS Compatibility

Verified against the current AWS API reference:
- `CreateDBCluster`: https://docs.aws.amazon.com/AmazonRDS/latest/APIReference/API_CreateDBCluster.html confirms `EngineMode` (String, optional, "either provisioned or serverless") and `StorageEncrypted` (Boolean, optional) as request parameters.
- `DescribeDBClusters` / `DBCluster` data type: https://docs.aws.amazon.com/AmazonRDS/latest/APIReference/API_DescribeDBClusters.html confirms the response elements are `<EngineMode>` and `<StorageEncrypted>`, and its sample responses show `EngineMode` defaulting to `provisioned` when Serverless v1 is not in use.

No KMS-key/StorageEncrypted cross-validation was added for clusters (unlike the existing `DbInstanceSettings` rule for instances): `DbCluster` has no general storage `KmsKeyId` field today, and AWS's docs don't document an equivalent hard validation error for `CreateDBCluster`, so adding one would be inventing behavior AWS doesn't document.

## Checklist

- [x] `./mvnw test` passes locally (ran `RdsQueryHandlerTest`, `RdsServiceTest`, `RdsCfnProvisionerTest`, `CloudFormationRdsIntegrationTest`, `DbClusterPersistenceTest`, `RdsParameterGroupTagIntegrationTest`, and the new test, all green)
- [x] New or updated integration test added (`RdsClusterEngineModeStorageEncryptedIntegrationTest`, plus two existing `RdsQueryHandlerTest` cases updated for the new method signature)
- [x] Commit messages follow Conventional Commits