### PR TITLE
fix(mwaa): reject a malformed configured AirflowVersion as ValidationException

### DIFF
--- a/src/main/java/io/github/hectorvent/floci/services/mwaa/MwaaService.java
+++ b/src/main/java/io/github/hectorvent/floci/services/mwaa/MwaaService.java
@@ -36,12 +36,23 @@ import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
+import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 
 @ApplicationScoped
 public class MwaaService implements TagHandler {
 
     private static final Logger LOG = Logger.getLogger(MwaaService.class);
+
+    /**
+     * Shape {@code MwaaEnvironmentManager.pythonTagFor} requires: at least a numeric
+     * {@code major.minor}, an optional {@code .patch}. {@code supported-versions} is
+     * operator-configurable, so a malformed entry (e.g. a stray {@code latest}) must be rejected
+     * here as a clean {@code ValidationException} rather than reaching {@code pythonTagFor} and
+     * surfacing as an internal {@code NumberFormatException} well after Postgres has already been
+     * created for the environment.
+     */
+    private static final Pattern AIRFLOW_VERSION_PATTERN = Pattern.compile("\\d+\\.\\d+(\\.\\d+)?");
 
     private final StorageBackend<String, Environment> storage;
     private final EmulatorConfig config;
@@ -339,7 +350,7 @@ public class MwaaService implements TagHandler {
     private String resolveAirflowVersion(String requested) {
         List<String> supported = config.services().mwaa().supportedVersions();
         String version = requested != null && !requested.isBlank() ? requested : config.services().mwaa().defaultVersion();
-        if (!supported.contains(version)) {
+        if (!AIRFLOW_VERSION_PATTERN.matcher(version).matches() || !supported.contains(version)) {
             throw new AwsException("ValidationException",
                     "Unsupported AirflowVersion '" + version + "'. Supported versions: " + supported, 400);
         }

--- a/src/test/java/io/github/hectorvent/floci/services/mwaa/MwaaServiceTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/mwaa/MwaaServiceTest.java
@@ -180,10 +180,14 @@ class MwaaServiceTest {
     }
 
     private EmulatorConfig testConfig() {
+        return testConfig(List.of("2.10.5", "2.9.3", "2.8.4"));
+    }
+
+    private EmulatorConfig testConfig(List<String> supportedVersions) {
         EmulatorConfig.MwaaServiceConfig mwaaConfig = proxy(EmulatorConfig.MwaaServiceConfig.class,
                 (proxy, method, args) -> switch (method.getName()) {
                     case "enabled", "mock" -> true;
-                    case "supportedVersions" -> List.of("2.10.5", "2.9.3", "2.8.4");
+                    case "supportedVersions" -> supportedVersions;
                     case "defaultVersion" -> "2.10.5";
                     case "proxyBasePort" -> 8700;
                     case "proxyMaxPort" -> 8799;
@@ -290,6 +294,35 @@ class MwaaServiceTest {
 
         AwsException ex = assertThrows(AwsException.class,
                 () -> mwaaService.createEnvironment("bad-version-env", request));
+        assertEquals(400, ex.getHttpStatus());
+        assertEquals("ValidationException", ex.getErrorCode());
+    }
+
+    @Test
+    void createEnvironmentRejectsAMalformedConfiguredVersionInsteadOfCrashing() {
+        // supported-versions is operator-configurable, so a stray non-numeric entry like "latest"
+        // must be rejected as a clean ValidationException here, not reach
+        // MwaaEnvironmentManager.pythonTagFor and surface as an internal NumberFormatException
+        // well after Postgres has already been created for the environment.
+        StorageFactory storageFactory = new StorageFactory(null, null) {
+            @Override
+            public synchronized <V> AccountAwareStorageBackend<V> create(String serviceName, String fileName,
+                    TypeReference<Map<String, V>> typeReference) {
+                return AccountAwareStorageBackend.inMemory("000000000000");
+            }
+        };
+        RegionResolver regionResolver = Mockito.mock(RegionResolver.class);
+        when(regionResolver.getAccountId()).thenReturn("000000000000");
+        when(regionResolver.getRegion()).thenReturn("us-east-1");
+        S3Service s3Service = Mockito.mock(S3Service.class);
+        MwaaService misconfiguredService = new MwaaService(storageFactory, testConfig(List.of("2.10.5", "latest")),
+                regionResolver, null, null, null, s3Service);
+
+        CreateEnvironmentRequest request = createRequest("arn:aws:s3:::my-bucket", "dags");
+        request.setAirflowVersion("latest");
+
+        AwsException ex = assertThrows(AwsException.class,
+                () -> misconfiguredService.createEnvironment("latest-version-env", request));
         assertEquals(400, ex.getHttpStatus());
         assertEquals("ValidationException", ex.getErrorCode());
     }


### PR DESCRIPTION
## Summary

Rejects a malformed configured `AirflowVersion` as a clean `ValidationException` at `CreateEnvironment`, instead of letting it reach `MwaaEnvironmentManager.pythonTagFor` and surface as an internal `NumberFormatException`.

Follow-up from hectorvent's review on #3445, and closes the `github-code-quality[bot]` finding on that same PR ("Missing catch of NumberFormatException").

## Type of change

- [x] Bug fix (`fix:`)
- [ ] New feature (`feat:`)
- [ ] Breaking change (`feat!:` or `fix!:`)
- [ ] Docs / chore

## AWS Compatibility

`pythonTagFor` parses `AirflowVersion` with a bare `Integer.parseInt`. `resolveAirflowVersion` only checked that the requested version was present in the operator-configured `supported-versions` list, it never validated the value's shape. `supported-versions` is itself operator-configurable (`FLOCI_SERVICES_MWAA_SUPPORTED_VERSIONS`), so a misconfigured entry, for example a stray `latest`, would pass the list-membership check and reach `pythonTagFor`, throwing a `NumberFormatException` well after Postgres had already been created for the environment, rather than a clean 400 at `CreateEnvironment` the way a real bad request should look.

Fix: `resolveAirflowVersion` now also validates the version's shape (a numeric `major.minor`, with an optional `.patch`) before checking list membership, so a malformed value is rejected immediately as `ValidationException`, with no containers ever created.

## Checklist

- [x] `./mvnw test` passes locally (ran `MwaaServiceTest`, `MwaaEnvironmentManagerTest`, and `MwaaIntegrationTest`: 44 + 11 tests, 0 failures; the existing `everySupportedAirflowVersionRoundTrips`/`unsupportedAirflowVersionIsRejected` integration tests confirm no regression)
- [ ] New or updated integration test added: added a unit test instead (`MwaaServiceTest#createEnvironmentRejectsAMalformedConfiguredVersionInsteadOfCrashing`, configuring `supportedVersions` with a stray `latest` entry). Exercising this exact scenario at the REST/integration level would need a Quarkus test profile overriding `FLOCI_SERVICES_MWAA_SUPPORTED_VERSIONS` just for one test, since `MwaaIntegrationTest` shares one fixed test `application.yml`; the unit test exercises the identical `resolveAirflowVersion` code path directly.
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
