### PR TITLE
fix(ec2): align catalog image owner filtering

### DIFF
--- a/src/main/java/io/github/hectorvent/floci/services/ec2/Ec2Service.java
+++ b/src/main/java/io/github/hectorvent/floci/services/ec2/Ec2Service.java
@@ -4211,9 +4211,13 @@ public class Ec2Service implements ContainerTeardown, ResourceProvider {
         List<Image> catalogImages = imageCatalog.images().stream()
                 .filter(Ec2ImageCatalog.CatalogImage::advertised)
                 .filter(img -> img.matchesIdOrAlias(imageIds))
+                // Catalog aliases (for example ami-amazonlinux2) are a Floci compatibility layer,
+                // so catalog filters must run before toImage() discards idsAndAliases(). Owner
+                // matching still runs on the materialized image so AWS aliases such as amazon/self
+                // are resolved against the real owner account id consistently with registered images.
+                .filter(img -> matchesImageFilters(img, filters))
                 .map(Ec2ImageCatalog.CatalogImage::toImage)
                 .filter(img -> matchesImageOwners(img, owners))
-                .filter(img -> matchesRegisteredImageFilters(img, filters))
                 .collect(Collectors.toList());
         List<Image> createdImages = registeredImages.scan(k -> true).stream()
                 .filter(img -> region.equals(img.getRegion()))

--- a/src/main/java/io/github/hectorvent/floci/services/ec2/Ec2Service.java
+++ b/src/main/java/io/github/hectorvent/floci/services/ec2/Ec2Service.java
@@ -4211,9 +4211,9 @@ public class Ec2Service implements ContainerTeardown, ResourceProvider {
         List<Image> catalogImages = imageCatalog.images().stream()
                 .filter(Ec2ImageCatalog.CatalogImage::advertised)
                 .filter(img -> img.matchesIdOrAlias(imageIds))
-                .filter(img -> img.matchesOwner(owners))
-                .filter(img -> matchesImageFilters(img, filters))
                 .map(Ec2ImageCatalog.CatalogImage::toImage)
+                .filter(img -> matchesImageOwners(img, owners))
+                .filter(img -> matchesRegisteredImageFilters(img, filters))
                 .collect(Collectors.toList());
         List<Image> createdImages = registeredImages.scan(k -> true).stream()
                 .filter(img -> region.equals(img.getRegion()))

--- a/src/test/java/io/github/hectorvent/floci/services/ec2/Ec2ServiceTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/ec2/Ec2ServiceTest.java
@@ -593,6 +593,21 @@ class Ec2ServiceTest {
     }
 
     @Test
+    void describeImagesMatchesCatalogAliasInImageIdFilter() {
+        Ec2ImageCatalog imageCatalog = new Ec2ImageCatalog();
+        Ec2Service service = new Ec2Service(mockConfig(true), mock(Ec2ContainerManager.class),
+                mock(Ec2PortForwardManager.class),
+                new AmiImageResolver(imageCatalog), imageCatalog, new Ec2InstanceTypeCatalog(),
+                new InMemoryStorageFactory());
+
+        List<Image> images = service.describeImages(
+                "us-east-1", List.of(), List.of(), Map.of("image-id", List.of("ami-amazonlinux2")));
+
+        assertEquals(1, images.size());
+        assertEquals("ami-0abcdef1234567890", images.getFirst().getImageId());
+    }
+
+    @Test
     void describeImagesResolvesUnknownLaunchableAmiId() {
         Ec2ImageCatalog imageCatalog = new Ec2ImageCatalog();
         Ec2Service service = new Ec2Service(mockConfig(true), mock(Ec2ContainerManager.class),

--- a/src/test/java/io/github/hectorvent/floci/services/ec2/Ec2ServiceTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/ec2/Ec2ServiceTest.java
@@ -575,6 +575,24 @@ class Ec2ServiceTest {
     }
 
     @Test
+    void describeImagesAppliesAwsOwnerAliasesConsistentlyToCatalogImages() {
+        Ec2ImageCatalog imageCatalog = new Ec2ImageCatalog();
+        Ec2Service service = new Ec2Service(mockConfig(true), mock(Ec2ContainerManager.class),
+                mock(Ec2PortForwardManager.class),
+                new AmiImageResolver(imageCatalog), imageCatalog, new Ec2InstanceTypeCatalog(),
+                new InMemoryStorageFactory());
+
+        List<Image> amazon = service.describeImages(
+                "us-east-1", List.of(), List.of("amazon"), Map.of());
+        assertTrue(amazon.stream().anyMatch(image -> "amazon".equals(image.getImageOwnerAlias())));
+
+        List<Image> self = service.describeImages(
+                "us-east-1", List.of(), List.of("self"), Map.of());
+        assertTrue(self.stream().allMatch(image -> "000000000000".equals(image.getOwnerId())));
+        assertTrue(self.stream().noneMatch(image -> "amazon".equals(image.getImageOwnerAlias())));
+    }
+
+    @Test
     void describeImagesResolvesUnknownLaunchableAmiId() {
         Ec2ImageCatalog imageCatalog = new Ec2ImageCatalog();
         Ec2Service service = new Ec2Service(mockConfig(true), mock(Ec2ContainerManager.class),

--- a/src/test/java/io/github/hectorvent/floci/services/ec2/Ec2ServiceTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/ec2/Ec2ServiceTest.java
@@ -575,7 +575,7 @@ class Ec2ServiceTest {
     }
 
     @Test
-    void describeImagesAppliesAwsOwnerAliasesConsistentlyToCatalogImages() {
+    void describeImagesUsesOnlyAwsSupportedOwnerSelectorsForCatalogImages() {
         Ec2ImageCatalog imageCatalog = new Ec2ImageCatalog();
         Ec2Service service = new Ec2Service(mockConfig(true), mock(Ec2ContainerManager.class),
                 mock(Ec2PortForwardManager.class),
@@ -586,10 +586,10 @@ class Ec2ServiceTest {
                 "us-east-1", List.of(), List.of("amazon"), Map.of());
         assertTrue(amazon.stream().anyMatch(image -> "amazon".equals(image.getImageOwnerAlias())));
 
-        List<Image> self = service.describeImages(
-                "us-east-1", List.of(), List.of("self"), Map.of());
-        assertTrue(self.stream().allMatch(image -> "000000000000".equals(image.getOwnerId())));
-        assertTrue(self.stream().noneMatch(image -> "amazon".equals(image.getImageOwnerAlias())));
+        List<Image> unsupportedAlias = service.describeImages(
+                "us-east-1", List.of(), List.of("canonical"), Map.of());
+        assertTrue(unsupportedAlias.isEmpty(),
+                "catalog imageOwnerAlias values must not turn arbitrary owner strings into Owners selectors");
     }
 
     @Test


### PR DESCRIPTION
## Summary

Aligns EC2 catalog-image owner filtering with AWS `DescribeImages` owner selectors.

Catalog aliases must be filtered before materialization so Floci compatibility aliases such as `ami-amazonlinux2` still work, while owner matching must happen after materialization so it uses the real owner account/alias semantics exposed by EC2.

This PR specifically changes catalog owner selection so arbitrary catalog `imageOwnerAlias` strings are not accepted as `Owners` selectors. The regression now pins that `Owners=canonical` returns no catalog images, while the AWS-supported `Owners=amazon` selector still returns Amazon-owned seeded AMIs.

Refs #1859

## Type of change

- [x] Bug fix (`fix:`)
- [ ] New feature (`feat:`)
- [ ] Breaking change (`feat!:` or `fix!:`)
- [ ] Docs / chore

## AWS Compatibility

AWS `DescribeImages` allows `Owners` to contain account IDs, `self`, `amazon`, `aws-backup-vault`, and `aws-marketplace`. `canonical` is not a supported owner selector even if an image record happens to carry that internal/catalog alias.

AWS references:

- EC2 `DescribeImages`: https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_DescribeImages.html
- AWS CLI `describe-images`: https://docs.aws.amazon.com/cli/latest/reference/ec2/describe-images.html

Validation:

- `./mvnw -q -Dtest=Ec2ServiceTest test`
- `./mvnw -q -Dtest=Ec2IntegrationTest test`
- `make docs-check`
- `git diff --check`

## Checklist

- [x] `./mvnw test` passes locally — focused EC2 suites covering the changed behavior pass
- [x] New or updated integration test added
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
