### PR TITLE
fix(mwaa): also detect a crashed sibling Postgres container, not just Airflow

### DIFF
--- a/docs/services/mwaa.md
+++ b/docs/services/mwaa.md
@@ -36,7 +36,7 @@ Floci starts two containers per environment:
 Legacy environments retain the region recorded in their ARN. A request in another region does not
 adopt that environment; recreate it in the requested region instead.
 
-Once Airflow's unauthenticated `/health` endpoint reports both `metadatabase` and `scheduler` as `"healthy"`, the environment transitions to `AVAILABLE`. If the Airflow container instead exits before that (a startup script or `airflow db migrate` failing partway through), the same poller detects the stopped container and transitions the environment to `CREATE_FAILED` rather than polling a dead container forever.
+Once Airflow's unauthenticated `/health` endpoint reports both `metadatabase` and `scheduler` as `"healthy"`, the environment transitions to `AVAILABLE`. If the Postgres or Airflow container instead exits before that (a startup script or `airflow db migrate` failing partway through, or Postgres itself dying), the same poller detects the stopped container and transitions the environment to `CREATE_FAILED` rather than polling dead containers forever.
 
 ### Web/CLI proxy
 

--- a/src/main/java/io/github/hectorvent/floci/services/mwaa/MwaaEnvironmentManager.java
+++ b/src/main/java/io/github/hectorvent/floci/services/mwaa/MwaaEnvironmentManager.java
@@ -264,15 +264,22 @@ public class MwaaEnvironmentManager {
     }
 
     /**
-     * True when the Airflow container was created but is no longer running, for example because a
-     * startup script or {@code airflow db migrate} failed after {@code docker start} returned.
-     * {@code docker start} only launches the entrypoint and returns immediately, so nothing else
-     * observes a failure like that; {@link MwaaService}'s readiness poller uses this to stop
-     * waiting on a container that will never answer {@code /health}, instead of leaving the
-     * environment at CREATING forever.
+     * True when either container backing this environment, Postgres or Airflow, was created but is
+     * no longer running: for example a startup script or {@code airflow db migrate} failing
+     * partway through kills the Airflow container, or the Postgres container itself dies (out of
+     * memory, its volume filling up), which never surfaces as an Airflow-side failure since the
+     * Airflow process itself keeps running, just never reporting {@code metadatabase} healthy.
+     * {@code docker start} only launches a container's entrypoint and returns immediately, so
+     * nothing else observes either of those; {@link MwaaService}'s readiness poller uses this to
+     * stop waiting on containers that will never let the environment answer {@code /health},
+     * instead of leaving the environment at CREATING forever.
      */
