### PR TITLE
fix(test): wait for DeleteStack to actually complete in CloudFront policies test

### DIFF
--- a/src/test/java/io/github/hectorvent/floci/services/cloudformation/CloudFormationCloudFrontPoliciesIntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/cloudformation/CloudFormationCloudFrontPoliciesIntegrationTest.java
@@ -16,7 +16,6 @@ import java.util.List;
 import java.util.Map;
 
 import static io.restassured.RestAssured.given;
-import static org.hamcrest.Matchers.containsString;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
@@ -267,16 +266,39 @@ class CloudFormationCloudFrontPoliciesIntegrationTest {
             .post("/")
         .then()
             .statusCode(200);
-        given()
-            .contentType("application/x-www-form-urlencoded")
-            .header("Authorization", CFN_AUTH)
-            .formParam("Action", "DescribeStacks")
-            .formParam("StackName", stackName)
-        .when()
-            .post("/")
-        .then()
-            .statusCode(400)
-            .body(containsString("Stack with id " + stackName + " does not exist"));
+        awaitStackDeleted(stackName);
+    }
+
+    /**
+     * github.com/floci-io/floci/issues/3365: DeleteStack answers before the stack is actually
+     * gone - deletion runs on an executor (CloudFormationService.deleteStack) - so a DescribeStacks
+     * call made immediately after DeleteStack's 200 races that executor and intermittently still
+     * finds the stack. Polls until DescribeStacks reports the stack unknown, matching the
+     * awaitStackDeleted helper CloudFormationIntegrationTest already uses for the same race.
+     */
+    private static void awaitStackDeleted(String stackName) {
+        long deadline = System.currentTimeMillis() + 10_000;
+        while (System.currentTimeMillis() < deadline) {
+            String body = given()
+                .contentType("application/x-www-form-urlencoded")
+                .header("Authorization", CFN_AUTH)
+                .formParam("Action", "DescribeStacks")
+                .formParam("StackName", stackName)
+            .when()
+                .post("/")
+            .then()
+                .extract().body().asString();
+            if (body.contains("Stack with id " + stackName + " does not exist")) {
+                return;
+            }
+            try {
+                Thread.sleep(200);
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+                throw new AssertionError("Interrupted while waiting for stack " + stackName + " to be deleted", e);
+            }
+        }
+        fail("Stack " + stackName + " did not become unknown to DescribeStacks within timeout");
     }
 
     private static String describeStacks(String stackName) {


### PR DESCRIPTION
## Summary

Fixes #3365. `CloudFormationCloudFrontPoliciesIntegrationTest.distributionRefToAResponseHeadersPolicyInTheSameStackResolves` intermittently fails CI with:

```
Expected status code <400> but was <200>.
```

on the `DescribeStacks` call immediately following this test's `deleteStack()` helper.

`CloudFormationService.deleteStack()` dispatches the actual resource cleanup onto an executor and returns before it completes (documented on the method itself: *"a future that completes when the resources have been removed"*). `CloudFormationIntegrationTest` already has an `awaitStackDeleted` helper for exactly this race, added because "DeleteStack answers before the stack is gone." This test class's own `deleteStack` helper never got that treatment and asserted the stack gone synchronously right after `DeleteStack`'s 200, which races the executor and only fails when the executor hasn't caught up yet - hence the intermittency.

## Type of change

- [x] Bug fix (`fix:`)
- [ ] New feature (`feat:`)
- [ ] Breaking change (`feat!:` or `fix!:`)
- [ ] Docs / chore

## AWS Compatibility

N/A - test-only change. `DeleteStack` itself is fine (and correctly asynchronous, matching real AWS); only the test's assumption about when deletion becomes visible was wrong.

## Checklist

- [x] `./mvnw test` passes locally (full `cloudformation` package: 1660 tests; the only failures are three known pre-existing flakes unrelated to this change - two 30s `SocketTimeoutException`s and one staging-directory extraction race, none touching CloudFront or `DeleteStack`)
- [x] Updated existing test (adds a poll helper mirroring `CloudFormationIntegrationTest.awaitStackDeleted`, an already-proven fix for this exact class of race in the same suite)
- [x] Commit messages follow Conventional Commits
