### PR TITLE
docs: standardize Java code style rules

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -23,6 +23,16 @@ Raise concerns when a PR introduces any of the following without strong justific
 - Broad refactors unrelated to the PR goal
 - New service patterns where an existing Floci pattern should be reused
 - Direct storage implementation usage instead of `StorageFactory`
+- `var` where an explicit type belongs. Floci reproduces AWS wire contracts, so the
+  concrete type at a call site is usually what a reviewer needs to see. The one
+  exception is a record deconstruction pattern.
+- Fully-qualified class names written inline instead of imported. Flag
+  `new java.util.ArrayList<>()`. Do not flag it when the file has a genuine name
+  collision, such as `apigateway` versus `apigatewayv2` model types, CDI `Instance`
+  versus the EC2 model `Instance`, or a service `Record` versus `java.lang.Record`.
+- Wildcard imports in `src/main`. Static wildcards in tests are fine.
+- An empty `catch` block. A tolerated exception is logged, or named `ignored` or
+  `expected` with a comment saying why swallowing is safe.
 
 ## Architecture Expectations
 
@@ -122,6 +132,9 @@ When analyzing a PR, check:
 - Are storage changes wired through `StorageFactory`?
 - Are tests added or updated where compatibility is affected?
 - Are docs updated when user-facing behavior changes?
+- Does new code follow the AGENTS.md Code Style rules: explicit types over `var`,
+  imported classes over inline fully-qualified names, no wildcard imports in
+  `src/main`, braces in conditionals, constructor injection?
 
 ## How to Write Feedback
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -323,13 +323,77 @@ References: `SqsCfnProvisioner` (smallest), `Ec2LaunchTemplateCfnProvisioner`
 
 ## Code Style
 
+### General
+
 - Use constructor injection
 - Prefer self-explanatory code over comments
 - Avoid unnecessary comments
 - Always use braces in conditionals
 - Never leave a `catch` block empty. If an exception is intentionally tolerated, log it with enough context to diagnose it later.
+  When swallowing really is correct and logging would be noise, name the variable
+  `ignored` or `expected` and say in a comment why it is safe. A bare
+  `catch (Exception e) {}` is never acceptable.
 - Follow existing project patterns
 - Use modern Java features only when they improve clarity
+
+### Types and names
+
+- **Do not use `var`. Write the explicit type.** Floci reproduces AWS wire
+  contracts, so the concrete type at a call site is usually the thing under
+  review: whether a value is a `LinkedHashMap` or a `Map`, an AWS model type or a
+  JDK one, is exactly what a reviewer needs to see. This covers local
+  declarations, enhanced-for (`for (Tag tag : tags)`), classic for-init, and
+  try-with-resources. The one exception is a record deconstruction pattern
+  (`case Node(var left, var right) ->`), where naming the component types is pure
+  noise.
+- **Import the classes you use. Do not write fully-qualified names inline.**
+  `new ArrayList<>()`, never `new java.util.ArrayList<>()`. The only reason to
+  qualify inline is a genuine name collision inside one file: import the type used
+  more often, qualify the other, and leave a short comment naming the clash.
+  Real examples in this repo are `apigateway` versus `apigatewayv2` model types,
+  CDI `jakarta.enterprise.inject.Instance` versus the EC2 model `Instance`,
+  `jakarta.inject.Provider` versus `jakarta.ws.rs.ext.Provider`, and a service's
+  own `Record` model versus `java.lang.Record`.
+
+### Imports
+
+- No wildcard imports in `src/main`. Static wildcards stay fine in tests, where
+  `Assertions.*`, `Mockito.*` and `Matchers.*` are the established idiom.
+- Import order: non-`java`/`javax` imports alphabetically, then `java.*` and
+  `javax.*` last. This is the IntelliJ default layout and what most of the tree
+  already uses.
+
+### Conventions the codebase already follows
+
+Written down so they stay true. New code should match them without thinking.
+A handful of files predate them; a violation you find in the tree is a straggler,
+not a precedent.
+
+- 4-space indentation, K&R braces. Never indent with a tab.
+- JBoss Logging, in a field named `LOG`, using the parameterized `...v()` form.
+  No string concatenation in log calls.
+- No `System.out` or `System.err`, and no `printStackTrace`. The one exception is a
+  command-line entry point under `tools/`, where stdout is the program's output.
+- `java.time` for everything Floci owns. `Calendar` and `SimpleDateFormat` appear
+  nowhere and must not be introduced. `java.util.Date` survives only where a
+  third-party signature forces it, currently the BouncyCastle certificate builder
+  and the JAX-RS `HttpHeaders.getDate()` override. Convert at that boundary with
+  `Date.from(instant)` and keep `java.time` on Floci's side of it.
+- Constructor injection in `src/main`. Field injection is fine in tests, and
+  `Instance<T>` field injection is a legitimate CDI pattern.
+- `Optional` as a return type only, never as a field or a parameter.
+- Switch expressions over switch statements. Pattern-matching `instanceof` over
+  cast-after-check.
+- `AwsException` for domain errors.
+- `final` on service fields, but not on locals or parameters.
+
+### Tests
+
+- Name test methods either as a camelCase sentence (`putAndGetFromMemory`) or as
+  `method_scenario_expectation`. Both are established here. Never `testX`.
+- JUnit 5 assertions with Hamcrest and RestAssured matchers. Do not introduce
+  AssertJ.
+- `@DisplayName` is deliberately not used. The method name carries the intent.
 
 ---
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -372,16 +372,22 @@ not a precedent.
 - 4-space indentation, K&R braces. Never indent with a tab.
 - JBoss Logging, in a field named `LOG`, using the parameterized `...v()` form.
   No string concatenation in log calls.
