### PR TITLE
fix(sfn): preserve Lambda function errors

### DIFF
--- a/src/main/java/io/github/hectorvent/floci/services/stepfunctions/AslExecutor.java
+++ b/src/main/java/io/github/hectorvent/floci/services/stepfunctions/AslExecutor.java
@@ -72,6 +72,7 @@ import jakarta.ws.rs.core.MultivaluedHashMap;
 import jakarta.ws.rs.core.MultivaluedMap;
 import org.jboss.logging.Logger;
 
+import java.io.IOException;
 import java.math.BigInteger;
 import java.net.URI;
 import java.nio.charset.StandardCharsets;
@@ -929,6 +930,31 @@ public class AslExecutor {
         CustomResourceLiveness.tokenIn(payload).ifPresent(customResourceLiveness::touch);
     }
 
+    private FailStateException lambdaFunctionFailure(String functionName, InvokeResult result) {
+        byte[] responsePayload = result.getPayload();
+        String cause = responsePayload == null ? null : new String(responsePayload, StandardCharsets.UTF_8);
+        if (responsePayload == null || responsePayload.length == 0) {
+            LOG.warnf("Lambda function %s returned FunctionError %s without an error payload; using Exception",
+                    functionName, result.getFunctionError());
+            return new FailStateException("Exception", cause);
+        }
+
+        try {
+            JsonNode errorPayload = objectMapper.readTree(responsePayload);
+            JsonNode errorType = errorPayload.path("errorType");
+            if (errorType.isTextual() && !errorType.textValue().isBlank()) {
+                return new FailStateException(errorType.textValue(), cause);
+            }
+            LOG.warnf("Lambda function %s returned FunctionError %s without a non-empty textual errorType; "
+                            + "using Exception",
+                    functionName, result.getFunctionError());
+        } catch (IOException e) {
+            LOG.warnf("Lambda function %s returned an invalid FunctionError payload; using Exception: %s",
+                    functionName, e.getMessage());
+        }
+        return new FailStateException("Exception", cause);
+    }
+
     private JsonNode invokeResource(String resource, JsonNode input, StateMachine sm, String taskToken,
                                     long executionDeadlineNanos, JsonNode rawParameters) throws Exception {
         // Support Lambda resources: direct ARN or optimized integration
@@ -968,7 +994,7 @@ public class AslExecutor {
             InvokeResult result = lambdaExecutor.invoke(fn, payloadBytes, InvocationType.RequestResponse);
 
             if (result.getFunctionError() != null) {
-                throw new FailStateException("Lambda.AWSLambdaException", result.getFunctionError());
+                throw lambdaFunctionFailure(functionName, result);
             }
 
             byte[] responseBytes = result.getPayload();

--- a/src/test/java/io/github/hectorvent/floci/services/stepfunctions/AslExecutorCatchTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/stepfunctions/AslExecutorCatchTest.java
@@ -46,6 +46,8 @@ class AslExecutorCatchTest {
     private static final String CLEANUP_FUNCTION_NAME = "cleanup-lambda";
     private static final String FAILING_FUNCTION_ARN = lambdaArn(FAILING_FUNCTION_NAME);
     private static final String CLEANUP_FUNCTION_ARN = lambdaArn(CLEANUP_FUNCTION_NAME);
+    private static final String ERROR_PAYLOAD =
+            "{\"errorType\":\"ContractFailure\",\"errorMessage\":\"forced failure\"}";
 
     private final ObjectMapper objectMapper = new ObjectMapper();
     private LambdaExecutorService lambdaExecutor;
@@ -152,8 +154,8 @@ class AslExecutorCatchTest {
                 """.formatted(FAILING_FUNCTION_ARN));
 
         assertEquals("FAILED", execution.getStatus());
-        assertEquals("Lambda.AWSLambdaException", execution.getError());
-        assertEquals("Handled", execution.getCause());
+        assertEquals("ContractFailure", execution.getError());
+        assertEquals(ERROR_PAYLOAD, execution.getCause());
         verify(lambdaExecutor).invoke(eq(failingFunction), any(byte[].class), eq(InvocationType.RequestResponse));
         verify(lambdaExecutor, never()).invoke(eq(cleanupFunction), any(byte[].class), eq(InvocationType.RequestResponse));
     }
@@ -178,7 +180,7 @@ class AslExecutorCatchTest {
     }
 
     private byte[] errorPayload() {
-        return "{\"errorType\":\"ContractFailure\",\"errorMessage\":\"forced failure\"}".getBytes(StandardCharsets.UTF_8);
+        return ERROR_PAYLOAD.getBytes(StandardCharsets.UTF_8);
     }
 
     private static LambdaFunction lambdaFunction(String name, String arn) {

--- a/src/test/java/io/github/hectorvent/floci/services/stepfunctions/AslExecutorRetryTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/stepfunctions/AslExecutorRetryTest.java
@@ -102,7 +102,7 @@ class AslExecutorRetryTest {
                       "Resource": "%s",
                       "End": true,
                       "Retry": [{
-                        "ErrorEquals": ["Lambda.AWSLambdaException"],
+                        "ErrorEquals": ["Boom"],
                         "IntervalSeconds": 1,
                         "BackoffRate": 1.0,
                         "MaxAttempts": 2
@@ -133,7 +133,7 @@ class AslExecutorRetryTest {
                       "Resource": "%s",
                       "End": true,
                       "Retry": [{
-                        "ErrorEquals": ["Lambda.AWSLambdaException"],
+                        "ErrorEquals": ["Boom"],
                         "IntervalSeconds": 1,
                         "BackoffRate": 1.0,
                         "MaxAttempts": 1
@@ -144,13 +144,13 @@ class AslExecutorRetryTest {
                 """.formatted(FLAKY_FUNCTION_ARN));
 
         assertEquals("FAILED", execution.getStatus());
-        assertEquals("Lambda.AWSLambdaException", execution.getError());
+        assertEquals("Boom", execution.getError());
         verify(lambdaExecutor, times(2))
                 .invoke(eq(flakyFunction), any(byte[].class), eq(InvocationType.RequestResponse));
     }
 
     @Test
-    void unmatchedErrorIsNotRetried() {
+    void lambdaServiceErrorRetrierDoesNotMatchFunctionError() {
         when(lambdaExecutor.invoke(eq(flakyFunction), any(byte[].class), eq(InvocationType.RequestResponse)))
                 .thenReturn(new InvokeResult(200, "Handled",
                         "{\"errorType\":\"Boom\"}".getBytes(StandardCharsets.UTF_8), null, "req-1"));
@@ -164,7 +164,8 @@ class AslExecutorRetryTest {
                       "Resource": "%s",
                       "End": true,
                       "Retry": [{
-                        "ErrorEquals": ["SomeOther.Error"],
+                        "ErrorEquals": ["Lambda.ClientExecutionTimeoutException", "Lambda.ServiceException",
+                                        "Lambda.AWSLambdaException", "Lambda.SdkClientException"],
                         "IntervalSeconds": 1,
                         "MaxAttempts": 3
                       }]
@@ -174,7 +175,7 @@ class AslExecutorRetryTest {
                 """.formatted(FLAKY_FUNCTION_ARN));
 
         assertEquals("FAILED", execution.getStatus());
-        assertEquals("Lambda.AWSLambdaException", execution.getError());
+        assertEquals("Boom", execution.getError());
         verify(lambdaExecutor, times(1))
                 .invoke(eq(flakyFunction), any(byte[].class), eq(InvocationType.RequestResponse));
     }
@@ -213,7 +214,7 @@ class AslExecutorRetryTest {
                 """.formatted(FLAKY_FUNCTION_ARN));
 
         assertEquals("SUCCEEDED", execution.getStatus());
-        assertEquals("Lambda.AWSLambdaException",
+        assertEquals("Boom",
                 objectMapper.readTree(execution.getOutput()).path("Error").asText());
         verify(lambdaExecutor, times(2))
                 .invoke(eq(flakyFunction), any(byte[].class), eq(InvocationType.RequestResponse));
@@ -234,7 +235,7 @@ class AslExecutorRetryTest {
                         "States": {"Inner": {"Type": "Task", "Resource": "%s", "End": true}}
                       }],
                       "Retry": [{
-                        "ErrorEquals": ["Lambda.AWSLambdaException"],
+                        "ErrorEquals": ["Boom"],
                         "IntervalSeconds": 1,
                         "BackoffRate": 1.0,
                         "MaxAttempts": 1
@@ -279,7 +280,7 @@ class AslExecutorRetryTest {
                 """.formatted(FLAKY_FUNCTION_ARN));
 
         assertEquals("SUCCEEDED", execution.getStatus());
-        assertEquals("Lambda.AWSLambdaException",
+        assertEquals("Boom",
                 objectMapper.readTree(execution.getOutput()).path("Error").asText());
         verify(lambdaExecutor, times(1))
                 .invoke(eq(flakyFunction), any(byte[].class), eq(InvocationType.RequestResponse));
@@ -303,7 +304,7 @@ class AslExecutorRetryTest {
                             "Resource": "%s",
                             "End": true,
                             "Retry": [{
-                              "ErrorEquals": ["Lambda.AWSLambdaException"],
+                              "ErrorEquals": ["Boom"],
                               "IntervalSeconds": 1,
                               "BackoffRate": 1.0,
                               "MaxAttempts": 1
@@ -340,7 +341,7 @@ class AslExecutorRetryTest {
                         "States": {"Inner": {"Type": "Task", "Resource": "%s", "End": true}}
                       },
                       "Retry": [{
-                        "ErrorEquals": ["Lambda.AWSLambdaException"],
+                        "ErrorEquals": ["Boom"],
                         "IntervalSeconds": 1,
                         "BackoffRate": 1.0,
                         "MaxAttempts": 1

--- a/src/test/java/io/github/hectorvent/floci/services/stepfunctions/AslExecutorTaskHistoryEventsTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/stepfunctions/AslExecutorTaskHistoryEventsTest.java
@@ -24,6 +24,7 @@ import jakarta.inject.Inject;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
@@ -258,6 +259,106 @@ class AslExecutorTaskHistoryEventsTest {
         assertNull(started.getDetails());
     }
 
+    @Test
+    void directLambdaFailurePreservesFunctionErrorInHistory() {
+        var functionName = "failing-lambda";
+        var functionArn = lambdaArn(functionName);
+        var errorPayload = "{\"errorType\":\"ValidationError\",\"errorMessage\":\"invalid input\"}";
+        stubLambdaFailure(functionName, functionArn, errorPayload.getBytes(StandardCharsets.UTF_8));
+
+        var history = new ArrayList<HistoryEvent>();
+        var execution = run("""
+                {
+                  "StartAt": "Call",
+                  "States": {
+                    "Call": {
+                      "Type": "Task",
+                      "Resource": "%s",
+                      "End": true
+                    }
+                  }
+                }
+                """.formatted(functionArn), "{}", null, history);
+
+        assertEquals("FAILED", execution.getStatus());
+        assertEquals("ValidationError", execution.getError());
+        assertEquals(errorPayload, execution.getCause());
+        assertEquals(
+                List.of("TaskStateEntered", "LambdaFunctionScheduled", "LambdaFunctionStarted",
+                        "LambdaFunctionFailed", "ExecutionFailed"),
+                typesOf(history));
+        var failed = eventOfType(history, "LambdaFunctionFailed");
+        assertEquals("ValidationError", failed.getDetails().get("error"));
+        assertEquals(errorPayload, failed.getDetails().get("cause"));
+        assertChain(history);
+    }
+
+    @Test
+    void optimizedLambdaFailurePreservesFunctionErrorInHistory() {
+        var functionName = "failing-lambda";
+        var functionArn = lambdaArn(functionName);
+        var errorPayload = "{\"errorType\":\"ValidationError\",\"errorMessage\":\"invalid input\"}";
+        stubLambdaFailure(functionName, functionArn, errorPayload.getBytes(StandardCharsets.UTF_8));
+
+        var history = new ArrayList<HistoryEvent>();
+        var execution = run("""
+                {
+                  "StartAt": "Call",
+                  "States": {
+                    "Call": {
+                      "Type": "Task",
+                      "Resource": "arn:aws:states:::lambda:invoke",
+                      "Parameters": {
+                        "FunctionName": "%s",
+                        "Payload": {"value": 1}
+                      },
+                      "End": true
+                    }
+                  }
+                }
+                """.formatted(functionArn), "{}", null, history);
+
+        assertEquals("FAILED", execution.getStatus());
+        assertEquals("ValidationError", execution.getError());
+        assertEquals(errorPayload, execution.getCause());
+        assertEquals(
+                List.of("TaskStateEntered", "TaskScheduled", "TaskStarted", "TaskFailed", "ExecutionFailed"),
+                typesOf(history));
+        var failed = eventOfType(history, "TaskFailed");
+        assertEquals("lambda", failed.getDetails().get("resourceType"));
+        assertEquals("invoke", failed.getDetails().get("resource"));
+        assertEquals("ValidationError", failed.getDetails().get("error"));
+        assertEquals(errorPayload, failed.getDetails().get("cause"));
+        assertChain(history);
+    }
+
+    @Test
+    void malformedLambdaErrorPayloadFallsBackToException() {
+        var functionName = "failing-lambda";
+        var functionArn = lambdaArn(functionName);
+        var errorPayload = "not-json";
+        stubLambdaFailure(functionName, functionArn, errorPayload.getBytes(StandardCharsets.UTF_8));
+
+        var execution = run(directLambdaDefinition(functionArn), "{}", null, new ArrayList<>());
+
+        assertEquals("FAILED", execution.getStatus());
+        assertEquals("Exception", execution.getError());
+        assertEquals(errorPayload, execution.getCause());
+    }
+
+    @Test
+    void missingLambdaErrorPayloadFallsBackToException() {
+        var functionName = "failing-lambda";
+        var functionArn = lambdaArn(functionName);
+        stubLambdaFailure(functionName, functionArn, null);
+
+        var execution = run(directLambdaDefinition(functionArn), "{}", null, new ArrayList<>());
+
+        assertEquals("FAILED", execution.getStatus());
+        assertEquals("Exception", execution.getError());
+        assertNull(execution.getCause());
+    }
+
     /**
      * A Parallel branch and a Map iteration run states of their own whose events floci does not
      * publish. The published history is still one unbroken chain: the ids of the events around them
@@ -346,6 +447,30 @@ class AslExecutorTaskHistoryEventsTest {
         return new MockedResponseStep(from, to, null, error, cause);
     }
 
+    private void stubLambdaFailure(String functionName, String functionArn, byte[] errorPayload) {
+        var function = new LambdaFunction();
+        function.setFunctionName(functionName);
+        function.setFunctionArn(functionArn);
+        when(functionStore.get(REGION, functionName)).thenReturn(Optional.of(function));
+        when(lambdaExecutor.invoke(eq(function), any(byte[].class), eq(InvocationType.RequestResponse)))
+                .thenReturn(new InvokeResult(200, "Handled", errorPayload, null, "failure-request"));
+    }
+
+    private static String directLambdaDefinition(String functionArn) {
+        return """
+                {
+                  "StartAt": "Call",
+                  "States": {
+                    "Call": {
+                      "Type": "Task",
+                      "Resource": "%s",
+                      "End": true
+                    }
+                  }
+                }
+                """.formatted(functionArn);
+    }
+
     private Execution run(String definition, String input, MockedTestCase mocks, List<HistoryEvent> history) {
         var stateMachine = new StateMachine();
         stateMachine.setName("history-events-test");
@@ -363,5 +488,9 @@ class AslExecutorTaskHistoryEventsTest {
         executor.executeSync(stateMachine, execution, history, mocks, (updated, events) -> {
         });
         return execution;
+    }
+
+    private static String lambdaArn(String name) {
+        return "arn:aws:lambda:%s:%s:function:%s".formatted(REGION, ACCOUNT, name);
     }
 }


### PR DESCRIPTION
## Summary

- report the Lambda payload `errorType` as the Step Functions task error
- preserve the original UTF-8 function error payload as `Cause` for direct and optimized Lambda integrations
- fall back to `Exception` with diagnostic logging when an error payload is missing or invalid

Closes #3411

## Type of change

- [x] Bug fix (`fix:`)
- [ ] New feature (`feat:`)
- [ ] Breaking change (`feat!:` or `fix!:`)
- [ ] Docs / chore

## AWS Compatibility

Previously, Lambda function errors were reported as `Lambda.AWSLambdaException` with `Handled` as the cause. This incorrectly matched AWS's recommended retry policy for transient Lambda service failures and discarded the function's real error.

The task now reports the function payload's `errorType` and keeps the raw payload as `Cause`, matching AWS behavior for both a direct function ARN and `arn:aws:states:::lambda:invoke`.

Focused verification: `./mvnw test -Dtest=AslExecutorRetryTest,AslExecutorCatchTest,AslExecutorTaskHistoryEventsTest` (23 tests).

## Checklist

- [ ] `./mvnw test` passes locally
- [x] New or updated integration test added
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)