### PR TITLE
fix(build): publish ARM64 baseline release image

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,6 +9,8 @@ name: Release
 #            public.ecr.aws/floci/floci:1.2.3        public.ecr.aws/floci/floci:latest
 #   Cedar:   floci/floci:1.2.3-cedar floci/floci:latest-cedar
 #            public.ecr.aws/floci/floci:1.2.3-cedar public.ecr.aws/floci/floci:latest-cedar
+#   Baseline: floci/floci:1.2.3-baseline floci/floci:latest-baseline
+#             public.ecr.aws/floci/floci:1.2.3-baseline public.ecr.aws/floci/floci:latest-baseline
 #   Compat:  floci/floci:1.2.3-compat floci/floci:latest-compat
 #            public.ecr.aws/floci/floci:1.2.3-compat public.ecr.aws/floci/floci:latest-compat
 #
@@ -100,10 +102,42 @@ jobs:
           if-no-files-found: warn
           retention-days: 1
 
+  # ── Build baseline native artifact — arm64 only ─────────────────────────
+  build-native-arm64-baseline:
+    name: Build baseline native artifact (arm64)
+    runs-on: ubuntu-24.04-arm
+    timeout-minutes: 45
+
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      - uses: graalvm/setup-graalvm@5298d94fb55a4f185c602eeac5de1b553882abe2 # v1
+        with:
+          java-version: '25'
+          distribution: 'mandrel'
+          cache: maven
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build ARMv8.0 baseline native executable
+        # Keep the normal arm64 artifact optimized as before. This additional release-only build
+        # targets ARMv8.0 explicitly so older cores such as Raspberry Pi 4's Cortex-A72 do not
+        # inherit optional AArch64 features (notably LSE) from the GitHub-hosted build runner.
+        run: mvn clean package -Dnative -DskipTests -B -Dquarkus.native.additional-build-args-append="-march=armv8-a,-H:-AOTSingleCallsiteInline"
+
+      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: native-arm64-baseline
+          path: |
+            target/*-runner
+            target/*.properties
+            target/*.so
+          if-no-files-found: warn
+          retention-days: 1
+
   # ── Push native + compat Docker images ───────────────────────────────────
   push-native:
     name: Push native and compat Docker images
-    needs: [build-native-amd64, build-native-arm64]
+    needs: [build-native-amd64, build-native-arm64, build-native-arm64-baseline]
     runs-on: ubuntu-latest
     timeout-minutes: 30
 
@@ -131,6 +165,11 @@ jobs:
         with:
           name: native-arm64
           path: native/arm64/
+
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: native-arm64-baseline
+          path: native-baseline/arm64/
 
       - name: Stage binaries under a fixed name
         run: |
@@ -183,6 +222,41 @@ jobs:
             vcs-ref=${{ github.sha }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
+
+      - name: Stage ARMv8.0 baseline artifact under the native package path
+        run: |
+          rm -rf native/amd64 native/arm64
+          mkdir -p native/arm64
+          cp -a native-baseline/arm64/. native/arm64/
+          mv native/arm64/*-runner native/arm64/application
+
+      - name: Build and push ARMv8.0 baseline image
+        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.3.0
+        env:
+          SOURCE_DATE_EPOCH: ${{ steps.source_date.outputs.epoch }}
+        with:
+          context: .
+          file: docker/Dockerfile.native-package
+          platforms: linux/arm64
+          push: true
+          provenance: mode=max
+          sbom: true
+          tags: |
+            floci/floci:${{ steps.version.outputs.version }}-baseline
+            floci/floci:latest-baseline
+            public.ecr.aws/floci/floci:${{ steps.version.outputs.version }}-baseline
+            public.ecr.aws/floci/floci:latest-baseline
+          build-args: |
+            VERSION=${{ steps.version.outputs.version }}
+          labels: |
+            org.opencontainers.image.version=${{ steps.version.outputs.version }}
+            org.opencontainers.image.revision=${{ github.sha }}
+            org.opencontainers.image.created=${{ steps.created.outputs.created }}
+            version=${{ steps.version.outputs.version }}
+            build-date=${{ steps.created.outputs.created }}
+            vcs-ref=${{ github.sha }}
+          cache-from: type=gha,scope=floci-arm64-baseline
+          cache-to: type=gha,scope=floci-arm64-baseline,mode=max
 
       - name: Build and push Cedar sidecar multi-arch image
         uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.3.0

--- a/README.md
+++ b/README.md
@@ -747,12 +747,12 @@ See the [full migration guide](https://floci.io/floci/getting-started/migrate-fr
 
 Every tag combines a variant and a channel.
 
-| Channel | Standard | Compat with AWS CLI and boto3 |
-|---|---|---|
-| Release, floating | `latest` | `latest-compat` |
-| Release, pinned | `x.y.z` | `x.y.z-compat` |
-| Nightly, floating | `nightly` | `nightly-compat` |
-| Nightly, dated | `nightly-mmddyyyy` | `nightly-mmddyyyy-compat` |
+| Channel | Standard | Baseline (ARM64 only) | Compat with AWS CLI and boto3 |
+|---|---|---|---|
+| Release, floating | `latest` | `latest-baseline` | `latest-compat` |
+| Release, pinned | `x.y.z` | `x.y.z-baseline` | `x.y.z-compat` |
+| Nightly, floating | `nightly` | — | `nightly-compat` |
+| Nightly, dated | `nightly-mmddyyyy` | — | `nightly-mmddyyyy-compat` |
 
 Use `latest` for stable releases, a pinned version for reproducible builds, and `nightly` to track `main`.
 
@@ -762,6 +762,9 @@ image: floci/floci:latest
 
 # Includes AWS CLI and boto3
 image: floci/floci:latest-compat
+
+# ARM64 baseline for Raspberry Pi 4 / pre-LSE cores
+image: floci/floci:latest-baseline
 
 # Pinned release
 image: floci/floci:x.y.z

--- a/docs/configuration/docker-images.md
+++ b/docs/configuration/docker-images.md
@@ -9,9 +9,10 @@ Every image tag combines two independent choices: **what's inside** (variant) an
 | Variant | Contents | When to use |
 |---|---|---|
 | **Standard** | Floci native binary only | General use: CI, local dev, Testcontainers **(recommended)** |
+| **Baseline** | Floci native binary compiled for ARMv8.0 (`armv8-a`) | ARM64 hosts without LSE, including Raspberry Pi 4-class CPUs |
 | **Compat** | Floci + Python 3 + AWS CLI + boto3 | Workflows that need AWS tooling available inside the container |
 
-The compat image runs the same native binary as the standard image, so startup time and memory footprint are identical. Only the image size increases.
+The compat image runs the same native binary as the standard image, so startup time and memory footprint are identical. Only the image size increases. The baseline image is different: it is an ARM64-only release artifact compiled for the ARMv8.0 ISA floor and is not published on nightly channels.
 
 The standard image is built on Red Hat UBI 9 micro. Besides Floci it contains only bash and coreutils. There is no package manager, curl, grep or sed inside. Pick the compat image when you need tools inside the container.
 
@@ -28,12 +29,12 @@ Release images are stable and recommended for most use cases. Between trains, `n
 
 Combining both axes gives the complete set of published tags:
 
-|  | Standard | Compat |
-|---|---|---|
-| **Release (latest)** | `latest` ✅ | `latest-compat` |
-| **Release (pinned)** | `x.y.z` | `x.y.z-compat` |
-| **Nightly (floating)** | `nightly` | `nightly-compat` |
-| **Nightly (dated)** | `nightly-mmddyyyy` | `nightly-mmddyyyy-compat` |
+|  | Standard | Baseline (ARM64 only) | Compat |
+|---|---|---|---|
+| **Release (latest)** | `latest` ✅ | `latest-baseline` | `latest-compat` |
+| **Release (pinned)** | `x.y.z` | `x.y.z-baseline` | `x.y.z-compat` |
+| **Nightly (floating)** | `nightly` | — | `nightly-compat` |
+| **Nightly (dated)** | `nightly-mmddyyyy` | — | `nightly-mmddyyyy-compat` |
 
 Dated nightly tags (e.g. `nightly-05022026`) name one night's build of `main`. A same-day rerun of the nightly workflow republishes that day's tag, so for a build you can rely on not changing, pin a release version.
 
@@ -49,6 +50,9 @@ image: floci/floci:latest
 # Compat release : includes AWS CLI and boto3
 image: floci/floci:latest-compat
 
+# ARM64 baseline release : Raspberry Pi 4 / pre-LSE AArch64 cores
+image: floci/floci:latest-baseline
+
 # Pinned release : reproducible builds
 image: floci/floci:x.y.z
 
@@ -58,7 +62,13 @@ image: floci/floci:nightly
 
 ## Multi-Architecture
 
-All images are published as multi-arch manifests supporting `linux/amd64` and `linux/arm64`. Docker selects the correct variant automatically.
+Standard and compat images are published as multi-arch manifests supporting `linux/amd64` and `linux/arm64`. Baseline images are intentionally `linux/arm64` only.
+
+## Raspberry Pi 4 and older ARM64 CPUs
+
+If the standard ARM64 image exits with `CPU features [FP, ASIMD, CRC32, LSE] not supported`, use the `-baseline` release tag. The baseline image is compiled with GraalVM `-march=armv8-a`, so it does not require LSE. For example, use `floci/floci:latest-baseline` or pin `floci/floci:x.y.z-baseline`.
+
+The baseline variant currently covers the Docker image only. The standalone `floci-linux-arm64` binary remains tracked in [#1114](https://github.com/floci-io/floci/issues/1114).
 
 ## Reusable Image Publishing
 

--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -19,12 +19,12 @@ docker pull floci/floci:latest
 
 Each tag combines a **variant** (what's inside) and a **channel** (how stable).
 
-|  | Standard | Compat (+ AWS CLI + boto3) |
-|---|---|---|
-| **Release (latest)** | `latest` ✅ | `latest-compat` |
-| **Release (pinned)** | `x.y.z` | `x.y.z-compat` |
-| **Nightly (floating)** | `nightly` | `nightly-compat` |
-| **Nightly (dated)** | `nightly-mmddyyyy` | `nightly-mmddyyyy-compat` |
+|  | Standard | Baseline (ARM64 only) | Compat (+ AWS CLI + boto3) |
+|---|---|---|---|
+| **Release (latest)** | `latest` ✅ | `latest-baseline` | `latest-compat` |
+| **Release (pinned)** | `x.y.z` | `x.y.z-baseline` | `x.y.z-compat` |
+| **Nightly (floating)** | `nightly` | — | `nightly-compat` |
+| **Nightly (dated)** | `nightly-mmddyyyy` | — | `nightly-mmddyyyy-compat` |
 
 For the full breakdown see [Docker Images](../configuration/docker-images.md).
 
@@ -49,7 +49,7 @@ services:
       - "4566:4566"
 ```
 
-Both variants have identical startup time (~24 ms) and memory footprint (~13 MiB).
+Standard and compat have identical startup time (~24 ms) and memory footprint (~13 MiB). On Raspberry Pi 4-class ARM64 CPUs that lack LSE, use `floci/floci:latest-baseline` (or a pinned `x.y.z-baseline` release).
 
 ## Build from Source
 


### PR DESCRIPTION
## Summary

Publishes an additional ARM64-only baseline release image for older AArch64 CPUs such as Raspberry Pi 4, without lowering the ISA target of Floci's existing ARM64 images.

The baseline native artifact is built with `-march=armv8-a` and published as:

- `floci/floci:<version>-baseline`
- `floci/floci:latest-baseline`
- `public.ecr.aws/floci/floci:<version>-baseline`
- `public.ecr.aws/floci/floci:latest-baseline`

The normal release, nightly, reusable-build, and compatibility workflows keep their existing architecture targets. The baseline variant is release-only and `linux/arm64` only.

Supersedes #3442 following the maintainer design in #1114.

Closes #1114

## Type of change

- [x] Bug fix (`fix:`)
- [ ] New feature (`feat:`)
- [ ] Breaking change (`feat!:` or `fix!:`)
- [ ] Docs / chore

## AWS Compatibility

Not an AWS protocol change. This addresses native-image CPU compatibility on ARM64.

The reported failure is `CPU features [FP, ASIMD, CRC32, LSE] not supported` on Raspberry Pi 4-class Cortex-A72 CPUs. Rather than reducing the default ARM64 target for every consumer, this PR adds the release-only baseline artifact requested in the maintainer design.

Official build references:

- GraalVM Native Image `-march`: https://www.graalvm.org/jdk25/reference-manual/native-image/overview/Options/
- GraalVM machine-specific optimization guidance: https://www.graalvm.org/jdk25/reference-manual/native-image/optimizations-and-performance/
- Quarkus native additional build arguments: https://quarkus.io/guides/building-native-image/

The standalone `floci-linux-arm64` binary remains out of scope, so #1114 intentionally stays open.

Validation:

- `git diff --cached --check`
- `make docs-sync`
- `make docs-check`
- `.github/workflows/release.yml` parses as YAML
- baseline build contains `-march=armv8-a`
- baseline image publishes only `linux/arm64`
- no baseline build/tag is added to `nightly.yml` or `compatibility.yml`
- baseline staging preserves the full native artifact (`*-runner`, `.so`, `.properties`) before renaming the runner to `application`

## Checklist

- [ ] `./mvnw test` passes locally — no Java behavior changed; this is release workflow + docs only
- [ ] New or updated integration test added — no runtime/protocol behavior changed
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
