### PR TITLE
test(cloudformation): record the ACM Certificate Id GetAtt gap

### DIFF
--- a/src/test/resources/cloudformation/getatt-attribute-gaps.tsv
+++ b/src/test/resources/cloudformation/getatt-attribute-gaps.tsv
@@ -1,3 +1,4 @@
+AWS::CertificateManager::Certificate	Id	schema gives no description; Ref returns the ARN and the legacy spec gives the type no attributes
 AWS::CodeBuild::Project	Id	schema gives no description; AWS's Id may differ from the project name Floci uses
 AWS::CodePipeline::CustomActionType	Id	schema gives no description; the custom action has no separate id in Floci
 AWS::CodePipeline::Webhook	Id	schema gives no description; Floci keys webhooks by name


### PR DESCRIPTION
## Summary

Adds one row to `src/test/resources/cloudformation/getatt-attribute-gaps.tsv` recording that Floci does not set `Id` on `AWS::CertificateManager::Certificate`.

The registry schema declares `readOnlyProperties: ["/properties/Id"]` for that type, but `AcmCfnProvisioner` sets only `CertificateArn`, and no row recorded the difference. The type is inventory-owned (`AcmCfnProvisioner` in `supported-resource-types.tsv`) rather than `LEGACY_SWITCH`, so `CfnSchemaCoverageTest` audits it and fails naming exactly that attribute.

**CI never saw it.** The check needs the CloudFormation schema corpus, which lives under the gitignored `local/aws`, and `schemasAvailable()` returns early when it is absent. It failed only for contributors holding the corpus, which is why a local run of the gate has been red on this one row since #3114.

Recorded as a gap rather than setting `Id`, following the `CodeBuild::Project` and `CodePipeline` precedent already in the file for the same shape: the schema gives `Id` no description, `Ref` on an ACM certificate returns the ARN, and the legacy spec gives the type no attributes. Any value here would be a guess, and `everyRecordedGapIsStillReal` will flag the row as stale the day someone sets it for a real reason.

## Type of change

- [ ] Bug fix (`fix:`)
- [ ] New feature (`feat:`)
- [ ] Breaking change (`feat!:` or `fix!:`)
- [x] Docs / chore

## AWS Compatibility

No wire behavior changes. This records a known `Fn::GetAtt` gap instead of inventing a value for it, which is what the gaps file exists to distinguish: "not emulated" from "forgotten".

## Checklist

- [x] `./mvnw test` passes locally
- [ ] New or updated integration test added
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)

The test *is* the change. Verified both directions locally, with the schema corpus present:

```
with the row:     BUILD SUCCESS
without the row:  Tests run: 3, Failures: 1
                  AWS::CertificateManager::Certificate	Id
```
