### PR TITLE
feat(athena): add UpdateWorkGroup support

### DIFF
--- a/compatibility-tests/sdk-test-java/src/test/java/com/floci/test/AthenaTest.java
+++ b/compatibility-tests/sdk-test-java/src/test/java/com/floci/test/AthenaTest.java
@@ -352,4 +352,42 @@ class AthenaTest {
         assertThat(response.tags().get(0).key()).isEqualTo("env");
         assertThat(response.tags().get(0).value()).isEqualTo("prod");
     }
+
+    @Test
+    @Order(11)
+    @DisplayName("updateWorkGroup round-trips changes through the Athena SDK")
+    void updateWorkGroupRoundTripsThroughSdk() {
+        String groupName = "sdk-update-" + UUID.randomUUID().toString().replace("-", "").substring(0, 8);
+        athena.createWorkGroup(CreateWorkGroupRequest.builder()
+                .name(groupName)
+                .description("before")
+                .configuration(WorkGroupConfiguration.builder()
+                        .resultConfiguration(ResultConfiguration.builder()
+                                .outputLocation("s3://before/results/")
+                                .build())
+                        .enforceWorkGroupConfiguration(true)
+                        .build())
+                .build());
+
+        athena.updateWorkGroup(UpdateWorkGroupRequest.builder()
+                .workGroup(groupName)
+                .description("after")
+                .state(WorkGroupState.DISABLED)
+                .configurationUpdates(WorkGroupConfigurationUpdates.builder()
+                        .resultConfigurationUpdates(ResultConfigurationUpdates.builder()
+                                .outputLocation("s3://after/results/")
+                                .build())
+                        .enforceWorkGroupConfiguration(false)
+                        .publishCloudWatchMetricsEnabled(true)
+                        .build())
+                .build());
+
+        WorkGroup workGroup = athena.getWorkGroup(r -> r.workGroup(groupName)).workGroup();
+        assertThat(workGroup.description()).isEqualTo("after");
+        assertThat(workGroup.state()).isEqualTo(WorkGroupState.DISABLED);
+        assertThat(workGroup.configuration().resultConfiguration().outputLocation())
+                .isEqualTo("s3://after/results/");
+        assertThat(workGroup.configuration().enforceWorkGroupConfiguration()).isFalse();
+        assertThat(workGroup.configuration().publishCloudWatchMetricsEnabled()).isTrue();
+    }
 }