-- No `System.out` or `System.err`, and no `printStackTrace`. The one exception is a
-  command-line entry point under `tools/`, where stdout is the program's output.
+- No `printStackTrace`, anywhere. No `System.out` or `System.err` in `src/main`; the
+  one exception is the CLI entry point `io.github.hectorvent.floci.tools.ami.AmiImageTool`,
+  where stdout is the program's output. A few tests print a failure repro just before
+  failing, which is the only good reason to print from a test: an assertion message
+  usually says it better.
 - `java.time` for everything Floci owns. `Calendar` and `SimpleDateFormat` appear
-  nowhere and must not be introduced. `java.util.Date` survives only where a
-  third-party signature forces it, currently the BouncyCastle certificate builder
-  and the JAX-RS `HttpHeaders.getDate()` override. Convert at that boundary with
-  `Date.from(instant)` and keep `java.time` on Floci's side of it.
+  nowhere and must not be introduced. A `Date` survives only at a third-party boundary
+  that forces one: the BouncyCastle certificate builder, the JAX-RS
+  `HttpHeaders.getDate()` override, and JDBC's `java.sql.Date` in the RDS Data mapper.
+  Convert at that boundary with `Date.from(instant)` and keep `java.time` on Floci's
+  side of it.
 - Constructor injection in `src/main`. Field injection is fine in tests, and
   `Instance<T>` field injection is a legitimate CDI pattern.
-- `Optional` as a return type only, never as a field or a parameter.
+- `Optional` as a return type, and never as a field: there are none, keep it that way.
+  It reaches a parameter only where a Quarkus `@ConfigProperty Optional<T>` is threaded
+  through; do not introduce it as a parameter for anything else.
 - Switch expressions over switch statements. Pattern-matching `instanceof` over
   cast-after-check.
 - `AwsException` for domain errors.
@@ -389,11 +395,16 @@ not a precedent.
 
 ### Tests
 
+These describe `src/test`. `compatibility-tests` is a separate module with the opposite
+idiom, AssertJ and `@DisplayName` in nearly every file. Follow the module you are in.
+
 - Name test methods either as a camelCase sentence (`putAndGetFromMemory`) or as
