### PR TITLE
fix(s3): authorize read on copyobject/uploadpartcopy source

### DIFF
--- a/src/main/java/io/github/hectorvent/floci/core/common/IamEnforcementFilter.java
+++ b/src/main/java/io/github/hectorvent/floci/core/common/IamEnforcementFilter.java
@@ -218,6 +218,76 @@ public class IamEnforcementFilter implements ContainerRequestFilter {
     }
 
     /**
+     * Authorizes a single (action, resource) pair for the caller identified by an
+     * Authorization header, following the same identity resolution and bypass rules
+     * as {@link #filter}. Callers use this for a secondary resource that never appears
+     * in the request URL and so is invisible to {@link ResourceArnBuilder} - such as
+     * the CopyObject/UploadPartCopy source object, which arrives only in the
+     * {@code x-amz-copy-source} header.
+     *
+     * <p>Returns normally when the action is allowed, or when enforcement does not
+     * apply to this request (enforcement disabled, no Authorization header, root or
+     * unknown access key). Throws {@link AwsException} with the same AccessDenied
+     * shape as {@link #filter} when the caller's policies deny the action.
+     */
+    public void authorizeAdditionalResource(String authorizationHeader, String action, String resource) {
+        if (!config.services().iam().enforcementEnabled()) {
+            return;
+        }
+        if (authorizationHeader == null) {
+            return;
+        }
+        String akid = accountResolver.extractAccessKeyId(authorizationHeader);
+        if (akid == null || "test".equals(akid)) {
+            return;
+        }
+        if (extractCredentialScope(authorizationHeader) == null) {
+            return;
+        }
+
+        String accountId = requestContext.getAccountId() == null
+                ? accountResolver.resolve(authorizationHeader)
+                : requestContext.getAccountId();
+
+        List<List<String>> scpLevels = scpProvider.isResolvable()
+                ? scpProvider.get().effectiveScpLevels(accountId) : null;
+
+        boolean accountRootPrincipal = false;
+        CallerContext caller = iamService.resolveCallerContext(akid);
+        if (caller == null) {
+            if (scpLevels == null || !akid.equals(accountId)) {
+                return;
+            }
+            caller = CallerContext.of(List.of(ROOT_ALLOW_ALL));
+            accountRootPrincipal = true;
+        }
+        if (scpLevels != null) {
+            caller = caller.withScpLevels(scpLevels);
+        }
+
+        Map<String, List<String>> conditionContext = null;
+        Optional<String> principalArn = accountRootPrincipal
+                ? Optional.of("arn:aws:iam::" + accountId + ":root")
+                : iamService.resolveCallerArn(akid);
+        if (principalArn.isPresent()) {
+            conditionContext = new HashMap<>();
+            conditionContext.put("aws:PrincipalArn", List.of(principalArn.get()));
+        }
+
+        Decision decision = evaluator.evaluate(caller, null, action, resource, conditionContext);
+        if (decision != Decision.DENY) {
+            return;
+        }
+        LOG.infov("IAM enforcement DENY: akid={0} action={1} resource={2}", akid, action, resource);
+        throw new AwsException("AccessDenied",
+                "User: arn:aws:iam::" + accountId + ":user/" + akid
+                        + " is not authorized to perform: " + action
+                        + " on resource: \"" + resource + "\""
+                        + " because no identity-based policy allows the " + action + " action",
+                403);
+    }
+
+    /**
      * Best-effort CloudTrail emission for S3 access denials. Without this hook,
      * denied requests get aborted before {@code S3Controller}'s try/catch sees
      * them, so denials would never appear in CloudTrail logs — leaving a major

--- a/src/main/java/io/github/hectorvent/floci/services/s3/S3Controller.java
+++ b/src/main/java/io/github/hectorvent/floci/services/s3/S3Controller.java
@@ -6,6 +6,7 @@ import io.github.hectorvent.floci.core.common.AccountResolver;
 import io.github.hectorvent.floci.core.common.AwsArnUtils;
 import io.github.hectorvent.floci.core.common.AwsException;
 import io.github.hectorvent.floci.core.common.AwsNamespaces;
+import io.github.hectorvent.floci.core.common.IamEnforcementFilter;
 import io.github.hectorvent.floci.core.common.XmlBuilder;
 import io.github.hectorvent.floci.core.common.XmlParser;
 import io.github.hectorvent.floci.core.common.RegionResolver;
@@ -94,6 +95,7 @@ public class S3Controller {
     private final AccountResolver accountResolver;
     private final RequestContext requestContext;
     private final IamService iamService;
+    private final IamEnforcementFilter iamEnforcementFilter;
 
     @Inject
     public S3Controller(S3Service s3Service, S3SelectService s3SelectService,
@@ -104,7 +106,8 @@ public class S3Controller {
                         CloudTrailService cloudTrailService,
                         AccountResolver accountResolver,
                         RequestContext requestContext,
-                        IamService iamService) {
+                        IamService iamService,
+                        IamEnforcementFilter iamEnforcementFilter) {
         this.s3Service = s3Service;
         this.s3SelectService = s3SelectService;
         this.regionResolver = regionResolver;
@@ -115,6 +118,7 @@ public class S3Controller {
         this.accountResolver = accountResolver;
         this.requestContext = requestContext;
         this.iamService = iamService;
+        this.iamEnforcementFilter = iamEnforcementFilter;
     }
 
     private void emitCloudTrailEvent(String eventName, String bucket, String key,
@@ -2556,6 +2560,7 @@ public class S3Controller {
                                       String contentType, HttpHeaders httpHeaders) {
         CopySourceRef sourceObject = parseCopySource(copySource);
         String sourceBucket = sourceObject.bucket();
+        authorizeCopySourceRead(httpHeaders, sourceBucket, sourceObject.objectKey());
         String copyContentEncoding = toPersistedContentEncoding(httpHeaders.getHeaderString("Content-Encoding"));
         String copyContentDisposition = httpHeaders.getHeaderString("Content-Disposition");
         String copyCacheControl = httpHeaders.getHeaderString("Cache-Control");
@@ -2635,6 +2640,7 @@ public class S3Controller {
                                            String uploadId, int partNumber, HttpHeaders httpHeaders) {
         CopySourceRef sourceObject = parseCopySource(copySource);
         String sourceBucket = sourceObject.bucket();
+        authorizeCopySourceRead(httpHeaders, sourceBucket, sourceObject.objectKey());
         String copySourceRange = httpHeaders.getHeaderString("x-amz-copy-source-range");
         String eTag = s3Service.uploadPartCopy(destBucket, destKey, uploadId, partNumber,
                 sourceBucket, sourceObject.objectKey(), sourceObject.versionId(), copySourceRange,
@@ -3697,6 +3703,19 @@ public class S3Controller {
         }
         s3Service.putBucketWebsite(bucket, new WebsiteConfiguration(indexDoc, errorDoc));
         return Response.ok().build();
+    }
+
+    /**
+     * Authorizes {@code s3:GetObject} on the CopyObject/UploadPartCopy source, which only ever appears
+     * in the {@code x-amz-copy-source} header and is otherwise invisible to the request-level IAM filter
+     * that authorizes the destination from the URL path. Real S3 requires both permissions: a caller
+     * allowed to write to the destination bucket must not be able to exfiltrate an object it cannot read.
+     * A no-op when IAM enforcement is disabled, matching {@link IamEnforcementFilter}'s own bypass rules.
+     */
+    private void authorizeCopySourceRead(HttpHeaders httpHeaders, String sourceBucket, String sourceKey) {
+        String resource = S3PublicAccessEvaluator.objectArn(sourceBucket, sourceKey);
+        iamEnforcementFilter.authorizeAdditionalResource(
+                httpHeaders.getHeaderString("Authorization"), "s3:GetObject", resource);
     }
 
     /**

--- a/src/test/java/io/github/hectorvent/floci/services/s3/S3CopyObjectSourcePermissionIntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/s3/S3CopyObjectSourcePermissionIntegrationTest.java
@@ -1,0 +1,192 @@
+package io.github.hectorvent.floci.services.s3;
+
+import io.quarkus.test.junit.QuarkusTest;
+import io.quarkus.test.junit.QuarkusTestProfile;
+import io.quarkus.test.junit.TestProfile;
+import org.junit.jupiter.api.Test;
+
+import java.util.Map;
+import java.util.UUID;
+
+import static io.restassured.RestAssured.given;
+import static org.hamcrest.Matchers.containsString;
+
+/**
+ * Regression tests for issue #2333: CopyObject and UploadPartCopy only authorized
+ * {@code s3:PutObject} on the destination and never checked {@code s3:GetObject} on
+ * the copy source, which only ever appears in the {@code x-amz-copy-source} header.
+ * A caller with write-only access to a bucket could therefore copy the contents of
+ * any object it could not otherwise read, as long as it could guess the bucket/key.
+ */
+@QuarkusTest
+@TestProfile(S3CopyObjectSourcePermissionIntegrationTest.IamEnforcementProfile.class)
+class S3CopyObjectSourcePermissionIntegrationTest {
+
+    private static final String REGION = "us-east-1";
+
+    @Test
+    void copyObjectIsDeniedWhenCallerCannotReadTheSource() {
+        String suffix = UUID.randomUUID().toString().substring(0, 8);
+        String sourceBucket = "copy-source-" + suffix;
+        String destBucket = "copy-dest-" + suffix;
+        String userName = "copy-write-only-" + suffix;
+
+        createBucketAsRoot(sourceBucket);
+        createBucketAsRoot(destBucket);
+        putObjectAsRoot(sourceBucket, "private-secret.txt", "top secret payload");
+
+        String accessKeyId = createUser(userName);
+        putUserPolicy(userName, "DestWriteOnly", """
+                {"Version":"2012-10-17","Statement":[
+                  {"Effect":"Allow","Action":"s3:PutObject","Resource":"arn:aws:s3:::%1$s/*"}
+                ]}""".formatted(destBucket));
+
+        given()
+                .header("Authorization", auth(accessKeyId, "s3"))
+                .header("x-amz-copy-source", "/" + sourceBucket + "/private-secret.txt")
+        .when()
+                .put("/" + destBucket + "/exfiltrated.txt")
+        .then()
+                .statusCode(403)
+                .body(containsString("<Code>AccessDenied</Code>"));
+    }
+
+    @Test
+    void copyObjectSucceedsWhenCallerCanReadSourceAndWriteDestination() {
+        String suffix = UUID.randomUUID().toString().substring(0, 8);
+        String sourceBucket = "copy-source-ok-" + suffix;
+        String destBucket = "copy-dest-ok-" + suffix;
+        String userName = "copy-read-write-" + suffix;
+
+        createBucketAsRoot(sourceBucket);
+        createBucketAsRoot(destBucket);
+        putObjectAsRoot(sourceBucket, "allowed.txt", "not secret");
+
+        String accessKeyId = createUser(userName);
+        putUserPolicy(userName, "SourceReadDestWrite", """
+                {"Version":"2012-10-17","Statement":[
+                  {"Effect":"Allow","Action":"s3:GetObject","Resource":"arn:aws:s3:::%1$s/*"},
+                  {"Effect":"Allow","Action":"s3:PutObject","Resource":"arn:aws:s3:::%2$s/*"}
+                ]}""".formatted(sourceBucket, destBucket));
+
+        given()
+                .header("Authorization", auth(accessKeyId, "s3"))
+                .header("x-amz-copy-source", "/" + sourceBucket + "/allowed.txt")
+        .when()
+                .put("/" + destBucket + "/copied.txt")
+        .then()
+                .statusCode(200);
+    }
+
+    @Test
+    void uploadPartCopyIsDeniedWhenCallerCannotReadTheSource() {
+        String suffix = UUID.randomUUID().toString().substring(0, 8);
+        String sourceBucket = "part-copy-source-" + suffix;
+        String destBucket = "part-copy-dest-" + suffix;
+        String userName = "part-copy-write-only-" + suffix;
+
+        createBucketAsRoot(sourceBucket);
+        createBucketAsRoot(destBucket);
+        putObjectAsRoot(sourceBucket, "private-secret.txt", "top secret payload");
+
+        String accessKeyId = createUser(userName);
+        putUserPolicy(userName, "DestWriteOnly", """
+                {"Version":"2012-10-17","Statement":[
+                  {"Effect":"Allow","Action":"s3:PutObject","Resource":"arn:aws:s3:::%1$s/*"}
+                ]}""".formatted(destBucket));
+
+        String uploadId = initiateMultipartUploadAsRoot(destBucket, "exfiltrated.txt");
+
+        given()
+                .header("Authorization", auth(accessKeyId, "s3"))
+                .header("x-amz-copy-source", "/" + sourceBucket + "/private-secret.txt")
+                .queryParam("uploadId", uploadId)
+                .queryParam("partNumber", 1)
+        .when()
+                .put("/" + destBucket + "/exfiltrated.txt")
+        .then()
+                .statusCode(403)
+                .body(containsString("<Code>AccessDenied</Code>"));
+    }
+
+    private static void createBucketAsRoot(String bucket) {
+        given()
+                .header("Authorization", auth("test", "s3"))
+        .when()
+                .put("/" + bucket)
+        .then()
+                .statusCode(200);
+    }
+
+    private static void putObjectAsRoot(String bucket, String key, String body) {
+        given()
+                .header("Authorization", auth("test", "s3"))
+                .contentType("text/plain")
+                .body(body)
+        .when()
+                .put("/" + bucket + "/" + key)
+        .then()
+                .statusCode(200);
+    }
+
+    private static String initiateMultipartUploadAsRoot(String bucket, String key) {
+        return given()
+                .header("Authorization", auth("test", "s3"))
+                .queryParam("uploads", "")
+        .when()
+                .post("/" + bucket + "/" + key)
+        .then()
+                .statusCode(200)
+                .extract()
+                .body()
+                .xmlPath()
+                .getString("InitiateMultipartUploadResult.UploadId");
+    }
+
+    private static String createUser(String userName) {
+        given()
+                .formParam("Action", "CreateUser")
+                .formParam("UserName", userName)
+                .header("Authorization", auth("test", "iam"))
+        .when()
+                .post("/")
+        .then()
+                .statusCode(200);
+
+        return given()
+                .formParam("Action", "CreateAccessKey")
+                .formParam("UserName", userName)
+                .header("Authorization", auth("test", "iam"))
+        .when()
+                .post("/")
+        .then()
+                .statusCode(200)
+                .extract()
+                .path("CreateAccessKeyResponse.CreateAccessKeyResult.AccessKey.AccessKeyId");
+    }
+
+    private static void putUserPolicy(String userName, String policyName, String policyDocument) {
+        given()
+                .formParam("Action", "PutUserPolicy")
+                .formParam("UserName", userName)
+                .formParam("PolicyName", policyName)
+                .formParam("PolicyDocument", policyDocument)
+                .header("Authorization", auth("test", "iam"))
+        .when()
+                .post("/")
+        .then()
+                .statusCode(200);
+    }
+
+    private static String auth(String accessKeyId, String service) {
+        return "AWS4-HMAC-SHA256 Credential=" + accessKeyId + "/20260629/" + REGION + "/" + service
+                + "/aws4_request, SignedHeaders=host, Signature=abc";
+    }
+
+    public static final class IamEnforcementProfile implements QuarkusTestProfile {
+        @Override
+        public Map<String, String> getConfigOverrides() {
+            return Map.of("floci.services.iam.enforcement-enabled", "true");
+        }
+    }
+}