--- a/docs/services/athena.md
+++ b/docs/services/athena.md
@@ -18,6 +18,7 @@ Floci emulates Amazon Athena with **real SQL execution** powered by a [floci-duc
 | `GetWorkGroup` | Returns information about a workgroup |
 | `ListWorkGroups` | Lists all workgroups |
 | `CreateWorkGroup` | Creates a new workgroup |
+| `UpdateWorkGroup` | Updates a workgroup's description, state and configuration |
 | `ListDataCatalogs` | Lists the built-in `AwsDataCatalog` plus every registered data catalog |
 | `GetDataCatalog` | Returns one data catalog, or `InvalidRequestException` when it does not exist |
 | `CreateDataCatalog` | Registers a `LAMBDA`, `GLUE`, `HIVE` or `FEDERATED` data catalog |

--- a/src/main/java/io/github/hectorvent/floci/services/athena/AthenaJsonHandler.java
+++ b/src/main/java/io/github/hectorvent/floci/services/athena/AthenaJsonHandler.java
@@ -8,6 +8,7 @@ import io.github.hectorvent.floci.services.athena.model.QueryExecution;
 import io.github.hectorvent.floci.services.athena.model.QueryExecutionContext;
 import io.github.hectorvent.floci.services.athena.model.ResultConfiguration;
 import io.github.hectorvent.floci.services.athena.model.ResultSet;
+import io.github.hectorvent.floci.services.athena.model.UpdateWorkGroupRequest;
 import io.github.hectorvent.floci.services.athena.model.WorkGroupTag;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
@@ -76,6 +77,11 @@ public class AthenaJsonHandler {
             case "CreateWorkGroup" -> {
                 CreateWorkGroupRequest createRequest = mapper.treeToValue(request, CreateWorkGroupRequest.class);
                 athenaService.createWorkGroup(createRequest, region);
+                yield Response.ok(Map.of()).build();
+            }
+            case "UpdateWorkGroup" -> {
+                UpdateWorkGroupRequest updateRequest = mapper.treeToValue(request, UpdateWorkGroupRequest.class);
+                athenaService.updateWorkGroup(updateRequest, region);
                 yield Response.ok(Map.of()).build();
             }
             case "ListDataCatalogs" ->

--- a/src/main/java/io/github/hectorvent/floci/services/athena/AthenaService.java
+++ b/src/main/java/io/github/hectorvent/floci/services/athena/AthenaService.java
@@ -7,10 +7,23 @@ import io.github.hectorvent.floci.core.common.AwsException;
 import io.github.hectorvent.floci.core.common.CsvParser;
 import io.github.hectorvent.floci.core.storage.StorageBackend;
 import io.github.hectorvent.floci.core.storage.StorageFactory;
-import io.github.hectorvent.floci.services.athena.model.*;
-import io.github.hectorvent.floci.services.glue.model.Column;
+import io.github.hectorvent.floci.services.athena.model.CreateWorkGroupConfigurationRequest;
+import io.github.hectorvent.floci.services.athena.model.CreateWorkGroupRequest;
+import io.github.hectorvent.floci.services.athena.model.DataCatalog;
+import io.github.hectorvent.floci.services.athena.model.QueryExecution;
+import io.github.hectorvent.floci.services.athena.model.QueryExecutionContext;
+import io.github.hectorvent.floci.services.athena.model.QueryExecutionState;
+import io.github.hectorvent.floci.services.athena.model.ResultConfiguration;
+import io.github.hectorvent.floci.services.athena.model.ResultConfigurationUpdates;
+import io.github.hectorvent.floci.services.athena.model.ResultSet;
+import io.github.hectorvent.floci.services.athena.model.UpdateWorkGroupRequest;
+import io.github.hectorvent.floci.services.athena.model.WorkGroup;
+import io.github.hectorvent.floci.services.athena.model.WorkGroupConfiguration;
+import io.github.hectorvent.floci.services.athena.model.WorkGroupConfigurationUpdates;
+import io.github.hectorvent.floci.services.athena.model.WorkGroupTag;
 import io.github.hectorvent.floci.services.floci.duck.FlociDuckClient;
 import io.github.hectorvent.floci.services.glue.GlueService;
+import io.github.hectorvent.floci.services.glue.model.Column;
 import io.github.hectorvent.floci.services.glue.model.Database;
 import io.github.hectorvent.floci.services.glue.model.Table;
 import io.github.hectorvent.floci.services.s3.S3Service;
@@ -25,7 +38,16 @@ import java.io.ByteArrayInputStream;
 import java.io.InputStreamReader;
 import java.nio.charset.StandardCharsets;
 import java.time.Instant;
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.Set;
+import java.util.UUID;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
@@ -205,9 +227,32 @@ public class AthenaService {
     public Map<String, Object> getWorkGroup(String name, String region) {
         String resolved = name == null || name.isBlank() ? DEFAULT_WORKGROUP : name;
         if (DEFAULT_WORKGROUP.equals(resolved)) {
-            return primaryWorkGroupSummary();
+            return toWorkGroupDetail(primaryWorkGroup(region));
         }
         return toWorkGroupDetail(requireWorkGroup(region, resolved));
+    }
+
+    public synchronized void updateWorkGroup(UpdateWorkGroupRequest request, String region) {
+        validateWorkGroupName(request.getWorkGroup());
+        validateWorkGroupDescription(request.getDescription());
+        validateWorkGroupState(request.getState());
+
+        WorkGroup workGroup = DEFAULT_WORKGROUP.equals(request.getWorkGroup())
+                ? primaryWorkGroup(region)
+                : requireWorkGroup(region, request.getWorkGroup());
+        if (request.getDescription() != null) {
+            workGroup.setDescription(request.getDescription());
+        }
+        if (request.getState() != null) {
+            workGroup.setState(request.getState());
+        }
+        WorkGroupConfiguration configuration = workGroup.getConfiguration();
+        if (configuration == null) {
+            configuration = defaultWorkGroupConfiguration();
+            workGroup.setConfiguration(configuration);
+        }
+        mergeWorkGroupConfiguration(configuration, request.getConfigurationUpdates());
+        workGroupStore.put(workGroupKey(region, workGroup.getName()), workGroup);
     }
 
     public void deleteWorkGroup(String name, String region) {
@@ -276,8 +321,9 @@ public class AthenaService {
 
     public List<Map<String, Object>> listWorkGroups(String region) {
         List<Map<String, Object>> workGroups = new ArrayList<>();
-        workGroups.add(primaryWorkGroupSummary());
+        workGroups.add(toWorkGroupDetail(primaryWorkGroup(region)));
         workGroups.addAll(workGroupStore.scan(k -> k.startsWith(region + ":")).stream()
+                .filter(workGroup -> !DEFAULT_WORKGROUP.equals(workGroup.getName()))
                 .sorted(Comparator.comparing(WorkGroup::getName))
                 .map(this::toWorkGroupSummary)
                 .toList());
@@ -563,6 +609,45 @@ public class AthenaService {
         return normalized;
     }
 
+    private void mergeWorkGroupConfiguration(WorkGroupConfiguration configuration,
+                                             WorkGroupConfigurationUpdates updates) {
+        if (updates == null) {
+            return;
+        }
+
+        ResultConfigurationUpdates resultUpdates = updates.getResultConfigurationUpdates();
+        if (resultUpdates != null) {
+            if (Boolean.TRUE.equals(resultUpdates.getRemoveOutputLocation())) {
+                configuration.setResultConfiguration(null);
+            } else if (resultUpdates.getOutputLocation() != null) {
+                configuration.setResultConfiguration(new ResultConfiguration(resultUpdates.getOutputLocation()));
+            }
+        }
+        if (updates.getEnforceWorkGroupConfiguration() != null) {
+            configuration.setEnforceWorkGroupConfiguration(updates.getEnforceWorkGroupConfiguration());
+        }
+        if (updates.getPublishCloudWatchMetricsEnabled() != null) {
+            configuration.setPublishCloudWatchMetricsEnabled(updates.getPublishCloudWatchMetricsEnabled());
+        }
+        if (updates.getRequesterPaysEnabled() != null) {
+            configuration.setRequesterPaysEnabled(updates.getRequesterPaysEnabled());
+        }
+        if (Boolean.TRUE.equals(updates.getRemoveBytesScannedCutoffPerQuery())) {
+            configuration.setBytesScannedCutoffPerQuery(null);
+        } else if (updates.getBytesScannedCutoffPerQuery() != null) {
+            configuration.setBytesScannedCutoffPerQuery(updates.getBytesScannedCutoffPerQuery());
+        }
+        if (updates.getEngineVersion() != null) {
+            String selectedEngineVersion = updates.getEngineVersion().getSelectedEngineVersion();
+            if (selectedEngineVersion != null && !selectedEngineVersion.isBlank()) {
+                QueryExecution.EngineVersion engineVersion = new QueryExecution.EngineVersion();
+                engineVersion.setSelectedEngineVersion(selectedEngineVersion);
+                engineVersion.setEffectiveEngineVersion(resolveEffectiveEngineVersion(selectedEngineVersion));
+                configuration.setEngineVersion(engineVersion);
+            }
+        }
+    }
+
     private String resolveEffectiveEngineVersion(String selectedEngineVersion) {
         if (selectedEngineVersion == null || selectedEngineVersion.isBlank() || "AUTO".equals(selectedEngineVersion)) {
             return DEFAULT_ENGINE_VERSION;
@@ -587,21 +672,14 @@ public class AthenaService {
         return engineVersion;
     }
 
-    private Map<String, Object> primaryWorkGroupSummary() {
-        return Map.of(
-                "Name", DEFAULT_WORKGROUP,
-                "State", "ENABLED",
-                "Configuration", Map.of(
-                        "EngineVersion", Map.of(
-                                "SelectedEngineVersion", DEFAULT_ENGINE_VERSION,
-                                "EffectiveEngineVersion", DEFAULT_ENGINE_VERSION
-                        ),
-                        "ResultConfiguration", Map.of("OutputLocation", "s3://" + DEFAULT_OUTPUT_BUCKET + "/results/"),
-                        "EnforceWorkGroupConfiguration", false,
-                        "PublishCloudWatchMetricsEnabled", false,
-                        "RequesterPaysEnabled", false
-                )
-        );
+    private WorkGroup primaryWorkGroup(String region) {
+        return workGroupStore.get(workGroupKey(region, DEFAULT_WORKGROUP)).orElseGet(() -> {
+            WorkGroup workGroup = new WorkGroup();
+            workGroup.setName(DEFAULT_WORKGROUP);
+            workGroup.setState("ENABLED");
+            workGroup.setConfiguration(defaultWorkGroupConfiguration());
+            return workGroup;
+        });
     }
 
     private Map<String, Object> toWorkGroupDetail(WorkGroup workGroup) {
@@ -818,6 +896,20 @@ public class AthenaService {
         }
         if (!name.matches("[A-Za-z0-9._-]{1,128}")) {
             throw new AwsException("InvalidRequestException", "Invalid WorkGroup name: " + name, 400);
+        }
+    }
+
+    private void validateWorkGroupDescription(String description) {
+        if (description != null && description.length() > 1024) {
+            throw new AwsException("InvalidRequestException",
+                    "Description must be 0 to 1024 characters.", 400);
+        }
+    }
+
+    private void validateWorkGroupState(String state) {
+        if (state != null && !Set.of("ENABLED", "DISABLED").contains(state)) {
+            throw new AwsException("InvalidRequestException",
+                    "State must be ENABLED or DISABLED.", 400);
         }
     }
 

--- a/src/main/java/io/github/hectorvent/floci/services/athena/AthenaService.java
+++ b/src/main/java/io/github/hectorvent/floci/services/athena/AthenaService.java
@@ -20,6 +20,7 @@ import io.github.hectorvent.floci.services.athena.model.UpdateWorkGroupRequest;
 import io.github.hectorvent.floci.services.athena.model.WorkGroup;
 import io.github.hectorvent.floci.services.athena.model.WorkGroupConfiguration;
 import io.github.hectorvent.floci.services.athena.model.WorkGroupConfigurationUpdates;
+import io.github.hectorvent.floci.services.athena.model.WorkGroupEngineVersionRequest;
 import io.github.hectorvent.floci.services.athena.model.WorkGroupTag;
 import io.github.hectorvent.floci.services.floci.duck.FlociDuckClient;
 import io.github.hectorvent.floci.services.glue.GlueService;
@@ -59,6 +60,7 @@ public class AthenaService {
     private static final String DEFAULT_OUTPUT_BUCKET = "floci-athena-results";
     private static final String DEFAULT_WORKGROUP = "primary";
     private static final String DEFAULT_ENGINE_VERSION = "Athena engine version 3";
+    private static final long MIN_BYTES_SCANNED_CUTOFF_PER_QUERY = 10_000_000L;
     private static final String WORKGROUP_RESOURCE = "workgroup/";
     private static final String DATA_CATALOG_RESOURCE = "datacatalog/";
     private static final Set<String> CATALOG_TYPES = Set.of("LAMBDA", "GLUE", "HIVE", "FEDERATED");
@@ -236,6 +238,7 @@ public class AthenaService {
         validateWorkGroupName(request.getWorkGroup());
         validateWorkGroupDescription(request.getDescription());
         validateWorkGroupState(request.getState());
+        validateWorkGroupConfigurationUpdates(request.getConfigurationUpdates());
 
         WorkGroup workGroup = DEFAULT_WORKGROUP.equals(request.getWorkGroup())
                 ? primaryWorkGroup(region)
@@ -639,7 +642,7 @@ public class AthenaService {
         }
         if (updates.getEngineVersion() != null) {
             String selectedEngineVersion = updates.getEngineVersion().getSelectedEngineVersion();
-            if (selectedEngineVersion != null && !selectedEngineVersion.isBlank()) {
+            if (selectedEngineVersion != null) {
                 QueryExecution.EngineVersion engineVersion = new QueryExecution.EngineVersion();
                 engineVersion.setSelectedEngineVersion(selectedEngineVersion);
                 engineVersion.setEffectiveEngineVersion(resolveEffectiveEngineVersion(selectedEngineVersion));
@@ -910,6 +913,24 @@ public class AthenaService {
         if (state != null && !Set.of("ENABLED", "DISABLED").contains(state)) {
             throw new AwsException("InvalidRequestException",
                     "State must be ENABLED or DISABLED.", 400);
+        }
+    }
+
+    private void validateWorkGroupConfigurationUpdates(WorkGroupConfigurationUpdates updates) {
+        if (updates == null) {
+            return;
+        }
+        Long bytesScannedCutoff = updates.getBytesScannedCutoffPerQuery();
+        if (bytesScannedCutoff != null && bytesScannedCutoff < MIN_BYTES_SCANNED_CUTOFF_PER_QUERY) {
+            throw new AwsException("InvalidRequestException",
+                    "BytesScannedCutoffPerQuery must be at least "
+                            + MIN_BYTES_SCANNED_CUTOFF_PER_QUERY + ".", 400);
+        }
+        WorkGroupEngineVersionRequest engineVersion = updates.getEngineVersion();
+        if (engineVersion != null && engineVersion.getSelectedEngineVersion() != null
+                && engineVersion.getSelectedEngineVersion().isBlank()) {
+            throw new AwsException("InvalidRequestException",
+                    "SelectedEngineVersion must not be empty.", 400);
         }
     }
 

--- a/src/main/java/io/github/hectorvent/floci/services/athena/model/ResultConfigurationUpdates.java
+++ b/src/main/java/io/github/hectorvent/floci/services/athena/model/ResultConfigurationUpdates.java
@@ -1,0 +1,23 @@
+package io.github.hectorvent.floci.services.athena.model;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import io.quarkus.runtime.annotations.RegisterForReflection;
+
+@RegisterForReflection
+public class ResultConfigurationUpdates {
+
+    @JsonProperty("OutputLocation")
+    private String outputLocation;
+
+    @JsonProperty("RemoveOutputLocation")
+    private Boolean removeOutputLocation;
+
+    public ResultConfigurationUpdates() {}
+
+    public String getOutputLocation() { return outputLocation; }
+    public void setOutputLocation(String outputLocation) { this.outputLocation = outputLocation; }
+    public Boolean getRemoveOutputLocation() { return removeOutputLocation; }
+    public void setRemoveOutputLocation(Boolean removeOutputLocation) {
+        this.removeOutputLocation = removeOutputLocation;
+    }
+}

--- a/src/main/java/io/github/hectorvent/floci/services/athena/model/UpdateWorkGroupRequest.java
+++ b/src/main/java/io/github/hectorvent/floci/services/athena/model/UpdateWorkGroupRequest.java
@@ -1,0 +1,33 @@
+package io.github.hectorvent.floci.services.athena.model;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import io.quarkus.runtime.annotations.RegisterForReflection;
+
+@RegisterForReflection
+public class UpdateWorkGroupRequest {
+
+    @JsonProperty("WorkGroup")
+    private String workGroup;
+
+    @JsonProperty("Description")
+    private String description;
+
+    @JsonProperty("State")
+    private String state;
+
+    @JsonProperty("ConfigurationUpdates")
+    private WorkGroupConfigurationUpdates configurationUpdates;
+
+    public UpdateWorkGroupRequest() {}
+
+    public String getWorkGroup() { return workGroup; }
+    public void setWorkGroup(String workGroup) { this.workGroup = workGroup; }
+    public String getDescription() { return description; }
+    public void setDescription(String description) { this.description = description; }
+    public String getState() { return state; }
+    public void setState(String state) { this.state = state; }
+    public WorkGroupConfigurationUpdates getConfigurationUpdates() { return configurationUpdates; }
+    public void setConfigurationUpdates(WorkGroupConfigurationUpdates configurationUpdates) {
+        this.configurationUpdates = configurationUpdates;
+    }
+}

--- a/src/main/java/io/github/hectorvent/floci/services/athena/model/WorkGroupConfigurationUpdates.java
+++ b/src/main/java/io/github/hectorvent/floci/services/athena/model/WorkGroupConfigurationUpdates.java
@@ -1,0 +1,56 @@
+package io.github.hectorvent.floci.services.athena.model;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import io.quarkus.runtime.annotations.RegisterForReflection;
+
+@RegisterForReflection
+public class WorkGroupConfigurationUpdates {
+
+    @JsonProperty("ResultConfigurationUpdates")
+    private ResultConfigurationUpdates resultConfigurationUpdates;
+
+    @JsonProperty("EnforceWorkGroupConfiguration")
+    private Boolean enforceWorkGroupConfiguration;
+
+    @JsonProperty("PublishCloudWatchMetricsEnabled")
+    private Boolean publishCloudWatchMetricsEnabled;
+
+    @JsonProperty("RequesterPaysEnabled")
+    private Boolean requesterPaysEnabled;
+
+    @JsonProperty("BytesScannedCutoffPerQuery")
+    private Long bytesScannedCutoffPerQuery;
+
+    @JsonProperty("RemoveBytesScannedCutoffPerQuery")
+    private Boolean removeBytesScannedCutoffPerQuery;
+
+    @JsonProperty("EngineVersion")
+    private WorkGroupEngineVersionRequest engineVersion;
+
+    public WorkGroupConfigurationUpdates() {}
+
+    public ResultConfigurationUpdates getResultConfigurationUpdates() { return resultConfigurationUpdates; }
+    public void setResultConfigurationUpdates(ResultConfigurationUpdates resultConfigurationUpdates) {
+        this.resultConfigurationUpdates = resultConfigurationUpdates;
+    }
+    public Boolean getEnforceWorkGroupConfiguration() { return enforceWorkGroupConfiguration; }
+    public void setEnforceWorkGroupConfiguration(Boolean enforceWorkGroupConfiguration) {
+        this.enforceWorkGroupConfiguration = enforceWorkGroupConfiguration;
+    }
+    public Boolean getPublishCloudWatchMetricsEnabled() { return publishCloudWatchMetricsEnabled; }
+    public void setPublishCloudWatchMetricsEnabled(Boolean publishCloudWatchMetricsEnabled) {
+        this.publishCloudWatchMetricsEnabled = publishCloudWatchMetricsEnabled;
+    }
+    public Boolean getRequesterPaysEnabled() { return requesterPaysEnabled; }
+    public void setRequesterPaysEnabled(Boolean requesterPaysEnabled) { this.requesterPaysEnabled = requesterPaysEnabled; }
+    public Long getBytesScannedCutoffPerQuery() { return bytesScannedCutoffPerQuery; }
+    public void setBytesScannedCutoffPerQuery(Long bytesScannedCutoffPerQuery) {
+        this.bytesScannedCutoffPerQuery = bytesScannedCutoffPerQuery;
+    }
+    public Boolean getRemoveBytesScannedCutoffPerQuery() { return removeBytesScannedCutoffPerQuery; }
+    public void setRemoveBytesScannedCutoffPerQuery(Boolean removeBytesScannedCutoffPerQuery) {
+        this.removeBytesScannedCutoffPerQuery = removeBytesScannedCutoffPerQuery;
+    }
+    public WorkGroupEngineVersionRequest getEngineVersion() { return engineVersion; }
+    public void setEngineVersion(WorkGroupEngineVersionRequest engineVersion) { this.engineVersion = engineVersion; }
+}

--- a/src/test/java/io/github/hectorvent/floci/services/athena/AthenaCreateWorkGroupPersistenceIntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/athena/AthenaCreateWorkGroupPersistenceIntegrationTest.java
@@ -18,6 +18,7 @@ import static io.restassured.RestAssured.given;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 @QuarkusTest
@@ -289,6 +290,62 @@ class AthenaCreateWorkGroupPersistenceIntegrationTest {
 
         assertEquals("Athena engine version 3", engineVersion.get("SelectedEngineVersion"));
         assertEquals("Athena engine version 3", engineVersion.get("EffectiveEngineVersion"));
+    }
+
+    @Test
+    void updateWorkGroupPersistsMergedState() throws Exception {
+        Files.deleteIfExists(WORKGROUPS_FILE);
+
+        given()
+            .header("X-Amz-Target", "AmazonAthena.CreateWorkGroup")
+            .contentType(CONTENT_TYPE)
+            .body("""
+                {
+                  "Name": "persistent-update",
+                  "Configuration": {
+                    "EnforceWorkGroupConfiguration": true,
+                    "BytesScannedCutoffPerQuery": 10000000
+                  }
+                }
+                """)
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200);
+
+        given()
+            .header("X-Amz-Target", "AmazonAthena.UpdateWorkGroup")
+            .contentType(CONTENT_TYPE)
+            .body("""
+                {
+                  "WorkGroup": "persistent-update",
+                  "Description": "persisted after update",
+                  "State": "DISABLED",
+                  "ConfigurationUpdates": {
+                    "PublishCloudWatchMetricsEnabled": true,
+                    "RemoveBytesScannedCutoffPerQuery": true
+                  }
+                }
+                """)
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200);
+
+        PersistentStorage<String, Map<String, Object>> store = new PersistentStorage<>(
+                WORKGROUPS_FILE,
+                new TypeReference<Map<String, Map<String, Object>>>() {});
+        store.load();
+
+        Map<String, Object> persisted = store.get("000000000000/us-east-1:persistent-update").orElseThrow();
+        assertEquals("persisted after update", persisted.get("Description"));
+        assertEquals("DISABLED", persisted.get("State"));
+
+        @SuppressWarnings("unchecked")
+        Map<String, Object> configuration = (Map<String, Object>) persisted.get("Configuration");
+        assertEquals(true, configuration.get("EnforceWorkGroupConfiguration"));
+        assertEquals(true, configuration.get("PublishCloudWatchMetricsEnabled"));
+        assertNull(configuration.get("BytesScannedCutoffPerQuery"));
     }
 
     public static final class PersistentStorageProfile implements QuarkusTestProfile {

--- a/src/test/java/io/github/hectorvent/floci/services/athena/AthenaUpdateWorkGroupIntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/athena/AthenaUpdateWorkGroupIntegrationTest.java
@@ -1,0 +1,189 @@
+package io.github.hectorvent.floci.services.athena;
+
+import io.github.hectorvent.floci.testing.RestAssuredJsonUtils;
+import io.quarkus.test.junit.QuarkusTest;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+import static io.restassured.RestAssured.given;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.nullValue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+@QuarkusTest
+class AthenaUpdateWorkGroupIntegrationTest {
+
+    private static final String CONTENT_TYPE = "application/x-amz-json-1.1";
+
+    @BeforeAll
+    static void configureRestAssured() {
+        RestAssuredJsonUtils.configureAwsContentTypes();
+    }
+
+    @Test
+    void updateWorkGroupMergesDescriptionStateAndConfiguration() {
+        given()
+            .header("X-Amz-Target", "AmazonAthena.CreateWorkGroup")
+            .contentType(CONTENT_TYPE)
+            .body("""
+                {
+                  "Name": "analytics-update",
+                  "Description": "before",
+                  "Configuration": {
+                    "ResultConfiguration": {
+                      "OutputLocation": "s3://before/results/"
+                    },
+                    "EnforceWorkGroupConfiguration": true,
+                    "PublishCloudWatchMetricsEnabled": false,
+                    "RequesterPaysEnabled": false,
+                    "BytesScannedCutoffPerQuery": 10000000
+                  }
+                }
+                """)
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200);
+
+        String responseBody = given()
+            .header("X-Amz-Target", "AmazonAthena.UpdateWorkGroup")
+            .contentType(CONTENT_TYPE)
+            .body("""
+                {
+                  "WorkGroup": "analytics-update",
+                  "Description": "after",
+                  "State": "DISABLED",
+                  "ConfigurationUpdates": {
+                    "ResultConfigurationUpdates": {
+                      "OutputLocation": "s3://after/results/"
+                    },
+                    "EnforceWorkGroupConfiguration": false,
+                    "PublishCloudWatchMetricsEnabled": true,
+                    "RequesterPaysEnabled": true,
+                    "BytesScannedCutoffPerQuery": 20000000,
+                    "EngineVersion": {
+                      "SelectedEngineVersion": "AUTO"
+                    }
+                  }
+                }
+                """)
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200)
+            .extract().asString();
+
+        assertEquals("{}", responseBody);
+
+        given()
+            .header("X-Amz-Target", "AmazonAthena.GetWorkGroup")
+            .contentType(CONTENT_TYPE)
+            .body("{ \"WorkGroup\": \"analytics-update\" }")
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200)
+            .body("WorkGroup.Description", equalTo("after"))
+            .body("WorkGroup.State", equalTo("DISABLED"))
+            .body("WorkGroup.Configuration.ResultConfiguration.OutputLocation",
+                    equalTo("s3://after/results/"))
+            .body("WorkGroup.Configuration.EnforceWorkGroupConfiguration", equalTo(false))
+            .body("WorkGroup.Configuration.PublishCloudWatchMetricsEnabled", equalTo(true))
+            .body("WorkGroup.Configuration.RequesterPaysEnabled", equalTo(true))
+            .body("WorkGroup.Configuration.BytesScannedCutoffPerQuery", equalTo(20000000))
+            .body("WorkGroup.Configuration.EngineVersion.SelectedEngineVersion", equalTo("AUTO"))
+            .body("WorkGroup.Configuration.EngineVersion.EffectiveEngineVersion",
+                    equalTo("Athena engine version 3"));
+    }
+
+    @Test
+    void updateWorkGroupPreservesOmittedSettingsAndAppliesRemovalFlags() {
+        given()
+            .header("X-Amz-Target", "AmazonAthena.CreateWorkGroup")
+            .contentType(CONTENT_TYPE)
+            .body("""
+                {
+                  "Name": "analytics-partial-update",
+                  "Configuration": {
+                    "ResultConfiguration": {
+                      "OutputLocation": "s3://before/results/"
+                    },
+                    "EnforceWorkGroupConfiguration": true,
+                    "BytesScannedCutoffPerQuery": 10000000
+                  }
+                }
+                """)
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200);
+
+        given()
+            .header("X-Amz-Target", "AmazonAthena.UpdateWorkGroup")
+            .contentType(CONTENT_TYPE)
+            .body("""
+                {
+                  "WorkGroup": "analytics-partial-update",
+                  "ConfigurationUpdates": {
+                    "ResultConfigurationUpdates": {
+                      "RemoveOutputLocation": true
+                    },
+                    "RemoveBytesScannedCutoffPerQuery": true
+                  }
+                }
+                """)
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200);
+
+        given()
+            .header("X-Amz-Target", "AmazonAthena.GetWorkGroup")
+            .contentType(CONTENT_TYPE)
+            .body("{ \"WorkGroup\": \"analytics-partial-update\" }")
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200)
+            .body("WorkGroup.State", equalTo("ENABLED"))
+            .body("WorkGroup.Configuration.EnforceWorkGroupConfiguration", equalTo(true))
+            .body("WorkGroup.Configuration.ResultConfiguration", nullValue())
+            .body("WorkGroup.Configuration.BytesScannedCutoffPerQuery", nullValue());
+    }
+
+    @Test
+    void updateWorkGroupRejectsMissingWorkGroup() {
+        given()
+            .header("X-Amz-Target", "AmazonAthena.UpdateWorkGroup")
+            .contentType(CONTENT_TYPE)
+            .body("{ \"WorkGroup\": \"missing-update-workgroup\", \"Description\": \"after\" }")
+        .when()
+            .post("/")
+        .then()
+            .statusCode(400)
+            .body("__type", equalTo("InvalidRequestException"))
+            .body("message", equalTo("WorkGroup missing-update-workgroup is not found."));
+    }
+
+    @Test
+    void updateWorkGroupRejectsInvalidState() {
+        given()
+            .header("X-Amz-Target", "AmazonAthena.CreateWorkGroup")
+            .contentType(CONTENT_TYPE)
+            .body("{ \"Name\": \"analytics-invalid-state\" }")
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200);
+
+        given()
+            .header("X-Amz-Target", "AmazonAthena.UpdateWorkGroup")
+            .contentType(CONTENT_TYPE)
+            .body("{ \"WorkGroup\": \"analytics-invalid-state\", \"State\": \"UNKNOWN\" }")
+        .when()
+            .post("/")
+        .then()
+            .statusCode(400)
+            .body("__type", equalTo("InvalidRequestException"));
+    }
+}

--- a/src/test/java/io/github/hectorvent/floci/services/athena/AthenaUpdateWorkGroupIntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/athena/AthenaUpdateWorkGroupIntegrationTest.java
@@ -186,4 +186,102 @@ class AthenaUpdateWorkGroupIntegrationTest {
             .statusCode(400)
             .body("__type", equalTo("InvalidRequestException"));
     }
+
+    @Test
+    void updateWorkGroupRejectsBytesScannedCutoffBelowMinimumWithoutApplyingOtherChanges() {
+        given()
+            .header("X-Amz-Target", "AmazonAthena.CreateWorkGroup")
+            .contentType(CONTENT_TYPE)
+            .body("""
+                {
+                  "Name": "analytics-invalid-cutoff",
+                  "Description": "before",
+                  "Configuration": {
+                    "BytesScannedCutoffPerQuery": 20000000
+                  }
+                }
+                """)
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200);
+
+        given()
+            .header("X-Amz-Target", "AmazonAthena.UpdateWorkGroup")
+            .contentType(CONTENT_TYPE)
+            .body("""
+                {
+                  "WorkGroup": "analytics-invalid-cutoff",
+                  "Description": "after",
+                  "ConfigurationUpdates": {
+                    "BytesScannedCutoffPerQuery": 9999999
+                  }
+                }
+                """)
+        .when()
+            .post("/")
+        .then()
+            .statusCode(400)
+            .body("__type", equalTo("InvalidRequestException"));
+
+        given()
+            .header("X-Amz-Target", "AmazonAthena.GetWorkGroup")
+            .contentType(CONTENT_TYPE)
+            .body("{ \"WorkGroup\": \"analytics-invalid-cutoff\" }")
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200)
+            .body("WorkGroup.Description", equalTo("before"))
+            .body("WorkGroup.Configuration.BytesScannedCutoffPerQuery", equalTo(20000000));
+    }
+
+    @Test
+    void updateWorkGroupRejectsEmptySelectedEngineVersionWithoutApplyingOtherChanges() {
+        given()
+            .header("X-Amz-Target", "AmazonAthena.CreateWorkGroup")
+            .contentType(CONTENT_TYPE)
+            .body("""
+                {
+                  "Name": "analytics-invalid-engine",
+                  "Description": "before"
+                }
+                """)
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200);
+
+        given()
+            .header("X-Amz-Target", "AmazonAthena.UpdateWorkGroup")
+            .contentType(CONTENT_TYPE)
+            .body("""
+                {
+                  "WorkGroup": "analytics-invalid-engine",
+                  "Description": "after",
+                  "ConfigurationUpdates": {
+                    "EngineVersion": {
+                      "SelectedEngineVersion": ""
+                    }
+                  }
+                }
+                """)
+        .when()
+            .post("/")
+        .then()
+            .statusCode(400)
+            .body("__type", equalTo("InvalidRequestException"));
+
+        given()
+            .header("X-Amz-Target", "AmazonAthena.GetWorkGroup")
+            .contentType(CONTENT_TYPE)
+            .body("{ \"WorkGroup\": \"analytics-invalid-engine\" }")
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200)
+            .body("WorkGroup.Description", equalTo("before"))
+            .body("WorkGroup.Configuration.EngineVersion.SelectedEngineVersion",
+                    equalTo("Athena engine version 3"));
+    }
 }


### PR DESCRIPTION
## Summary

Adds AWS-compatible Athena `UpdateWorkGroup` support for updating a workgroup's description, state, and configuration while preserving omitted settings.

The implementation supports output location and byte cutoff removal flags, engine-version resolution, persistent storage, and updates to the built-in `primary` workgroup.

Closes #3418

## Type of change

- [ ] Bug fix (`fix:`)
- [x] New feature (`feat:`)
- [ ] Breaking change (`feat!:` or `fix!:`)
- [ ] Docs / chore

## AWS Compatibility

- Verified an Athena create, update, and get round trip with AWS SDK for Java v2.52.0.
- Verified the same round trip with AWS CLI 2.36.8.
- Uses the existing AWS JSON 1.1 endpoint and `AmazonAthena.UpdateWorkGroup` target.

## Testing

- `./mvnw test '-Dtest=Athena*Test'`: 63 tests passed.
- `AthenaTest#updateWorkGroupRoundTripsThroughSdk`: passed against a live local Floci instance.
- `make docs-sync`: generated documentation is current.

## Checklist

- [ ] `./mvnw test` passes locally
- [x] New or updated integration test added
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)

The full suite was not run per the requested Athena-only test scope.
