### PR TITLE
fix(codepipeline): populate stage execution status

### DIFF
--- a/src/main/java/io/github/hectorvent/floci/services/codepipeline/CodePipelineService.java
+++ b/src/main/java/io/github/hectorvent/floci/services/codepipeline/CodePipelineService.java
@@ -385,7 +385,8 @@ public class CodePipelineService {
 
     private ObjectNode getPipelineState(JsonNode request, String region, String account) {
         CodePipelinePipeline pipeline = requirePipeline(account, region, text(request, "name"));
-        CodePipelineExecution latest = executions(account, region, pipeline.getName()).stream().findFirst().orElse(null);
+        List<CodePipelineExecution> pipelineExecutions = executions(account, region, pipeline.getName());
+        CodePipelineExecution latest = pipelineExecutions.stream().findFirst().orElse(null);
         ObjectNode response = mapper.createObjectNode();
         response.put("pipelineName", pipeline.getName());
         response.put("pipelineVersion", pipeline.getVersion());
@@ -414,11 +415,16 @@ public class CodePipelineService {
                             .ifPresent(a -> actionState.set("latestExecution", actionStateNode(a)));
                 }
             }
-            if (latest != null && stageName.equals(latest.getCurrentStage())) {
+            CodePipelineExecution latestStageExecution = pipelineExecutions.stream()
+                    .filter(execution -> !actionExecutionsForStage(execution, stageName).isEmpty())
+                    .findFirst()
+                    .orElse(null);
+            if (latestStageExecution != null) {
                 ObjectNode latestExecution = state.putObject("latestExecution");
-                latestExecution.put("pipelineExecutionId", latest.getPipelineExecutionId());
-                latestExecution.put("status", latest.getStatus());
-                latestExecution.put("type", latest.getExecutionType());
+                latestExecution.put("pipelineExecutionId", latestStageExecution.getPipelineExecutionId());
+                latestExecution.put("status", stageExecutionStatus(
+                        actionExecutionsForStage(latestStageExecution, stageName)));
+                latestExecution.put("type", latestStageExecution.getExecutionType());
             }
         }
         return response;
@@ -1310,6 +1316,22 @@ public class CodePipelineService {
         return execution.getActionExecutions().stream()
                 .filter(a -> stage.equals(a.getStageName()))
                 .toList();
+    }
+
+    private String stageExecutionStatus(List<ActionExecution> actions) {
+        if (actions.stream().anyMatch(action -> "Failed".equals(action.getStatus()))) {
+            return "Failed";
+        }
+        if (actions.stream().anyMatch(action -> "InProgress".equals(action.getStatus()))) {
+            return "InProgress";
+        }
+        if (actions.stream().anyMatch(action -> "Abandoned".equals(action.getStatus()))) {
+            return "Stopped";
+        }
+        if (actions.stream().allMatch(action -> "Succeeded".equals(action.getStatus()))) {
+            return "Succeeded";
+        }
+        return "Failed";
     }
 
     private List<Map<String, Object>> objectList(JsonNode node) {

--- a/src/main/java/io/github/hectorvent/floci/services/codepipeline/CodePipelineService.java
+++ b/src/main/java/io/github/hectorvent/floci/services/codepipeline/CodePipelineService.java
@@ -146,6 +146,7 @@ public class CodePipelineService {
                         execution.setStopRequested(false);
                         execution.setAbandon(false);
                         execution.setActionExecutions(new ArrayList<>());
+                        execution.setStageExecutionStatuses(new LinkedHashMap<>());
                         putExecution(execution);
                         executor.submit(() -> runExecution(pipeline, execution));
                     }, () -> {
@@ -299,6 +300,9 @@ public class CodePipelineService {
         execution.setStatus("Stopping");
         execution.setStatusSummary(request.path("reason").asText("Stop requested."));
         execution.setLastUpdateTime(now());
+        if (execution.getCurrentStage() != null) {
+            execution.getStageExecutionStatuses().put(execution.getCurrentStage(), "Stopping");
+        }
         if (execution.isAbandon()) {
             execution.getActionExecutions().stream()
                     .filter(a -> "InProgress".equals(a.getStatus()))
@@ -416,14 +420,13 @@ public class CodePipelineService {
                 }
             }
             CodePipelineExecution latestStageExecution = pipelineExecutions.stream()
-                    .filter(execution -> !actionExecutionsForStage(execution, stageName).isEmpty())
+                    .filter(execution -> hasStageExecution(execution, stageName))
                     .findFirst()
                     .orElse(null);
             if (latestStageExecution != null) {
                 ObjectNode latestExecution = state.putObject("latestExecution");
                 latestExecution.put("pipelineExecutionId", latestStageExecution.getPipelineExecutionId());
-                latestExecution.put("status", stageExecutionStatus(
-                        actionExecutionsForStage(latestStageExecution, stageName)));
+                latestExecution.put("status", stageExecutionStatus(latestStageExecution, stageName));
                 latestExecution.put("type", latestStageExecution.getExecutionType());
             }
         }
@@ -501,9 +504,16 @@ public class CodePipelineService {
                     "The approval action has already been approved or rejected.", 400);
         }
 
-        approval.setStatus("Approved".equals(status) ? "Succeeded" : "Failed");
+        boolean approved = "Approved".equals(status);
+        approval.setStatus(approved ? "Succeeded" : "Failed");
         approval.setSummary(summary);
         approval.setLastUpdateTime(now());
+        if (!approved) {
+            execution.setStatus("Failed");
+            execution.setStatusSummary("Action " + actionName + " failed: " + summary);
+            execution.getStageExecutionStatuses().put(stageName, "Failed");
+            execution.setLastUpdateTime(now());
+        }
         putExecution(execution);
         return mapper.createObjectNode().put("approvedAt", now());
     }
@@ -748,17 +758,30 @@ public class CodePipelineService {
                     if (finishIfStopped(execution)) {
                         return;
                     }
-                    execution.setCurrentStage(stage.path("name").asText());
+                    String stageName = stage.path("name").asText();
+                    execution.setCurrentStage(stageName);
+                    execution.getStageExecutionStatuses().put(stageName, "InProgress");
                     execution.setLastUpdateTime(now());
                     putExecution(execution);
                     runStage(pipeline, execution, stage);
-                    if ("Failed".equals(execution.getStatus()) || finishIfStopped(execution)) {
+                    if ("Failed".equals(execution.getStatus())) {
+                        execution.getStageExecutionStatuses().put(stageName, "Failed");
                         return;
                     }
+                    if (finishIfStopped(execution)) {
+                        return;
+                    }
+                    execution.getStageExecutionStatuses().put(stageName, "Succeeded");
+                    execution.setCurrentStage(null);
+                    execution.setLastUpdateTime(now());
+                    putExecution(execution);
                 }
                 execution.setStatus("Succeeded");
                 execution.setStatusSummary("Pipeline execution succeeded.");
             } catch (Exception e) {
+                if (execution.getCurrentStage() != null) {
+                    execution.getStageExecutionStatuses().put(execution.getCurrentStage(), "Failed");
+                }
                 execution.setStatus("Failed");
                 execution.setStatusSummary(e.getMessage() == null ? e.getClass().getSimpleName() : e.getMessage());
                 LOG.errorf(e, "CodePipeline execution %s failed", execution.getPipelineExecutionId());
@@ -1058,6 +1081,9 @@ public class CodePipelineService {
         execution.setStatus("Stopped");
         execution.setStatusSummary("Pipeline execution stopped.");
         execution.setLastUpdateTime(now());
+        if (execution.getCurrentStage() != null) {
+            execution.getStageExecutionStatuses().put(execution.getCurrentStage(), "Stopped");
+        }
         putExecution(execution);
         return true;
     }
@@ -1318,9 +1344,19 @@ public class CodePipelineService {
                 .toList();
     }
 
-    private String stageExecutionStatus(List<ActionExecution> actions) {
+    private boolean hasStageExecution(CodePipelineExecution execution, String stage) {
+        return execution.getStageExecutionStatuses().containsKey(stage)
+                || !actionExecutionsForStage(execution, stage).isEmpty();
+    }
+
+    private String stageExecutionStatus(CodePipelineExecution execution, String stage) {
+        List<ActionExecution> actions = actionExecutionsForStage(execution, stage);
         if (actions.stream().anyMatch(action -> "Failed".equals(action.getStatus()))) {
             return "Failed";
+        }
+        String trackedStatus = execution.getStageExecutionStatuses().get(stage);
+        if (trackedStatus != null) {
+            return trackedStatus;
         }
         if (actions.stream().anyMatch(action -> "InProgress".equals(action.getStatus()))) {
             return "InProgress";

--- a/src/main/java/io/github/hectorvent/floci/services/codepipeline/model/CodePipelineExecution.java
+++ b/src/main/java/io/github/hectorvent/floci/services/codepipeline/model/CodePipelineExecution.java
@@ -30,6 +30,7 @@ public class CodePipelineExecution {
     private List<Map<String, String>> variables = new ArrayList<>();
     private Map<String, String> trigger = new LinkedHashMap<>();
     private List<ActionExecution> actionExecutions = new ArrayList<>();
+    private Map<String, String> stageExecutionStatuses = new LinkedHashMap<>();
     private String currentStage;
     private boolean stopRequested;
     private boolean abandon;
@@ -161,6 +162,15 @@ public class CodePipelineExecution {
 
     public void setActionExecutions(List<ActionExecution> actionExecutions) {
         this.actionExecutions = actionExecutions;
+    }
+
+    public Map<String, String> getStageExecutionStatuses() {
+        return stageExecutionStatuses;
+    }
+
+    public void setStageExecutionStatuses(Map<String, String> stageExecutionStatuses) {
+        this.stageExecutionStatuses = stageExecutionStatuses == null
+                ? new LinkedHashMap<>() : stageExecutionStatuses;
     }
 
     public String getCurrentStage() {

--- a/src/test/java/io/github/hectorvent/floci/services/codepipeline/CodePipelineIntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/codepipeline/CodePipelineIntegrationTest.java
@@ -262,7 +262,11 @@ class CodePipelineIntegrationTest {
                 .then()
                 .statusCode(200)
                 .body("stageStates", hasSize(2))
-                .body("stageStates[0].actionStates[0].latestExecution.status", equalTo("Succeeded"));
+                .body("stageStates[0].actionStates[0].latestExecution.status", equalTo("Succeeded"))
+                .body("stageStates[0].latestExecution.pipelineExecutionId", equalTo(executionId))
+                .body("stageStates[0].latestExecution.status", equalTo("Succeeded"))
+                .body("stageStates[1].latestExecution.pipelineExecutionId", equalTo(executionId))
+                .body("stageStates[1].latestExecution.status", equalTo("Succeeded"));
 
         post("ListActionExecutions", """
                 {
@@ -764,7 +768,9 @@ class CodePipelineIntegrationTest {
                 .then()
                 .statusCode(200)
                 .body("stageStates[0].actionStates[0].latestExecution.status", equalTo("Failed"))
-                .body("stageStates[0].actionStates[0].latestExecution.summary", equalTo("Rejected by test"));
+                .body("stageStates[0].actionStates[0].latestExecution.summary", equalTo("Rejected by test"))
+                .body("stageStates[0].latestExecution.pipelineExecutionId", equalTo(executionId2))
+                .body("stageStates[0].latestExecution.status", equalTo("Failed"));
     }
 
     @Test

--- a/src/test/java/io/github/hectorvent/floci/services/codepipeline/CodePipelineIntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/codepipeline/CodePipelineIntegrationTest.java
@@ -774,6 +774,130 @@ class CodePipelineIntegrationTest {
     }
 
     @Test
+    void stageStatusTracksMultipleRunOrdersAndStopBeforeLaterGroup() throws Exception {
+        String pipelineName = "multi-run-order-stage-status";
+        post("CreatePipeline", pipeline(pipelineName, """
+                {
+                    "name": "Approve",
+                    "actions": [
+                        {
+                            "name": "FirstApproval",
+                            "actionTypeId": {
+                                "category": "Approval",
+                                "owner": "AWS",
+                                "provider": "Manual",
+                                "version": "1"
+                            },
+                            "configuration": {},
+                            "runOrder": 1
+                        },
+                        {
+                            "name": "SecondApproval",
+                            "actionTypeId": {
+                                "category": "Approval",
+                                "owner": "AWS",
+                                "provider": "Manual",
+                                "version": "1"
+                            },
+                            "configuration": {},
+                            "runOrder": 2
+                        },
+                        {
+                            "name": "NeverStartedApproval",
+                            "actionTypeId": {
+                                "category": "Approval",
+                                "owner": "AWS",
+                                "provider": "Manual",
+                                "version": "1"
+                            },
+                            "configuration": {},
+                            "runOrder": 3
+                        }
+                    ]
+                },
+                {
+                    "name": "Deploy",
+                    "actions": [{
+                        "name": "PlaceholderAction",
+                        "actionTypeId": {
+                            "category": "Deploy",
+                            "owner": "AWS",
+                            "provider": "S3",
+                            "version": "1"
+                        },
+                        "configuration": {
+                            "BucketName": "codepipeline-artifacts",
+                            "ObjectKey": "placeholder"
+                        },
+                        "runOrder": 1
+                    }]
+                }
+                """))
+                .then()
+                .statusCode(200);
+
+        String executionId = post("StartPipelineExecution", """
+                {"name": "%s"}
+                """.formatted(pipelineName))
+                .then()
+                .statusCode(200)
+                .extract().path("pipelineExecutionId");
+
+        String firstToken = waitForApprovalToken(pipelineName, 0);
+        post("PutApprovalResult", """
+                {
+                    "pipelineName": "%s",
+                    "stageName": "Approve",
+                    "actionName": "FirstApproval",
+                    "token": "%s",
+                    "result": {"status": "Approved", "summary": "First group complete"}
+                }
+                """.formatted(pipelineName, firstToken))
+                .then()
+                .statusCode(200);
+
+        waitForApprovalToken(pipelineName, 1);
+        post("GetPipelineState", """
+                {"name": "%s"}
+                """.formatted(pipelineName))
+                .then()
+                .statusCode(200)
+                .body("stageStates[0].latestExecution.pipelineExecutionId", equalTo(executionId))
+                .body("stageStates[0].latestExecution.status", equalTo("InProgress"))
+                .body("stageStates[0].actionStates[0].latestExecution.status", equalTo("Succeeded"))
+                .body("stageStates[0].actionStates[1].latestExecution.status", equalTo("InProgress"))
+                .body("stageStates[0].actionStates[2].latestExecution", nullValue());
+
+        post("StopPipelineExecution", """
+                {
+                    "pipelineName": "%s",
+                    "pipelineExecutionId": "%s",
+                    "abandon": true,
+                    "reason": "Verify stage status"
+                }
+                """.formatted(pipelineName, executionId))
+                .then()
+                .statusCode(200)
+                .body("pipelineExecutionId", equalTo(executionId));
+
+        waitForExecution(pipelineName, executionId, "Stopped");
+        post("GetPipelineState", """
+                {"name": "%s"}
+                """.formatted(pipelineName))
+                .then()
+                .statusCode(200)
+                .body("stageStates[0].latestExecution.pipelineExecutionId", equalTo(executionId))
+                .body("stageStates[0].latestExecution.status", equalTo("Stopped"))
+                .body("stageStates[0].actionStates[0].latestExecution.status", equalTo("Succeeded"))
+                .body("stageStates[0].actionStates[1].latestExecution.status", equalTo("Abandoned"))
+                .body("stageStates[0].actionStates[2].latestExecution", nullValue());
+
+        post("DeletePipeline", """
+                {"name": "%s"}
+                """.formatted(pipelineName)).then().statusCode(200);
+    }
+
+    @Test
     void putApprovalResultValidatesErrors() throws Exception {
         String pipelineName = "error-test-pipeline";
         post("CreatePipeline", pipeline(pipelineName, """
@@ -1100,13 +1224,18 @@ class CodePipelineIntegrationTest {
     }
 
     private String waitForApprovalToken(String pipelineName) throws Exception {
+        return waitForApprovalToken(pipelineName, 0);
+    }
+
+    private String waitForApprovalToken(String pipelineName, int actionIndex) throws Exception {
         Instant deadline = Instant.now().plus(Duration.ofSeconds(5));
         String token;
         do {
             token = post("GetPipelineState", """
                     {"name": "%s"}
                     """.formatted(pipelineName))
-                    .jsonPath().getString("stageStates[0].actionStates[0].latestExecution.token");
+                    .jsonPath().getString(
+                            "stageStates[0].actionStates[%d].latestExecution.token".formatted(actionIndex));
             if (token != null) {
                 return token;
             }


### PR DESCRIPTION
## Summary

Track each CodePipeline stage execution independently from the action rows created for individual runOrder groups. GetPipelineState now reports the latest stage execution after completion and throughout InProgress, Stopping, Stopped, Failed, and Succeeded transitions.

Closes #2227

## Type of change

- [x] Bug fix (fix:)
- [ ] New feature (feat:)
- [ ] Breaking change (feat!: or fix!:)
- [ ] Docs / chore

## AWS Compatibility

Previously, stage-level latestExecution disappeared after currentStage was cleared and could report Succeeded between runOrder groups because only already-created action executions were considered. Stage status is now tracked for the stage lifecycle itself, including a stop before a later runOrder group starts.

## Checklist

- [ ] ./mvnw test passes locally
- [x] New or updated integration test added
- [x] Commit messages follow Conventional Commits