### PR TITLE
fix(stepfunctions): preserve Lambda function errors

### DIFF
--- a/src/main/java/io/github/hectorvent/floci/services/stepfunctions/AslExecutor.java
+++ b/src/main/java/io/github/hectorvent/floci/services/stepfunctions/AslExecutor.java
@@ -946,7 +946,7 @@ public class AslExecutor {
             InvokeResult result = lambdaExecutor.invoke(fn, payloadBytes, InvocationType.RequestResponse);
 
             if (result.getFunctionError() != null) {
-                throw new FailStateException("Lambda.AWSLambdaException", result.getFunctionError());
+                throw lambdaFunctionFailure(result);
             }
 
             byte[] responseBytes = result.getPayload();
@@ -1087,6 +1087,26 @@ public class AslExecutor {
 
         throw new FailStateException("States.TaskFailed",
                 "Unsupported resource: " + resource);
+    }
+
+    private FailStateException lambdaFunctionFailure(InvokeResult result) {
+        byte[] payload = result.getPayload();
+        String cause = payload != null && payload.length > 0
+                ? new String(payload, StandardCharsets.UTF_8)
+                : result.getFunctionError();
+        String error = "Lambda.Unknown";
+        if (payload != null && payload.length > 0) {
+            try {
+                String payloadErrorType = objectMapper.readTree(payload).path("errorType").asText(null);
+                if (payloadErrorType != null && !payloadErrorType.isBlank()) {
+                    error = payloadErrorType;
+                }
+            } catch (Exception ignored) {
+                // Lambda can return a non-JSON payload from a custom runtime. Preserve it as the
+                // cause and use Lambda.Unknown rather than misclassifying it as a service failure.
+            }
+        }
+        return new FailStateException(error, cause);
     }
 
     /**

--- a/src/test/java/io/github/hectorvent/floci/services/stepfunctions/AslExecutorCatchTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/stepfunctions/AslExecutorCatchTest.java
@@ -152,10 +152,43 @@ class AslExecutorCatchTest {
                 """.formatted(FAILING_FUNCTION_ARN));
 
         assertEquals("FAILED", execution.getStatus());
-        assertEquals("Lambda.AWSLambdaException", execution.getError());
-        assertEquals("Handled", execution.getCause());
+        assertEquals("ContractFailure", execution.getError());
+        assertEquals(new String(errorPayload(), StandardCharsets.UTF_8), execution.getCause());
         verify(lambdaExecutor).invoke(eq(failingFunction), any(byte[].class), eq(InvocationType.RequestResponse));
         verify(lambdaExecutor, never()).invoke(eq(cleanupFunction), any(byte[].class), eq(InvocationType.RequestResponse));
+    }
+
+    @Test
+    void optimizedLambdaFailurePreservesFunctionErrorAndSkipsServiceErrorRetrier() throws Exception {
+        Execution execution = run("""
+                {
+                  "StartAt": "FailingLambdaTask",
+                  "States": {
+                    "FailingLambdaTask": {
+                      "Type": "Task",
+                      "Resource": "arn:aws:states:::lambda:invoke",
+                      "Parameters": {"FunctionName": "%s", "Payload.$": "$"},
+                      "Retry": [{
+                        "ErrorEquals": ["Lambda.AWSLambdaException"],
+                        "IntervalSeconds": 0,
+                        "MaxAttempts": 3
+                      }],
+                      "Catch": [{
+                        "ErrorEquals": ["States.ALL"],
+                        "Next": "Handled"
+                      }],
+                      "End": true
+                    },
+                    "Handled": {"Type": "Pass", "End": true}
+                  }
+                }
+                """.formatted(FAILING_FUNCTION_ARN));
+
+        assertEquals("SUCCEEDED", execution.getStatus());
+        JsonNode failure = objectMapper.readTree(execution.getOutput());
+        assertEquals("ContractFailure", failure.path("Error").asText());
+        assertEquals(new String(errorPayload(), StandardCharsets.UTF_8), failure.path("Cause").asText());
+        verify(lambdaExecutor).invoke(eq(failingFunction), any(byte[].class), eq(InvocationType.RequestResponse));
     }
 
     private Execution run(String definition) {

--- a/src/test/java/io/github/hectorvent/floci/services/stepfunctions/AslExecutorRetryTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/stepfunctions/AslExecutorRetryTest.java
@@ -102,7 +102,7 @@ class AslExecutorRetryTest {
                       "Resource": "%s",
                       "End": true,
                       "Retry": [{
-                        "ErrorEquals": ["Lambda.AWSLambdaException"],
+                        "ErrorEquals": ["Boom"],
                         "IntervalSeconds": 1,
                         "BackoffRate": 1.0,
                         "MaxAttempts": 2
@@ -133,7 +133,7 @@ class AslExecutorRetryTest {
                       "Resource": "%s",
                       "End": true,
                       "Retry": [{
-                        "ErrorEquals": ["Lambda.AWSLambdaException"],
+                        "ErrorEquals": ["Boom"],
                         "IntervalSeconds": 1,
                         "BackoffRate": 1.0,
                         "MaxAttempts": 1
@@ -144,7 +144,7 @@ class AslExecutorRetryTest {
                 """.formatted(FLAKY_FUNCTION_ARN));
 
         assertEquals("FAILED", execution.getStatus());
-        assertEquals("Lambda.AWSLambdaException", execution.getError());
+        assertEquals("Boom", execution.getError());
         verify(lambdaExecutor, times(2))
                 .invoke(eq(flakyFunction), any(byte[].class), eq(InvocationType.RequestResponse));
     }
@@ -164,7 +164,7 @@ class AslExecutorRetryTest {
                       "Resource": "%s",
                       "End": true,
                       "Retry": [{
-                        "ErrorEquals": ["SomeOther.Error"],
+                        "ErrorEquals": ["Lambda.AWSLambdaException"],
                         "IntervalSeconds": 1,
                         "MaxAttempts": 3
                       }]
@@ -174,7 +174,7 @@ class AslExecutorRetryTest {
                 """.formatted(FLAKY_FUNCTION_ARN));
 
         assertEquals("FAILED", execution.getStatus());
-        assertEquals("Lambda.AWSLambdaException", execution.getError());
+        assertEquals("Boom", execution.getError());
         verify(lambdaExecutor, times(1))
                 .invoke(eq(flakyFunction), any(byte[].class), eq(InvocationType.RequestResponse));
     }
@@ -213,7 +213,7 @@ class AslExecutorRetryTest {
                 """.formatted(FLAKY_FUNCTION_ARN));
 
         assertEquals("SUCCEEDED", execution.getStatus());
-        assertEquals("Lambda.AWSLambdaException",
+        assertEquals("Boom",
                 objectMapper.readTree(execution.getOutput()).path("Error").asText());
         verify(lambdaExecutor, times(2))
                 .invoke(eq(flakyFunction), any(byte[].class), eq(InvocationType.RequestResponse));
@@ -234,7 +234,7 @@ class AslExecutorRetryTest {
                         "States": {"Inner": {"Type": "Task", "Resource": "%s", "End": true}}
                       }],
                       "Retry": [{
-                        "ErrorEquals": ["Lambda.AWSLambdaException"],
+                        "ErrorEquals": ["Boom"],
                         "IntervalSeconds": 1,
                         "BackoffRate": 1.0,
                         "MaxAttempts": 1
@@ -279,7 +279,7 @@ class AslExecutorRetryTest {
                 """.formatted(FLAKY_FUNCTION_ARN));
 
         assertEquals("SUCCEEDED", execution.getStatus());
-        assertEquals("Lambda.AWSLambdaException",
+        assertEquals("Boom",
                 objectMapper.readTree(execution.getOutput()).path("Error").asText());
         verify(lambdaExecutor, times(1))
                 .invoke(eq(flakyFunction), any(byte[].class), eq(InvocationType.RequestResponse));
@@ -303,7 +303,7 @@ class AslExecutorRetryTest {
                             "Resource": "%s",
                             "End": true,
                             "Retry": [{
-                              "ErrorEquals": ["Lambda.AWSLambdaException"],
+                              "ErrorEquals": ["Boom"],
                               "IntervalSeconds": 1,
                               "BackoffRate": 1.0,
                               "MaxAttempts": 1
@@ -340,7 +340,7 @@ class AslExecutorRetryTest {
                         "States": {"Inner": {"Type": "Task", "Resource": "%s", "End": true}}
                       },
                       "Retry": [{
-                        "ErrorEquals": ["Lambda.AWSLambdaException"],
+                        "ErrorEquals": ["Boom"],
                         "IntervalSeconds": 1,
                         "BackoffRate": 1.0,
                         "MaxAttempts": 1


### PR DESCRIPTION
## Summary

Propagate a Lambda function error's own `errorType` and complete payload through Step Functions task failures. Malformed or missing error metadata falls back to `Lambda.Unknown` rather than being mislabeled as the transient Lambda service error `Lambda.AWSLambdaException`.

Closes #3411

## Type of change

- [x] Bug fix (`fix:`)
- [ ] New feature (`feat:`)
- [ ] Breaking change (`feat!:` or `fix!:`)
- [ ] Docs / chore

## AWS Compatibility

Previously, both direct Lambda ARN tasks and optimized `lambda:invoke` tasks converted every function response error to `Lambda.AWSLambdaException` with cause `Handled`. They now expose the function error name and JSON payload like AWS Step Functions, so service-error retriers do not retry permanent handler failures and Catch receives the original diagnostic.

## Testing

- `AslExecutorRetryTest`
- `AslExecutorCatchTest`
- 14 tests passed, including direct and optimized Lambda integrations and a service-error retrier mismatch

## Checklist

- [x] Focused test suite passes locally
- [x] New or updated integration test added
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
