### PR TITLE
test(cloudformation): pin account scoping of ListStacks and DescribeStackResources

### DIFF
--- a/src/test/java/io/github/hectorvent/floci/services/cloudformation/CloudFormationAccountOwnershipIntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/cloudformation/CloudFormationAccountOwnershipIntegrationTest.java
@@ -8,6 +8,7 @@ import org.junit.jupiter.api.Test;
 import static io.restassured.RestAssured.given;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.not;
+import static org.hamcrest.Matchers.startsWith;
 
 @QuarkusTest
 class CloudFormationAccountOwnershipIntegrationTest {
@@ -89,6 +90,60 @@ class CloudFormationAccountOwnershipIntegrationTest {
                 .body(not(containsString("Changed")));
     }
 
+    @Test
+    void listStacksIsScopedToCallerAccount() {
+        createStack(ACCOUNT_1, US_EAST_1, "cfn-list-scope-account-1");
+        createStack(ACCOUNT_2, US_EAST_1, "cfn-list-scope-account-2");
+
+        listStacks(ACCOUNT_1, US_EAST_1)
+                .statusCode(200)
+                .body(containsString("<StackName>cfn-list-scope-account-1</StackName>"))
+                .body(not(containsString("<StackName>cfn-list-scope-account-2</StackName>")));
+        listStacks(ACCOUNT_2, US_EAST_1)
+                .statusCode(200)
+                .body(containsString("<StackName>cfn-list-scope-account-2</StackName>"))
+                .body(not(containsString("<StackName>cfn-list-scope-account-1</StackName>")));
+    }
+
+    @Test
+    void assumedRoleCredentialsScopeListStacksAndDescribeStackResources() {
+        createStack(ACCOUNT_1, US_EAST_1, "cfn-management-stack",
+                "{\"Resources\":{\"ManagementBucket\":{\"Type\":\"AWS::S3::Bucket\"}}}");
+
+        String memberAccessKeyId = given()
+                .header("Authorization", auth(ACCOUNT_1, US_EAST_1, "sts"))
+                .contentType("application/x-www-form-urlencoded")
+                .formParam("Action", "AssumeRole")
+                .formParam("RoleArn", "arn:aws:iam::" + ACCOUNT_2 + ":role/cfn-member-deploy-role")
+                .formParam("RoleSessionName", "cfn-member-session")
+                .when().post("/").then()
+                .statusCode(200)
+                .body("AssumeRoleResponse.AssumeRoleResult.Credentials.AccessKeyId", startsWith("ASIA"))
+                .extract().path("AssumeRoleResponse.AssumeRoleResult.Credentials.AccessKeyId");
+
+        createStack(memberAccessKeyId, US_EAST_1, "cfn-member-stack",
+                "{\"Resources\":{\"MemberBucket\":{\"Type\":\"AWS::S3::Bucket\"}}}");
+
+        listStacks(memberAccessKeyId, US_EAST_1)
+                .statusCode(200)
+                .body(containsString("<StackName>cfn-member-stack</StackName>"))
+                .body(not(containsString("<StackName>cfn-management-stack</StackName>")));
+        listStacks(ACCOUNT_1, US_EAST_1)
+                .statusCode(200)
+                .body(containsString("<StackName>cfn-management-stack</StackName>"))
+                .body(not(containsString("<StackName>cfn-member-stack</StackName>")));
+
+        describeStackResources(memberAccessKeyId, US_EAST_1, "cfn-member-stack")
+                .statusCode(200)
+                .body(containsString("MemberBucket"));
+        describeStackResources(memberAccessKeyId, US_EAST_1, "cfn-management-stack")
+                .statusCode(400)
+                .body(containsString("does not exist"));
+        describeStackResources(ACCOUNT_1, US_EAST_1, "cfn-member-stack")
+                .statusCode(400)
+                .body(containsString("does not exist"));
+    }
+
     private static String createStack(String account, String region, String name) {
         return createStack(account, region, name, "{\"Resources\":{}}");
     }
@@ -132,6 +187,13 @@ class CloudFormationAccountOwnershipIntegrationTest {
                 .when().post("/").then();
     }
 
+    private static io.restassured.response.ValidatableResponse listStacks(String accessKeyId, String region) {
+        return given().header("Authorization", auth(accessKeyId, region))
+                .contentType("application/x-www-form-urlencoded")
+                .formParam("Action", "ListStacks")
+                .when().post("/").then();
+    }
+
     private static io.restassured.response.ValidatableResponse listExports(String account, String region) {
         return given().header("Authorization", auth(account, region))
                 .contentType("application/x-www-form-urlencoded")
@@ -139,9 +201,13 @@ class CloudFormationAccountOwnershipIntegrationTest {
                 .when().post("/").then();
     }
 
-    private static String auth(String account, String region) {
-        return "AWS4-HMAC-SHA256 Credential=" + account
-                + "/20260907/" + region + "/cloudformation/aws4_request,"
+    private static String auth(String accessKeyId, String region) {
+        return auth(accessKeyId, region, "cloudformation");
+    }
+
+    private static String auth(String accessKeyId, String region, String service) {
+        return "AWS4-HMAC-SHA256 Credential=" + accessKeyId
+                + "/20260907/" + region + "/" + service + "/aws4_request,"
                 + " SignedHeaders=host, Signature=abc";
     }
 }


### PR DESCRIPTION

## Summary

Closes #2248.

#2248 reports that `ListStacks` and `DescribeStackResources` ignored the caller's account, so
assumed-role credentials for a member account returned the management account's stacks from two
of the three read APIs while `DescribeStacks` scoped correctly. That is already fixed on `main`:
#3185 threaded the request-scoped account through every stack read, including both of these,
but it did not reference the issue, so it stayed open.

What #3185 did not do is test the two operations the issue names. Its test class never calls
`ListStacks`, and only calls `DescribeStackResources` from the owning account. With the account
filter removed from either service method, every existing test in that class still passes. This
PR adds the missing regression tests so the fix cannot silently regress, and closes the issue.

Before (main at 2026-08-11, when the issue was filed):

```bash
# Management account 000000000001 owns a stack; the caller has assumed a role in 000000000002.
aws cloudformation list-stacks --query 'StackSummaries[].StackName'
# ["cfn-management-stack"]                      <- another account's stack

aws cloudformation describe-stack-resources --stack-name cfn-management-stack \
  --query 'StackResources[].LogicalResourceId'
# ["ManagementBucket"]                          <- resolved another account's stack

aws cloudformation describe-stacks --stack-name cfn-management-stack
# ValidationError: Stack with id cfn-management-stack does not exist   <- correct
```

After (main today, with #3185):

```bash
aws cloudformation list-stacks --query 'StackSummaries[].StackName'
# []
aws cloudformation describe-stack-resources --stack-name cfn-management-stack
# ValidationError: Stack with id cfn-management-stack does not exist
aws cloudformation describe-stacks --stack-name cfn-management-stack
# ValidationError: Stack with id cfn-management-stack does not exist
```

Root cause of the original report: `listStacks(region)` filtered by region only and
`describeStackResources` resolved the stack key without an account, while `describeStacks` took
the caller's account. #3185 introduced `currentAccount()` and routed all three through it.

## Type of change

- [ ] Bug fix (`fix:`)
- [ ] New feature (`feat:`)
- [ ] Breaking change (`feat!:` or `fix!:`)
- [x] Docs / chore (test only)

## AWS Compatibility

No production code changes. The tests assert the AWS shape: a stack that belongs to another
account is invisible to `ListStacks` and `DescribeStackResources` returns `400 ValidationError`
"Stack with id X does not exist", the same error `DescribeStacks` already returns.

Two tests in `CloudFormationAccountOwnershipIntegrationTest`:

- `listStacksIsScopedToCallerAccount`: two accounts each create a stack; each `ListStacks`
  contains only its own.
- `assumedRoleCredentialsScopeListStacksAndDescribeStackResources`: the scenario from the issue.
  Account `000000000001` creates a stack, assumes a role in `000000000002` via STS, creates a
  stack with the `ASIA` key, then asserts `ListStacks` from each side lists only its own stack,
  `DescribeStackResources` with the temporary key returns the member stack's resource and a 400
  for the management stack, and the management key gets a 400 for the member stack.

Helpers: `listStacks(accessKeyId, region)` and an `auth(accessKeyId, region, service)` overload
so `AssumeRole` can sign with the `sts` scope. The existing two-argument `auth` delegates to it.

Verified the tests are not vacuous by temporarily removing the account filter from
`listStacks` (region-only, the pre-#3185 shape) and from `describeStackResources` (resolve by
name and region across accounts): pre-existing tests all pass under both mutations; the new
tests fail under each (`ListStacks` contains the foreign stack; expected 400, got 200). Both
mutations were reverted and are not in this diff.

## Checklist

- [x] `./mvnw test` passes locally: the CloudFormation package, its `provisioners` subpackage and
  `AssumedRoleAccountRoutingIntegrationTest` (167 classes) at 1,682 tests before and 1,684 after,
  0 failures, 0 errors, 0 skipped. Full suite not run; no production code changed.
- [x] New or updated integration test added
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
