### PR TITLE
fix(storage): load each backend once and close WAL writers on shutdown

### DIFF
--- a/src/main/java/io/github/hectorvent/floci/core/storage/StorageFactory.java
+++ b/src/main/java/io/github/hectorvent/floci/core/storage/StorageFactory.java
@@ -11,9 +11,12 @@ import org.jboss.logging.Logger;
 
 import java.nio.file.Path;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.HashMap;
+import java.util.IdentityHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 
 /**
  * Factory that creates {@link AccountAwareStorageBackend} instances based on configuration.
@@ -34,6 +37,10 @@ public class StorageFactory {
     private final Map<Path, StorageBackend<?, ?>> backendsByPath = new HashMap<>();
     private final List<HybridStorage<?, ?>> hybridBackends = new ArrayList<>();
     private final List<WalStorage<?, ?>> walBackends = new ArrayList<>();
+    // Backends whose initial load has completed. create() loads each backend exactly once and
+    // loadAll() only picks up backends that were never loaded, so neither path replays a store
+    // that is already live or opens a second WAL writer on top of the first.
+    private final Set<StorageBackend<?, ?>> loadedBackends = Collections.newSetFromMap(new IdentityHashMap<>());
 
     @Inject
     Instance<RequestContext> requestContextInstance;
@@ -93,20 +100,30 @@ public class StorageFactory {
             default -> throw new IllegalArgumentException("Unknown storage mode: " + mode);
         };
 
-        inner.load();
-
         AccountAwareStorageBackend<V> backend = new AccountAwareStorageBackend<>(
                 inner, requestContextInstance, config.defaultAccountId());
+        // create() owns the initial load. Most services are lazily instantiated and only reach
+        // this point after the lifecycle's loadAll() has already run, so a backend that is not
+        // loaded here would serve an empty store and (for WAL) never open its writer (#71).
+        loadOnce(backend);
         allBackends.add(backend);
         backendsByPath.put(filePath, backend);
         return backend;
     }
 
-    /** Load all storage backends from disk. */
+    /** Load every managed backend that has not been loaded yet. Safe to call repeatedly. */
     public synchronized void loadAll() {
         for (StorageBackend<?, ?> backend : allBackends) {
-            backend.load();
+            loadOnce(backend);
         }
+    }
+
+    private void loadOnce(StorageBackend<?, ?> backend) {
+        if (loadedBackends.contains(backend)) {
+            return;
+        }
+        backend.load();
+        loadedBackends.add(backend);
     }
 
     /** Flush all storage backends to disk. */
@@ -124,15 +141,19 @@ public class StorageFactory {
         flushAll();
     }
 