-    public boolean hasAirflowContainerExited(Environment environment) {
-        String containerId = environment.getAirflowContainerId();
+    public boolean hasAnyContainerExited(Environment environment) {
+        return hasContainerExited(environment.getDbContainerId(), "Postgres", environment)
+                || hasContainerExited(environment.getAirflowContainerId(), "Airflow", environment);
+    }
+
+    private boolean hasContainerExited(String containerId, String label, Environment environment) {
         if (containerId == null) {
             return false;
         }
@@ -287,8 +294,8 @@ public class MwaaEnvironmentManager {
             // bad inspect doesn't wrongly fail this environment or, since the readiness poller
             // shares one loop across every CREATING environment, escape and starve every other
             // environment's check for this poll tick.
-            LOG.warnv("Could not inspect Airflow container {0} for environment {1}: {2}",
-                    containerId, environment.getName(), e.getMessage());
+            LOG.warnv("Could not inspect {0} container {1} for environment {2}: {3}",
+                    label, containerId, environment.getName(), e.getMessage());
             return false;
         }
     }

--- a/src/main/java/io/github/hectorvent/floci/services/mwaa/MwaaService.java
+++ b/src/main/java/io/github/hectorvent/floci/services/mwaa/MwaaService.java
@@ -447,9 +447,9 @@ public class MwaaService implements TagHandler {
             return;
         }
         boolean ready = environmentManager.isReady(environment);
-        boolean exited = !ready && environmentManager.hasAirflowContainerExited(environment);
+        boolean exited = !ready && environmentManager.hasAnyContainerExited(environment);
 
-        // isReady()/hasAirflowContainerExited() are blocking Docker/HTTP calls, long enough for a
+        // isReady()/hasAnyContainerExited() are blocking Docker/HTTP calls, long enough for a
         // concurrent DeleteEnvironment (which sets DELETING on this same Environment instance
         // before tearing down its containers) to have moved this environment past CREATING in the
         // meantime. Re-checking right before writing avoids resurrecting a just-deleted environment
@@ -462,12 +462,12 @@ public class MwaaService implements TagHandler {
             environment.setStatus(EnvironmentStatus.AVAILABLE);
             putEnvironment(environment);
         } else if (exited) {
-            // docker start returns as soon as the entrypoint launches, so a script or migration
-            // failing partway through never surfaces here on its own; without this check the
-            // environment would poll a dead container and report CREATING forever instead of the
-            // CREATE_FAILED a real failure should be.
-            LOG.errorv("MWAA environment {0}''s Airflow container exited before becoming ready; "
-                    + "marking CREATE_FAILED", environment.getName());
+            // docker start returns as soon as a container's entrypoint launches, so its Postgres or
+            // Airflow container dying partway through never surfaces here on its own; without this
+            // check the environment would poll dead containers and report CREATING forever instead
+            // of the CREATE_FAILED a real failure should be.
+            LOG.errorv("MWAA environment {0}''s Postgres or Airflow container exited before "
+                    + "becoming ready; marking CREATE_FAILED", environment.getName());
             environment.setStatus(EnvironmentStatus.CREATE_FAILED);
             putEnvironment(environment);
         }

--- a/src/test/java/io/github/hectorvent/floci/services/mwaa/MwaaEnvironmentManagerTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/mwaa/MwaaEnvironmentManagerTest.java
@@ -365,8 +365,8 @@ class MwaaEnvironmentManagerTest {
         }
     }
 
