### PR TITLE
fix(s3): route signed multipart requests by virtual host

### DIFF
--- a/src/main/java/io/github/hectorvent/floci/services/s3/S3VirtualHostFilter.java
+++ b/src/main/java/io/github/hectorvent/floci/services/s3/S3VirtualHostFilter.java
@@ -107,14 +107,16 @@ public class S3VirtualHostFilter implements ContainerRequestFilter {
 
         // Do not hijack requests meant for other AWS services
         String auth = requestContext.getHeaderString("Authorization");
-        if (auth != null && auth.contains("Credential=") && !auth.contains("/s3/aws4_request")) {
+        boolean signedForS3 = auth != null && auth.contains("Credential=")
+                && auth.contains("/s3/aws4_request");
+        if (auth != null && auth.contains("Credential=") && !signedForS3) {
             return;
         }
 
-        // S3 does not use these content types for bucket/object operations,
-        // but other AWS services (AwsQuery, JSON protocols) do.
+        // Other AWS services use these content types on the shared edge endpoint. An explicit
+        // S3 SigV4 scope is authoritative, including empty-body multipart initiation requests.
         String contentType = requestContext.getHeaderString("Content-Type");
-        if (contentType != null && (
+        if (!signedForS3 && contentType != null && (
                 contentType.startsWith("application/x-www-form-urlencoded") ||
                 contentType.startsWith("application/x-amz-json-"))) {
             return;

--- a/src/test/java/io/github/hectorvent/floci/services/s3/S3VirtualHostFilterTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/s3/S3VirtualHostFilterTest.java
@@ -18,7 +18,9 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -438,6 +440,41 @@ class S3VirtualHostFilterTest {
         ArgumentCaptor<URI> rewritten = ArgumentCaptor.forClass(URI.class);
         verify(ctx).setRequestUri(rewritten.capture());
         assertEquals("/www.example.com/index.html", rewritten.getValue().getRawPath());
+    }
+
+    @Test
+    void filterRewritesFormRequestExplicitlySignedForS3() {
+        URI requestUri = URI.create("http://vhost-bucket.localhost:4566/archive.zip?uploads=");
+        UriInfo uriInfo = mock(UriInfo.class);
+        when(uriInfo.getRequestUri()).thenReturn(requestUri);
+        ContainerRequestContext ctx = mock(ContainerRequestContext.class);
+        when(ctx.getUriInfo()).thenReturn(uriInfo);
+        when(ctx.getHeaderString("Host")).thenReturn("vhost-bucket.localhost:4566");
+        when(ctx.getHeaderString("Authorization")).thenReturn(
+                "AWS4-HMAC-SHA256 Credential=test/20260912/us-east-1/s3/aws4_request, Signature=fake");
+        when(ctx.getHeaderString("Content-Type")).thenReturn("application/x-www-form-urlencoded; charset=UTF-8");
+
+        new S3VirtualHostFilter().filter(ctx);
+
+        ArgumentCaptor<URI> rewritten = ArgumentCaptor.forClass(URI.class);
+        verify(ctx).setRequestUri(rewritten.capture());
+        assertEquals("/vhost-bucket/archive.zip", rewritten.getValue().getRawPath());
+        assertEquals("uploads=", rewritten.getValue().getRawQuery());
+    }
+
+    @Test
+    void filterStillIgnoresUnsignedFormRequests() {
+        URI requestUri = URI.create("http://vhost-bucket.localhost:4566/archive.zip?uploads=");
+        UriInfo uriInfo = mock(UriInfo.class);
+        when(uriInfo.getRequestUri()).thenReturn(requestUri);
+        ContainerRequestContext ctx = mock(ContainerRequestContext.class);
+        when(ctx.getUriInfo()).thenReturn(uriInfo);
+        when(ctx.getHeaderString("Host")).thenReturn("vhost-bucket.localhost:4566");
+        when(ctx.getHeaderString("Content-Type")).thenReturn("application/x-www-form-urlencoded");
+
+        new S3VirtualHostFilter().filter(ctx);
+
+        verify(ctx, never()).setRequestUri(any(URI.class));
     }
 
     // --- Other services' virtual-host schemes must not be swallowed as dotted buckets ---

--- a/src/test/java/io/github/hectorvent/floci/services/s3/S3VirtualHostIntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/s3/S3VirtualHostIntegrationTest.java
@@ -299,6 +299,34 @@ class S3VirtualHostIntegrationTest {
 
     @Test
     @Order(20)
+    void createMultipartUploadViaVirtualHost() {
+        String key = "virtual-multipart.zip";
+        var response = given()
+            .header("Host", HOST)
+            .header("Authorization",
+                    "AWS4-HMAC-SHA256 Credential=test/20260912/us-east-1/s3/aws4_request, Signature=fake")
+            .contentType("application/x-www-form-urlencoded")
+            .queryParam("uploads", "")
+        .when()
+            .post("/" + key)
+        .then()
+            .statusCode(200)
+            .body(containsString("<Bucket>" + BUCKET + "</Bucket>"))
+            .body(containsString("<Key>" + key + "</Key>"))
+            .extract().response();
+
+        String uploadId = response.xmlPath().getString("InitiateMultipartUploadResult.UploadId");
+        given()
+            .header("Host", HOST)
+            .queryParam("uploadId", uploadId)
+        .when()
+            .delete("/" + key)
+        .then()
+            .statusCode(204);
+    }
+
+    @Test
+    @Order(21)
     void cleanupAndDeleteBucket() {
         given().header("Host", HOST).delete("/hello.txt");
         given().header("Host", HOST).delete("/path/to/nested.json");


### PR DESCRIPTION
## Summary

- Treat an explicit S3 SigV4 scope as authoritative for virtual-host routing, including empty-body requests reported as form-urlencoded.
- Preserve the object path and `uploads` query so `CreateMultipartUpload` reaches the object-level S3 handler.
- Add filter-level coverage for signed and unsigned form requests, plus a multipart lifecycle integration regression.

Addresses the reproducible virtual-hosted `CreateMultipartUpload` failure described in #2955. The separate, not-yet-isolated `PutObject` symptom remains open for further investigation.

## Type of change

- [x] Bug fix (`fix:`)
- [ ] New feature (`feat:`)
- [ ] Breaking change (`feat!:` or `fix!:`)
- [ ] Docs / chore

## AWS Compatibility

AWS CLI signs `CreateMultipartUpload` for S3 while sending an empty body. That request can carry `application/x-www-form-urlencoded`; previously the content-type guard prevented virtual-host path rewriting and the request fell into the bucket-level POST handler with `POST on bucket requires ?delete parameter.` The S3 signing scope now takes precedence, while unsigned form requests remain excluded from S3 routing.

Focused verification: `S3VirtualHostFilterTest` and `S3VirtualHostIntegrationTest`, 191 tests passed.

## Checklist

- [ ] `./mvnw test` passes locally
- [x] New or updated integration test added
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)