### PR TITLE
fix(s3): decode unsigned streaming checksum payloads

### DIFF
--- a/src/main/java/io/github/hectorvent/floci/services/s3/S3Controller.java
+++ b/src/main/java/io/github/hectorvent/floci/services/s3/S3Controller.java
@@ -1922,9 +1922,11 @@ public class S3Controller {
      * Format: hex-size;chunk-signature=sig\r\n data \r\n ... 0;chunk-signature=sig\r\n
      */
     private byte[] decodeAwsChunked(byte[] body, String contentEncoding, String contentSha256) {
-        boolean isAwsChunked = (contentEncoding != null && contentEncoding.contains("aws-chunked"))
+        boolean isAwsChunked = (contentEncoding != null
+                && contentEncoding.toLowerCase(Locale.ROOT).contains("aws-chunked"))
                 || "STREAMING-AWS4-HMAC-SHA256-PAYLOAD".equals(contentSha256)
-                || "STREAMING-AWS4-HMAC-SHA256-PAYLOAD-TRAILER".equals(contentSha256);
+                || "STREAMING-AWS4-HMAC-SHA256-PAYLOAD-TRAILER".equals(contentSha256)
+                || "STREAMING-UNSIGNED-PAYLOAD-TRAILER".equals(contentSha256);
         if (!isAwsChunked) {
             return body;
         }

--- a/src/test/java/io/github/hectorvent/floci/services/s3/S3FlexibleChecksumIntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/s3/S3FlexibleChecksumIntegrationTest.java
@@ -1,0 +1,72 @@
+package io.github.hectorvent.floci.services.s3;
+
+import io.github.hectorvent.floci.services.s3.model.S3Checksum;
+import io.quarkus.test.junit.QuarkusTest;
+import io.restassured.config.DecoderConfig;
+import io.restassured.config.RestAssuredConfig;
+import io.restassured.response.Response;
+import org.junit.jupiter.api.Test;
+
+import java.io.ByteArrayOutputStream;
+import java.nio.charset.StandardCharsets;
+import java.util.zip.GZIPOutputStream;
+
+import static io.restassured.RestAssured.given;
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+@QuarkusTest
+class S3FlexibleChecksumIntegrationTest {
+
+    @Test
+    void putObjectDecodesUnsignedAwsChunkedPayloadWithChecksumTrailer() throws Exception {
+        String bucket = "flexible-checksum-bucket";
+        String key = "when-supported.gz";
+        byte[] original = gzip("{\"hello\":\"world\"}");
+        byte[] framed = awsChunked(original, S3Checksum.crc32Base64(original));
+
+        given()
+                .when().put("/" + bucket)
+                .then().statusCode(200);
+
+        given()
+                .contentType("application/octet-stream")
+                .header("Content-Encoding", "gzip")
+                .header("x-amz-content-sha256", "STREAMING-UNSIGNED-PAYLOAD-TRAILER")
+                .header("x-amz-decoded-content-length", original.length)
+                .header("x-amz-trailer", "x-amz-checksum-crc32")
+                .body(framed)
+                .when().put("/" + bucket + "/" + key)
+                .then().statusCode(200);
+
+        RestAssuredConfig noDecompression = RestAssuredConfig.config()
+                .decoderConfig(DecoderConfig.decoderConfig().noContentDecoders());
+        Response response = given()
+                .config(noDecompression)
+                .when().get("/" + bucket + "/" + key)
+                .then().statusCode(200)
+                .extract().response();
+
+        assertEquals("gzip", response.header("Content-Encoding"));
+        assertArrayEquals(original, response.asByteArray());
+    }
+
+    private static byte[] gzip(String value) throws Exception {
+        ByteArrayOutputStream output = new ByteArrayOutputStream();
+        try (GZIPOutputStream gzip = new GZIPOutputStream(output)) {
+            gzip.write(value.getBytes(StandardCharsets.UTF_8));
+        }
+        return output.toByteArray();
+    }
+
+    private static byte[] awsChunked(byte[] payload, String checksum) throws Exception {
+        ByteArrayOutputStream output = new ByteArrayOutputStream();
+        output.write(Integer.toHexString(payload.length).getBytes(StandardCharsets.US_ASCII));
+        output.write("\r\n".getBytes(StandardCharsets.US_ASCII));
+        output.write(payload);
+        output.write("\r\n0\r\nx-amz-checksum-crc32:".getBytes(StandardCharsets.US_ASCII));
+        output.write(checksum.getBytes(StandardCharsets.US_ASCII));
+        output.write("\r\n\r\n".getBytes(StandardCharsets.US_ASCII));
+        return output.toByteArray();
+    }
+}


### PR DESCRIPTION
## Summary

Recognize the `STREAMING-UNSIGNED-PAYLOAD-TRAILER` content hash used by AWS SDK for Java v2 flexible checksums and decode its `aws-chunked` body before persisting an S3 object. Content-encoding detection is also case-insensitive.

Closes #3413

## Type of change

- [x] Bug fix (`fix:`)
- [ ] New feature (`feat:`)
- [ ] Breaking change (`feat!:` or `fix!:`)
- [ ] Docs / chore

## AWS Compatibility

The SDK's default `RequestChecksumCalculation.WHEN_SUPPORTED` upload path sends an unsigned streaming payload with a checksum trailer. Floci did not recognize that content hash variant, so the chunk-size line and trailer could be stored as object bytes. The integration test sends the same wire framing and verifies that the original gzip bytes and content encoding round-trip unchanged.

## Testing

- `S3FlexibleChecksumIntegrationTest`
- 1 end-to-end regression test passed

## Checklist

- [x] Focused test suite passes locally
- [x] New or updated integration test added
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