-    /** Shutdown all managed backends (stop schedulers, close connections). */
+    /**
+     * Shutdown all managed backends (stop schedulers, close connections). The final flush runs
+     * first: a WAL flush compacts and reopens the writer, so flushing after shutdown would leave
+     * every WAL backend with an open writer that nothing closes.
+     */
     public synchronized void shutdownAll() {
+        flushAll();
         for (HybridStorage<?, ?> hybrid : hybridBackends) {
             hybrid.shutdown();
         }
         for (WalStorage<?, ?> wal : walBackends) {
             wal.shutdown();
         }
-        flushAll();
     }
 
     private String resolveMode(String serviceName) {

--- a/src/test/java/io/github/hectorvent/floci/core/storage/StorageFactoryLifecycleTest.java
+++ b/src/test/java/io/github/hectorvent/floci/core/storage/StorageFactoryLifecycleTest.java
@@ -1,0 +1,128 @@
+package io.github.hectorvent.floci.core.storage;
+
+import com.fasterxml.jackson.core.type.TypeReference;
+import io.github.hectorvent.floci.config.EmulatorConfig;
+import io.github.hectorvent.floci.core.common.ServiceConfigAccess;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Map;
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.RETURNS_DEEP_STUBS;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+/**
+ * Lifecycle contract of {@link StorageFactory}: {@code create()} owns the initial load of each
+ * backend, {@code loadAll()} never reloads a live backend, and {@code shutdownAll()} performs the
+ * final flush and then leaves no open WAL writer behind.
+ */
+class StorageFactoryLifecycleTest {
+
+    private static final TypeReference<Map<String, String>> TYPE = new TypeReference<>() {};
+
+    @TempDir
+    Path tempDir;
+
+    @Test
+    void loadAllDoesNotReplayABackendThatCreateAlreadyLoaded() {
+        StorageFactory factory = newFactory("hybrid");
+        AccountAwareStorageBackend<String> backend = factory.create("svc", "svc.json", TYPE);
+        backend.put("seed", "v1");
+        factory.flushAll();
+        backend.put("unflushed", "v2");
+
+        // Boot calls loadAll() once; a second call must be just as harmless. A reload of the
+        // hybrid store would clear it and drop the write that has not been flushed yet.
+        factory.loadAll();
+        factory.loadAll();
+
+        assertEquals(Optional.of("v1"), backend.get("seed"));
+        assertEquals(Optional.of("v2"), backend.get("unflushed"));
+        factory.shutdownAll();
+    }
+
+    @Test
+    void createLoadsPersistedStateForBackendsRegisteredAfterLoadAll() {
+        StorageFactory first = newFactory("wal");
+        first.create("svc", "svc.json", TYPE).put("persisted", "v1");
+        first.shutdownAll();
+
+        // Lazily instantiated services register their backend after the lifecycle's loadAll().
+        StorageFactory second = newFactory("wal");
+        second.loadAll();
+        AccountAwareStorageBackend<String> late = second.create("svc", "svc.json", TYPE);
+        assertEquals(Optional.of("v1"), late.get("persisted"));
+        late.put("written-late", "v2");
+        second.shutdownAll();
+
+        StorageFactory third = newFactory("wal");
+        AccountAwareStorageBackend<String> reloaded = third.create("svc", "svc.json", TYPE);
+        assertEquals(Optional.of("v1"), reloaded.get("persisted"));
+        assertEquals(Optional.of("v2"), reloaded.get("written-late"));
+        third.shutdownAll();
+    }
+
+    @Test
+    void shutdownFlushesAndLeavesNoOpenWalWriter() throws IOException {
+        StorageFactory factory = newFactory("wal");
+        AccountAwareStorageBackend<String> backend = factory.create("svc", "svc.json", TYPE);
+        backend.put("before", "v1");
+        factory.loadAll();
+        factory.flushAll();
+        factory.loadAll();
+
+        factory.shutdownAll();
+
+        assertTrue(Files.readString(tempDir.resolve("svc-snapshot.json")).contains("before"),
+                "final shutdown must flush the store into the snapshot");
+        long walSizeAfterShutdown = walSize();
+        backend.put("after", "v2");
+        assertEquals(walSizeAfterShutdown, walSize(), "no WAL writer may be open after shutdown");
+    }
+
+    @Test
+    void shutdownIsSafeAfterACompletedFlushAndCanBeRepeated() throws IOException {
+        StorageFactory factory = newFactory("wal");
+        AccountAwareStorageBackend<String> backend = factory.create("svc", "svc.json", TYPE);
+        backend.put("before", "v1");
+        factory.flushAll();
+
+        factory.shutdownAll();
+        assertDoesNotThrow(factory::shutdownAll);
+
+        long walSizeAfterShutdown = walSize();
+        backend.put("after", "v2");
+        assertEquals(walSizeAfterShutdown, walSize(), "no WAL writer may be open after shutdown");
+
+        StorageFactory reloaded = newFactory("wal");
+        AccountAwareStorageBackend<String> again = reloaded.create("svc", "svc.json", TYPE);
+        assertEquals(Optional.of("v1"), again.get("before"));
+        assertEquals(Optional.empty(), again.get("after"));
+        reloaded.shutdownAll();
+    }
+
+    private long walSize() throws IOException {
+        Path wal = tempDir.resolve("svc.wal");
+        return Files.exists(wal) ? Files.size(wal) : 0L;
+    }
+
+    private StorageFactory newFactory(String mode) {
+        EmulatorConfig config = mock(EmulatorConfig.class, RETURNS_DEEP_STUBS);
+        when(config.defaultAccountId()).thenReturn("000000000000");
+        when(config.storage().persistentPath()).thenReturn(tempDir.toString());
+        when(config.storage().wal().compactionIntervalMs()).thenReturn(60_000L);
+        ServiceConfigAccess serviceConfigAccess = mock(ServiceConfigAccess.class);
+        when(serviceConfigAccess.storageMode(anyString())).thenReturn(mode);
+        when(serviceConfigAccess.storageFlushInterval(anyString())).thenReturn(60_000L);
+        return new StorageFactory(config, serviceConfigAccess);
+    }
+}


### PR DESCRIPTION
## Summary

Make `StorageFactory` load each backend exactly once and finish shutdown with every WAL writer closed.

`shutdownAll()` ran `flushAll()` after the WAL backends were shut down. A WAL flush compacts and reopens the writer, so shutdown left every WAL backend with an open writer that nothing closed. `loadAll()` also reloaded backends that `create()` had already loaded (the create-time load from #71), which replayed live stores and opened a second WAL writer on top of the first.

`create()` now owns the initial load, `loadAll()` only loads backends that have not been loaded yet, and `shutdownAll()` flushes first and then shuts the backends down. Memory, persistent and hybrid behavior is unchanged, and lazily created services still see persisted state because the create-time load is kept.

## Type of change

- [x] Bug fix (`fix:`)
- [ ] New feature (`feat:`)
- [ ] Breaking change (`feat!:` or `fix!:`)
- [ ] Docs / chore

## AWS Compatibility

Emulator lifecycle only; no wire protocol changes.

Before: after shutdown a WAL backend still had an open writer, and a second `loadAll()` replayed stores that were already live (dropping unflushed hybrid writes, opening duplicate WAL writers). After: each backend is loaded once, the final flush lands in the snapshot, and no WAL writer stays open.

New `StorageFactoryLifecycleTest` covers: load-once across repeated `loadAll()` calls, a backend created after `loadAll()` seeing persisted state and persisting its own writes, shutdown flushing and leaving no open WAL writer, and repeated shutdown after a completed flush. Focused runs of `StorageFactoryLifecycleTest`, `WalStorageTest`, `HybridStorageTest`, `PersistentStorageTest`, `StorageFactoryDuplicateBackendTest` and `StorageFactoryServiceCatalogIntegrationTest` pass; `./mvnw package -DskipTests` passes.

## Checklist

- [ ] `./mvnw test` passes locally
- [x] New or updated integration test added
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