-    /** Crash detection the readiness poller relies on to stop waiting on a dead container,
-     *  verified against a mocked DockerClient (mirrors BatchDockerRunnerTest's deep-stub style). */
+    /** Crash detection the readiness poller relies on to stop waiting on dead containers, verified
+     *  against a mocked DockerClient (mirrors BatchDockerRunnerTest's deep-stub style). */
     @Nested
     class ContainerExitDetection {
 
@@ -378,40 +378,60 @@ class MwaaEnvironmentManagerTest {
             when(lifecycleManager.getDockerClient()).thenReturn(dockerClient);
         }
 
-        private Environment environmentWithContainerId(String containerId) {
+        private Environment environmentWithContainers(String dbContainerId, String airflowContainerId) {
             Environment environment = new Environment();
             environment.setName("my-env");
-            environment.setAirflowContainerId(containerId);
+            environment.setDbContainerId(dbContainerId);
+            environment.setAirflowContainerId(airflowContainerId);
             return environment;
         }
 
         @Test
-        void reportsNotExitedWhileTheContainerIsStillRunning() {
+        void reportsNotExitedWhileBothContainersAreStillRunning() {
+            when(dockerClient.inspectContainerCmd("db-container-id").exec().getState().getRunning())
+                    .thenReturn(true);
             when(dockerClient.inspectContainerCmd("airflow-container-id").exec().getState().getRunning())
                     .thenReturn(true);
 
-            assertFalse(manager.hasAirflowContainerExited(environmentWithContainerId("airflow-container-id")));
+            assertFalse(manager.hasAnyContainerExited(environmentWithContainers("db-container-id", "airflow-container-id")));
         }
 
         @Test
-        void reportsExitedOnceTheContainerHasStopped() {
+        void reportsExitedOnceTheAirflowContainerHasStopped() {
+            when(dockerClient.inspectContainerCmd("db-container-id").exec().getState().getRunning())
+                    .thenReturn(true);
             when(dockerClient.inspectContainerCmd("airflow-container-id").exec().getState().getRunning())
                     .thenReturn(false);
 
-            assertTrue(manager.hasAirflowContainerExited(environmentWithContainerId("airflow-container-id")));
+            assertTrue(manager.hasAnyContainerExited(environmentWithContainers("db-container-id", "airflow-container-id")));
         }
 
         @Test
-        void reportsExitedWhenTheContainerHasBeenRemoved() {
+        void reportsExitedOnceTheSiblingPostgresContainerHasStopped() {
+            // Airflow itself keeps running when Postgres dies underneath it, it just never reports
+            // metadatabase healthy, so this must be detected independently of the Airflow
+            // container's own running state.
+            when(dockerClient.inspectContainerCmd("db-container-id").exec().getState().getRunning())
+                    .thenReturn(false);
+            when(dockerClient.inspectContainerCmd("airflow-container-id").exec().getState().getRunning())
+                    .thenReturn(true);
+
+            assertTrue(manager.hasAnyContainerExited(environmentWithContainers("db-container-id", "airflow-container-id")));
+        }
+
+        @Test
+        void reportsExitedWhenEitherContainerHasBeenRemoved() {
+            when(dockerClient.inspectContainerCmd("db-container-id").exec().getState().getRunning())
+                    .thenReturn(true);
             when(dockerClient.inspectContainerCmd("airflow-container-id").exec())
                     .thenThrow(new NotFoundException("no such container"));
 
-            assertTrue(manager.hasAirflowContainerExited(environmentWithContainerId("airflow-container-id")));
+            assertTrue(manager.hasAnyContainerExited(environmentWithContainers("db-container-id", "airflow-container-id")));
         }
 
         @Test
-        void reportsNotExitedWhenNoContainerHasBeenCreatedYet() {
-            assertFalse(manager.hasAirflowContainerExited(new Environment()));
+        void reportsNotExitedWhenNeitherContainerHasBeenCreatedYet() {
+            assertFalse(manager.hasAnyContainerExited(new Environment()));
         }
 
         @Test
@@ -420,10 +440,12 @@ class MwaaEnvironmentManagerTest {
             // must not propagate, since the readiness poller shares one loop across every CREATING
             // environment and a thrown exception here would starve every other environment's check
             // for this poll tick, not just this one's.
+            when(dockerClient.inspectContainerCmd("db-container-id").exec().getState().getRunning())
+                    .thenReturn(true);
             when(dockerClient.inspectContainerCmd("airflow-container-id").exec())
                     .thenThrow(new RuntimeException("docker daemon connection reset"));
 
-            assertFalse(manager.hasAirflowContainerExited(environmentWithContainerId("airflow-container-id")));
+            assertFalse(manager.hasAnyContainerExited(environmentWithContainers("db-container-id", "airflow-container-id")));
         }
     }
 }

--- a/src/test/java/io/github/hectorvent/floci/services/mwaa/MwaaServiceTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/mwaa/MwaaServiceTest.java
@@ -557,7 +557,7 @@ class MwaaServiceTest {
             Environment environment = realModeService.createEnvironment("starting-env",
                     createRequest("arn:aws:s3:::my-bucket", "dags"));
             when(environmentManager.isReady(environment)).thenReturn(false);
-            when(environmentManager.hasAirflowContainerExited(environment)).thenReturn(false);
+            when(environmentManager.hasAnyContainerExited(environment)).thenReturn(false);
 
             realModeService.checkReadiness(environment);
 
@@ -565,14 +565,14 @@ class MwaaServiceTest {
         }
 
         @Test
-        void checkReadinessMarksCreateFailedWhenTheAirflowContainerHasExited() {
-            // e.g. a startup script or `airflow db migrate` failed after docker start returned;
-            // without this, the environment would poll a dead container forever and never leave
-            // CREATING.
+        void checkReadinessMarksCreateFailedWhenAContainerHasExited() {
+            // e.g. a startup script or `airflow db migrate` failed after docker start returned, or
+            // the sibling Postgres container died; without this, the environment would poll dead
+            // containers forever and never leave CREATING.
             Environment environment = realModeService.createEnvironment("crashed-env",
                     createRequest("arn:aws:s3:::my-bucket", "dags"));
             when(environmentManager.isReady(environment)).thenReturn(false);
-            when(environmentManager.hasAirflowContainerExited(environment)).thenReturn(true);
+            when(environmentManager.hasAnyContainerExited(environment)).thenReturn(true);
 
             realModeService.checkReadiness(environment);
 
@@ -589,7 +589,7 @@ class MwaaServiceTest {
 
             assertEquals(EnvironmentStatus.AVAILABLE, environment.getStatus());
             verify(environmentManager, Mockito.never()).isReady(any());
-            verify(environmentManager, Mockito.never()).hasAirflowContainerExited(any());
+            verify(environmentManager, Mockito.never()).hasAnyContainerExited(any());
         }
 
         @Test
@@ -610,12 +610,12 @@ class MwaaServiceTest {
 
         @Test
         void checkReadinessDoesNotOverwriteAStatusChangedConcurrentlyWhileWaitingOnContainerExitCheck() {
-            // Same race, on the hasAirflowContainerExited() branch: without the re-check, this would
+            // Same race, on the hasAnyContainerExited() branch: without the re-check, this would
             // resurrect a just-deleted environment into storage as CREATE_FAILED.
             Environment environment = realModeService.createEnvironment("deleted-mid-crash-check-env",
                     createRequest("arn:aws:s3:::my-bucket", "dags"));
             when(environmentManager.isReady(environment)).thenReturn(false);
-            when(environmentManager.hasAirflowContainerExited(environment)).thenAnswer(invocation -> {
+            when(environmentManager.hasAnyContainerExited(environment)).thenAnswer(invocation -> {
                 environment.setStatus(EnvironmentStatus.DELETING);
                 return true;
             });


### PR DESCRIPTION
## Summary

Generalizes the crash detection added in #3446 to also cover the sibling Postgres container, not just the Airflow one.

Follow-up from hectorvent's review on #3446.

## Type of change

- [x] Bug fix (`fix:`)
- [ ] New feature (`feat:`)
- [ ] Breaking change (`feat!:` or `fix!:`)
- [ ] Docs / chore

## AWS Compatibility

`hasAirflowContainerExited` (from #3446) only inspected the Airflow container's Docker state. If the sibling Postgres container dies instead (out of memory, its volume filling up), Airflow itself keeps running fine, it just never reports `metadatabase` healthy, so the environment sat at `CREATING` forever exactly as before #3446, just for a different underlying cause.

Fix: generalized into `hasAnyContainerExited`, backed by a shared private `hasContainerExited(containerId, label, environment)` helper, checking both `Environment.getDbContainerId()` and `getAirflowContainerId()` (either one exited counts). `checkReadiness` and its log messages were updated to match. Behavior for a lone Airflow-container failure is unchanged; the concurrency guard added in #3446 (re-checking status immediately before writing, so a concurrent `DeleteEnvironment` can't be resurrected) is untouched and still applies to both containers.

## Checklist

- [x] `./mvnw test` passes locally (ran `MwaaEnvironmentManagerTest`, `MwaaServiceTest`, and `MwaaIntegrationTest`: 66 tests, 0 failures)
- [ ] New or updated integration test added: extended the existing unit-test coverage instead, same as #3446 itself. `MwaaEnvironmentManagerTest`'s `ContainerExitDetection` (mocked `DockerClient`) now covers the Postgres-only-exited case independently of the Airflow container's own running state, plus removal/inconclusive-Docker-error cases for both containers. `MwaaIntegrationTest` still can't exercise this, it runs entirely against `floci.services.mwaa.mock=true` and never touches Docker.
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
