### PR TITLE
fix(lifecycle): run every shutdown step even when one of them fails

### DIFF
--- a/src/main/java/io/github/hectorvent/floci/lifecycle/EmulatorLifecycle.java
+++ b/src/main/java/io/github/hectorvent/floci/lifecycle/EmulatorLifecycle.java
@@ -302,24 +302,26 @@ public class EmulatorLifecycle {
         // SIGTERM grace window and trigger SIGKILL; if the flush ran last it would be skipped and
         // in-memory (hybrid) data would be lost on an otherwise-graceful shutdown. shutdownAll()
         // still runs at the end to stop the flush schedulers and capture any shutdown-time writes.
-        storageFactory.flushAll();
-        if (config.services().ec2().enabled() && !config.services().ec2().mock()) {
-            ec2MetadataServer.stop();
-        }
-        elastiCacheProxyManager.stopAll();
-        rdsProxyManager.stopAll();
-        memoryDbProxyManager.stopAll();
-        neptuneProxyManager.stopAll();
-        elastiCacheContainerManager.stopAll();
-        elastiCacheMemcachedContainerManager.stopAll();
-        rdsContainerManager.stopAll();
-        memoryDbContainerManager.stopAll();
-        docDbContainerManager.stopAll();
-        neptuneContainerManager.stopAll();
-        rabbitMqManager.stopAll();
-        flinkContainerManager.stopAll();
-        ecrRegistryManager.shutdown();
-        flociUiManager.shutdown();
+        runCleanup("storage flush", storageFactory::flushAll);
+        runCleanup("EC2 metadata server", () -> {
+            if (config.services().ec2().enabled() && !config.services().ec2().mock()) {
+                ec2MetadataServer.stop();
+            }
+        });
+        runCleanup("ElastiCache proxy", elastiCacheProxyManager::stopAll);
+        runCleanup("RDS proxy", rdsProxyManager::stopAll);
+        runCleanup("MemoryDB proxy", memoryDbProxyManager::stopAll);
+        runCleanup("Neptune proxy", neptuneProxyManager::stopAll);
+        runCleanup("ElastiCache container", elastiCacheContainerManager::stopAll);
+        runCleanup("ElastiCache Memcached container", elastiCacheMemcachedContainerManager::stopAll);
+        runCleanup("RDS container", rdsContainerManager::stopAll);
+        runCleanup("MemoryDB container", memoryDbContainerManager::stopAll);
+        runCleanup("DocDB container", docDbContainerManager::stopAll);
+        runCleanup("Neptune container", neptuneContainerManager::stopAll);
+        runCleanup("RabbitMQ", rabbitMqManager::stopAll);
+        runCleanup("Flink", flinkContainerManager::stopAll);
+        runCleanup("ECR registry", ecrRegistryManager::shutdown);
+        runCleanup("Floci UI", flociUiManager::shutdown);
         // Centralized teardown for process-bound containers (Lambda warm pool, ECS tasks,
         // EC2 instances, in-flight build/job containers). Runs before shutdownAll() so any
         // state written while stopping is captured by the final flush.
@@ -331,8 +333,16 @@ public class EmulatorLifecycle {
                         teardown.getClass().getSimpleName(), e.getMessage());
             }
         }
-        storageFactory.shutdownAll();
+        runCleanup("storage shutdown", storageFactory::shutdownAll);
 
         LOG.info("=== AWS Local Emulator Stopped ===");
+    }
+
+    private void runCleanup(String resource, Runnable cleanup) {
+        try {
+            cleanup.run();
+        } catch (RuntimeException e) {
+            LOG.warnv(e, "Shutdown cleanup failed for {0}; continuing with the remaining steps", resource);
+        }
     }
 }

--- a/src/test/java/io/github/hectorvent/floci/lifecycle/EmulatorLifecycleTest.java
+++ b/src/test/java/io/github/hectorvent/floci/lifecycle/EmulatorLifecycleTest.java
@@ -444,6 +444,40 @@ class EmulatorLifecycleTest {
     }
 
     @Test
+    @DisplayName("Should continue cleanup and shut down storage when the initial flush fails")
+    void shouldContinueCleanupWhenInitialFlushFails() {
+        doThrow(new IllegalStateException("flush failed")).when(storageFactory).flushAll();
+
+        emulatorLifecycle.onStop(Mockito.mock(ShutdownEvent.class));
+
+        verify(elastiCacheProxyManager).stopAll();
+        verify(rdsProxyManager).stopAll();
+        verify(storageFactory).shutdownAll();
+    }
+
+    @Test
+    @DisplayName("Should continue cleanup after a middle resource cleanup fails")
+    void shouldContinueCleanupAfterMiddleResourceFailure() {
+        doThrow(new IllegalStateException("proxy failed")).when(rdsProxyManager).stopAll();
+
+        emulatorLifecycle.onStop(Mockito.mock(ShutdownEvent.class));
+
+        verify(memoryDbProxyManager).stopAll();
+        verify(neptuneProxyManager).stopAll();
+        verify(storageFactory).shutdownAll();
+    }
+
+    @Test
+    @DisplayName("Should shut down storage when a late resource cleanup fails")
+    void shouldShutDownStorageAfterLateResourceFailure() {
+        doThrow(new IllegalStateException("UI shutdown failed")).when(flociUiManager).shutdown();
+
+        emulatorLifecycle.onStop(Mockito.mock(ShutdownEvent.class));
+
+        verify(storageFactory).shutdownAll();
+    }
+
+    @Test
     @DisplayName("Should still run full resource cleanup when a pre-shutdown hook fails")
     void shouldRunFullCleanupAfterFailingPreShutdownHook() throws IOException, InterruptedException {
         doThrow(new IOException("hook blew up")).when(initializationHooksRunner).run(InitializationHook.STOP);


### PR DESCRIPTION
## Summary

Isolate the shutdown cleanup steps in `EmulatorLifecycle.onStop` so one failing step no longer skips the rest.

The steps ran as one straight sequence. A `RuntimeException` from any of them (a proxy manager, a container manager, the ECR registry, the UI) skipped everything after it, including the final storage shutdown, so WAL and hybrid stores were left unflushed and open.

Each step now runs through a small `runCleanup` wrapper: a failure is logged with the resource name and stack trace, the remaining steps still run, and storage shutdown always runs last. The existing order is unchanged.

## Type of change

- [x] Bug fix (`fix:`)
- [ ] New feature (`feat:`)
- [ ] Breaking change (`feat!:` or `fix!:`)
- [ ] Docs / chore

## AWS Compatibility

Emulator lifecycle only; no wire protocol changes. Before: a stop failure in any resource could leave persisted stores unflushed. After: storage shutdown runs regardless of earlier failures.

New `EmulatorLifecycleTest` cases: an early failure (initial flush), a middle failure (RDS proxy) and a late failure (Floci UI) each still run the later steps and storage shutdown; the existing order test is unchanged. `EmulatorLifecycleTest` (29 tests) passes; `./mvnw package -DskipTests` passes.

## Checklist

- [ ] `./mvnw test` passes locally
- [x] New or updated integration test added
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