-  `method_scenario_expectation`. Both are established here. Never `testX`.
-- JUnit 5 assertions with Hamcrest and RestAssured matchers. Do not introduce
-  AssertJ.
-- `@DisplayName` is deliberately not used. The method name carries the intent.
+  `method_scenario_expectation`. Both are established. `testX` names are common in
+  older tests and are not the pattern to copy.
+- JUnit 5 assertions with Hamcrest and RestAssured matchers. AssertJ is a declared test
+  dependency, used by the Lambda launcher tests; prefer the established matchers
+  everywhere else.
+- `@DisplayName` is not used here. The method name carries the intent.
 
 ---
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -134,6 +134,28 @@ ln -s AGENTS.md GEMINI.md
 ln -s AGENTS.md COPILOT.md
 ```
 
+## Code Style
+
+[AGENTS.md](AGENTS.md#code-style) carries the full list. The rules worth knowing
+before your first PR:
+
+- **Write explicit types. Do not use `var`.** Floci reproduces AWS wire contracts,
+  so the concrete type at a call site is usually what a reviewer needs to see:
+  whether a value is a `LinkedHashMap` or a `Map`, an AWS model type or a JDK one.
+  The one exception is a record deconstruction pattern.
+- **Import the classes you use. No fully-qualified names inline.**
+  `new ArrayList<>()`, never `new java.util.ArrayList<>()`. Qualify inline only for
+  a genuine name collision in that file, and say in a comment what collides.
+- **No wildcard imports in `src/main`.** Static wildcards are fine in tests.
+- **Never leave a `catch` block empty.** If swallowing is correct, name the
+  variable `ignored` or `expected` and say why in a comment.
+- **Always use braces in conditionals**, and use constructor injection.
+- **Tests**: JUnit 5 with Hamcrest and RestAssured. Name methods as a camelCase
+  sentence or `method_scenario_expectation`, never `testX`.
+
+Existing code does not yet satisfy all of these everywhere. Match the rules in code
+you add or change; leave unrelated cleanups for their own PR.
+
 ## Adding a New AWS Service
 
 1. Create a package under `src/main/java/.../services/<service>/`

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -95,11 +95,32 @@ Quick summary:
 5. Add `*ServiceTest.java` and `*IntegrationTest.java` tests
 6. Add the docs page, its `mkdocs.yml` nav entry, a Service Matrix row and a README row (`make docs-check` gates the matrix)
 
+## Code Style
+
+`AGENTS.md` carries the full list. The ones worth knowing before your first PR:
+
+- **Write explicit types. Do not use `var`.** Floci reproduces AWS wire contracts,
+  so the concrete type at a call site is usually what a reviewer needs to see. The
+  one exception is a record deconstruction pattern.
+- **Import the classes you use. No fully-qualified names inline.** `new ArrayList<>()`,
+  never `new java.util.ArrayList<>()`. Qualify only for a real name collision in that
+  file, and say in a comment what collides.
+- **No wildcard imports in `src/main`.** Static wildcards are fine in tests.
+- **Never leave a `catch` block empty.** If swallowing is correct, name the variable
+  `ignored` or `expected` and say why in a comment.
+- **Always use braces in conditionals**, and use constructor injection.
+- **Tests**: JUnit 5 with Hamcrest and RestAssured. Name methods as a camelCase
+  sentence or `method_scenario_expectation`, never `testX`.
+
+Existing code does not yet satisfy all of these everywhere. Match them in code you
+add or change, and leave unrelated cleanups for their own PR.
+
 ## Pull Request Checklist
 
 - [ ] `mvn test` passes
 - [ ] New or updated integration test added
 - [ ] Commit messages follow Conventional Commits
+- [ ] Code follows the style rules above
 
 Please keep at most **5 open PRs** at a time. A bot leaves an advisory note (label `over-pr-limit`) on PRs opened beyond that. See [CONTRIBUTING.md](https://github.com/floci-io/floci/blob/main/CONTRIBUTING.md#pull-request-guidelines) for details.
 


### PR DESCRIPTION
## Summary

Makes `AGENTS.md` the canonical Code Style source and adds a Code Style section to `CONTRIBUTING.md`, `docs/contributing.md` and `.github/copilot-instructions.md`, none of which had one. Documentation only: no Java file changes, and nothing in CI enforces these.

Two new rules:

- **Write the explicit type, not `var`.** Floci reproduces AWS wire contracts, so the concrete type at a call site is usually the thing under review: whether a value is a `LinkedHashMap` or a `Map`, an AWS model type or a JDK one. The one exception is a record deconstruction pattern, where naming component types is pure noise.
- **Import the classes you use, do not write fully-qualified names inline.** The only reason to qualify inline is a genuine same-file collision, and the four real ones in this tree are named so a reviewer can tell them from carelessness.

The rest is existing practice written down so it stays true, regrouped into General, Types and names, Imports, conventions the codebase already follows, and Tests. The empty-catch rule now blesses naming the variable `ignored` or `expected`, which is the convention the code already uses.

## Second commit: corrections from review

@pgermosen caught that the `System.out` claim does not hold. Re-measuring the rest of the section the same way turned up five more, so the second commit corrects all six. Counts are against `src/main/java` and `src/test/java`, with `compatibility-tests` counted separately since it is a different module.

| Claim as first written | Verdict | What the tree actually contains |
|---|---|---|
| `System.out`/`System.err` only in a `tools/` CLI | wrong | 4 test files print too. The CLI is also the Java *package* `...tools.ami`, not a `tools/` directory, which holds only `tools/docs` |
| `Date` forced in 2 places | wrong | 3 boundaries: BouncyCastle, JAX-RS `HttpHeaders.getDate()`, and JDBC's `java.sql.Date`, which the old wording read as prohibiting |
| `Optional` never a field or parameter | half wrong | never a field is exact (zero). As a parameter it is common, where Quarkus threads `@ConfigProperty Optional<T>` |
| "Never `testX`" | wrong | 291 methods across 52 files |
| "Do not introduce AssertJ" | wrong | already a declared `pom.xml` test dependency, used by 6 Lambda launcher tests |
| "`@DisplayName` is deliberately not used" | wrong | rare in `src/test` (13 of 1455) but the norm in `compatibility-tests` (183 of 208), as is AssertJ (197 of 208) |

Rules that survived the re-check unchanged, and are now stated with confidence: no `printStackTrace` in `src/`, every logger field named `LOG` (391 files, no exceptions), no `Calendar`, no `SimpleDateFormat`, no `Optional` field.

The Tests rules now say they describe `src/test` and point a contributor at the module they are in, rather than marking 197 compatibility-test files as non-conforming.

Existing code does not satisfy all of this everywhere. The section says so: a violation found in the tree is a straggler, not a precedent.

## Type of change

- [ ] Bug fix (`fix:`)
- [ ] New feature (`feat:`)
- [ ] Breaking change (`feat!:` or `fix!:`)
- [x] Docs / chore

## AWS Compatibility

No wire behavior changes. No Java file is touched by this PR.

## Checklist

- [x] `./mvnw test` passes locally
- [ ] New or updated integration test added
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)

No test is added because nothing here is executable: the rules are documentation, and no CI check enforces them.
