### PR TITLE
fix(rds): register instances before starting auth proxy

### DIFF
--- a/src/main/java/io/github/hectorvent/floci/services/rds/RdsService.java
+++ b/src/main/java/io/github/hectorvent/floci/services/rds/RdsService.java
@@ -688,15 +688,26 @@ public class RdsService implements Resettable, ResourceProvider {
             attachManagedMasterUserSecret(instance, effectiveRegion, masterUserSecretKmsKeyId);
         }
 
+        String accountId = accountIdFromArn(instance.getDbInstanceArn());
+        putInstanceForScope(accountId, effectiveRegion, id, instance);
+
         if (!mock && hasBackend(backendHost, backendPort)) {
-            final String accountId = accountIdFromArn(instance.getDbInstanceArn());
             final String instanceRegion = regionFromArn(instance.getDbInstanceArn());
-            proxyManager.startProxy(rdsResourceRelayKey(instance.getDbInstanceArn(), id),
-                    engine, iamEnabled, proxyPort, backendHost, backendPort,
-                    instance.getEndpoint().address(),
-                    masterUsername, masterPassword, dbName,
-                    (user, pw) -> validateDbPasswordForScope(
-                            accountId, instanceRegion, id, user, pw));
+            try {
+                proxyManager.startProxy(rdsResourceRelayKey(instance.getDbInstanceArn(), id),
+                        engine, iamEnabled, proxyPort, backendHost, backendPort,
+                        instance.getEndpoint().address(),
+                        masterUsername, masterPassword, dbName,
+                        (user, pw) -> validateDbPasswordForScope(
+                                accountId, instanceRegion, id, user, pw));
+            } catch (RuntimeException | Error e) {
+                try {
+                    deleteInstanceForScope(accountId, effectiveRegion, id);
+                } catch (RuntimeException rollbackFailure) {
+                    e.addSuppressed(rollbackFailure);
+                }
+                throw e;
+            }
         }
 
         if (dbClusterIdentifier != null && !dbClusterIdentifier.isBlank()) {
@@ -709,7 +720,6 @@ public class RdsService implements Resettable, ResourceProvider {
             }
         }
 
-        putInstanceForScope(currentAccountId(), effectiveRegion, id, instance);
         LOG.infov("DB instance {0} created, engine={1}, endpoint={2}:{3}",
                 id, engine, endpoint.address(), String.valueOf(endpoint.port()));
         return instance;

--- a/src/test/java/io/github/hectorvent/floci/services/rds/RdsServiceTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/rds/RdsServiceTest.java
@@ -172,6 +172,34 @@ class RdsServiceTest {
     }
 
     @Test
+    void createDbInstanceMakesRequestedPasswordValidBeforeProxyStartsAcceptingConnections() {
+        doAnswer(invocation -> {
+            RdsAuthProxy.MasterPasswordCheck passwordCheck = invocation.getArgument(10);
+            assertTrue(passwordCheck.validate("admin", "secret123"));
+            assertFalse(passwordCheck.validate("admin", "wrong"));
+            return null;
+        }).when(proxyManager).startProxy(any(), any(), anyBoolean(), anyInt(), any(), anyInt(),
+                any(), any(), any(), any(), any());
+
+        rdsService.createDbInstance("mypostgres", "postgres", "13",
+                "admin", "secret123", null, "db.t3.micro",
+                20, false, null, null, null, null, false);
+    }
+
+    @Test
+    void createDbInstanceRemovesVisibleRecordWhenProxyStartupFails() {
+        doThrow(new IllegalStateException("proxy down"))
+                .when(proxyManager).startProxy(any(), any(), anyBoolean(), anyInt(), any(), anyInt(),
+                        any(), any(), any(), any(), any());
+
+        assertThrows(IllegalStateException.class, () -> rdsService.createDbInstance(
+                "mypostgres", "postgres", "13",
+                "admin", "secret123", null, "db.t3.micro",
+                20, false, null, null, null, null, false));
+        assertThrows(AwsException.class, () -> rdsService.getDbInstance("mypostgres"));
+    }
+
+    @Test
     void createDbInstanceRejectsLegacyBareAuroraEngine() {
         // "aurora" (bare) is the retired Aurora MySQL 5.6 identifier; real AWS no
         // longer accepts it for new instances/clusters and rejects it outright


### PR DESCRIPTION
## Summary

Closes #3191

- register a new DB instance before its auth proxy begins accepting connections
- roll back the visible instance record if proxy startup fails
- cover startup-time master-password validation and rollback behavior

## Type of change

- [x] Bug fix (`fix:`)
- [ ] New feature (`feat:`)
- [ ] Breaking change (`feat!:` or `fix!:`)
- [ ] Docs / chore

## AWS Compatibility

`CreateDBInstance` could expose its PostgreSQL proxy before the instance credentials were available to the password validator. A connection accepted in that window rejected the exact `MasterUserPassword` from the request. The instance is now registered before the listener starts.

## Checklist

- [ ] `./mvnw test` passes locally
- [ ] New or updated integration test added
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)

## Testing

- `./mvnw -Dtest=RdsServiceTest test` (284 tests)