### PR TITLE
fix(test): stop XmlParserTest matching a localized parser message

### DIFF
--- a/src/test/java/io/github/hectorvent/floci/core/common/XmlParserTest.java
+++ b/src/test/java/io/github/hectorvent/floci/core/common/XmlParserTest.java
@@ -49,8 +49,7 @@ class XmlParserTest {
                 r2.next();
             }
         }, "an entity from the skipped DTD must not expand");
-        assertTrue(e.getMessage().contains("not declared"),
-                "should fail because the DTD never took effect, was: " + e.getMessage());
+        assertFailedOnUndeclaredEntity(e, "x");
     }
 
     @Test
@@ -68,7 +67,8 @@ class XmlParserTest {
                 r.next();
             }
         }, "an external entity must never be resolved");
-        assertTrue(e.getMessage().contains("not declared"),
+        assertFailedOnUndeclaredEntity(e, "secret");
+        assertFalse(e.getMessage().contains("nonexistent"),
                 "must fail without reading the file at all, was: " + e.getMessage());
     }
 
@@ -396,5 +396,16 @@ class XmlParserTest {
         assertNull(XmlParser.rootElementName("garbage {} not xml"));
         assertNull(XmlParser.rootElementName("<AccelerateConfiguration><Status>Enabled"));
         assertNull(XmlParser.rootElementName("<AccelerateConfiguration/>trailing"));
+    }
+
+    /**
+     * Asserts the parse stopped at an entity reference the document never declared. The parser
+     * translates the sentence it reports, so a JVM with a non-English default locale spells this
+     * failure differently, and on macOS that locale comes from system preferences rather than from
+     * LANG. The entity name it quotes is the part no translation touches.
+     */
+    private static void assertFailedOnUndeclaredEntity(XMLStreamException e, String entityName) {
+        assertTrue(e.getMessage().contains('"' + entityName + '"'),
+                "should fail on the undeclared entity " + entityName + ", was: " + e.getMessage());
     }
 }

--- a/src/test/java/io/github/hectorvent/floci/core/common/XmlParserTest.java
+++ b/src/test/java/io/github/hectorvent/floci/core/common/XmlParserTest.java
@@ -68,8 +68,9 @@ class XmlParserTest {
             }
         }, "an external entity must never be resolved");
         assertFailedOnUndeclaredEntity(e, "secret");
-        assertFalse(e.getMessage().contains("nonexistent"),
-                "must fail without reading the file at all, was: " + e.getMessage());
+        String message = String.valueOf(e.getMessage());
+        assertFalse(message.contains("nonexistent"),
+                "must fail without reading the file at all, was: " + message);
     }
 
     @Test
@@ -405,7 +406,8 @@ class XmlParserTest {
      * LANG. The entity name it quotes is the part no translation touches.
      */
     private static void assertFailedOnUndeclaredEntity(XMLStreamException e, String entityName) {
-        assertTrue(e.getMessage().contains('"' + entityName + '"'),
-                "should fail on the undeclared entity " + entityName + ", was: " + e.getMessage());
+        String message = String.valueOf(e.getMessage());
+        assertTrue(message.contains("\"" + entityName + "\""),
+                "should fail on the undeclared entity " + entityName + ", was: " + message);
     }
 }


### PR DESCRIPTION
## Summary

Both DTD tests in `XmlParserTest` asserted that the parse failure message contains "not declared". The JDK's XML parser translates that sentence, so on a JVM whose default locale is not English the same failure reads differently and the tests fail:

```
must fail without reading the file at all, was: ParseError at [row,col]:[2,22]
Message: エンティティ"secret"が参照されていますが、宣言されていません。
```

Nothing in the emulator behaves differently, only the wording of the message the tests inspect. On macOS the default locale comes from system preferences, so neither `LANG` nor `-Duser.language` on the Maven command line works around it: the suite cannot pass on such a machine at all.

- The assertion now matches the entity name the parser quotes, which no translation touches, through a named helper that carries the reasoning once.
- `newStreamReaderDoesNotExpandAnExternalEntity` also asserts the message does not name the file it was pointed at. That is what the test is really proving, since a parser that resolved the entity would fail while reading `file:///nonexistent/secret`, and the entity name alone would match that path too.

## Type of change

- [x] Bug fix (`fix:`)
- [ ] New feature (`feat:`)
- [ ] Breaking change (`feat!:` or `fix!:`)
- [ ] Docs / chore

## AWS Compatibility

No product code changes. The hardening under test, refusing DTDs and never resolving external entities, is unchanged; only the way the tests recognise the resulting failure is.

Verified on both sides of the problem: with a Japanese default locale, and with `user.language=en` forced into the surefire fork, `XmlParserTest` runs 21 tests with no failures. Before the change the same class fails 2 of 21 under the Japanese locale. On JDK 25 only `ja` translates this message and every other shipped locale falls back to English, but both spell the entity name in ASCII double quotes, which is the part the assertion now reads.

Checked as well that nothing else depends on a JDK-localized message: the remaining `getMessage().contains(...)` sites in tests and in `src/main` read Floci's own exception text or docker-java's, neither of which is translated.

## Checklist

- [ ] `./mvnw test` passes locally
- [x] New or updated integration test added
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