### PR DESCRIPTION
## Summary

CopyObject and UploadPartCopy only authorized `s3:PutObject` on the destination object. The copy source, which arrives solely in the `x-amz-copy-source` header, never went through any authorization check, so a caller with write-only access to any bucket could copy the contents of an object it could not read, as long as it could guess the source bucket and key.

This adds an `s3:GetObject` authorization check against the copy source before CopyObject/UploadPartCopy proceed, reusing the same IAM enforcement engine (`IamEnforcementFilter`) and the same caller identity already used for the destination check. Enforcement only applies when `floci.services.iam.enforcement-enabled` is `true`; the default (disabled) behavior is unchanged.

Closes #2333

## Type of change

- [x] Bug fix (`fix:`)
- [ ] New feature (`feat:`)
- [ ] Breaking change (`feat!:` or `fix!:`)
- [ ] Docs / chore

## AWS Compatibility

Per the AWS CopyObject API reference (Permissions section), a caller needs `s3:GetObject` on the source object and `s3:PutObject` on the destination object. floci only enforced the destination permission. The fix adds the missing source check and returns the same 403 AccessDenied shape (`<Error><Code>AccessDenied</Code>...`) already used by every other enforce-auth rejection in this codebase.

## Checklist

- [x] `./mvnw test` passes locally
- [x] New or updated integration test added
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)