### PR TITLE
feat(cloudformation): pass EngineMode and StorageEncrypted to RDS clusters

### DIFF
--- a/src/main/java/io/github/hectorvent/floci/services/cloudformation/CloudFormationResourceProvisioner.java
+++ b/src/main/java/io/github/hectorvent/floci/services/cloudformation/CloudFormationResourceProvisioner.java
@@ -1461,14 +1461,23 @@ public class CloudFormationResourceProvisioner {
             String databaseName = resolveOptional(props, "DatabaseName", engine);
             boolean iamEnabled = parseBoolProp(props, "EnableIAMDatabaseAuthentication", engine);
             String parameterGroup = resolveOptional(props, "DBClusterParameterGroupName", engine);
-            if (serverlessV2MinCapacity == null && serverlessV2MaxCapacity == null
-                    && serverlessV2SecondsUntilAutoPause == null) {
-                cluster = rdsService.createDbCluster(id, engineName, engineVersion, masterUsername,
-                        masterPassword, databaseName, iamEnabled, parameterGroup, null, null, false, region);
+            String engineMode = resolveOptional(props, "EngineMode", engine);
+            boolean storageEncrypted = parseBoolProp(props, "StorageEncrypted", engine);
+            if (engineMode == null && !storageEncrypted) {
+                if (serverlessV2MinCapacity == null && serverlessV2MaxCapacity == null
+                        && serverlessV2SecondsUntilAutoPause == null) {
+                    cluster = rdsService.createDbCluster(id, engineName, engineVersion, masterUsername,
+                            masterPassword, databaseName, iamEnabled, parameterGroup, null, null, false, region);
+                } else {
+                    cluster = rdsService.createDbCluster(id, engineName, engineVersion, masterUsername,
+                            masterPassword, databaseName, iamEnabled, parameterGroup, null, null, false, region,
+                            serverlessV2MinCapacity, serverlessV2MaxCapacity, serverlessV2SecondsUntilAutoPause);
+                }
             } else {
                 cluster = rdsService.createDbCluster(id, engineName, engineVersion, masterUsername,
                         masterPassword, databaseName, iamEnabled, parameterGroup, null, null, false, region,
-                        serverlessV2MinCapacity, serverlessV2MaxCapacity, serverlessV2SecondsUntilAutoPause);
+                        serverlessV2MinCapacity, serverlessV2MaxCapacity, serverlessV2SecondsUntilAutoPause,
+                        false, null, engineMode, storageEncrypted);
             }
             deleteRenamedResource(priorPhysicalId, id, rdsService::deleteDbCluster, "DB cluster");
         }

--- a/src/test/java/io/github/hectorvent/floci/services/cloudformation/RdsCfnProvisionerTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/cloudformation/RdsCfnProvisionerTest.java
@@ -221,6 +221,25 @@ class RdsCfnProvisionerTest {
     }
 
     @Test
+    void provisionsDbClusterWithEngineModeAndStorageEncrypted() {
+        DbCluster cluster = mock(DbCluster.class);
+        when(cluster.getDbClusterIdentifier()).thenReturn("mycluster");
+        when(rdsService.createDbCluster(any(), any(), any(), any(), any(), any(), anyBoolean(), any(),
+                any(), any(), anyBoolean(), any(), any(), any(), any(), anyBoolean(), any(), any(),
+                anyBoolean()))
+                .thenReturn(cluster);
+
+        provision("Cluster", "AWS::RDS::DBCluster", """
+                {"DBClusterIdentifier":"mycluster","Engine":"aurora-postgresql",
+                 "EngineMode":"serverless","StorageEncrypted":true}
+                """);
+
+        verify(rdsService).createDbCluster("mycluster", "aurora-postgresql", null,
+                null, null, null, false, null, null, null, false, "us-east-1",
+                null, null, null, false, null, "serverless", true);
+    }
+
+    @Test
     void rejectsNonNumericServerlessV2Capacity() {
         // A non-numeric capacity is invalid input, not an absent value: the stack fails rather than
         // silently dropping the scaling configuration.


### PR DESCRIPTION
## Summary

Follow-up to #3448. That PR made `RdsService`/`RdsQueryHandler` persist and return `EngineMode`/`StorageEncrypted` for `CreateDBCluster` and `DescribeDBClusters`, but `AWS::RDS::DBCluster` templates provisioned through CloudFormation never read either property, so CFN-provisioned clusters still silently got the defaults.

`CloudFormationResourceProvisioner.provisionDbCluster` now resolves `EngineMode` and `StorageEncrypted` from the template properties and threads them through to `RdsService.createDbCluster` alongside the existing engine/credentials/serverless-scaling handling, mirroring the raw Query API path.

Depends on #3448 (adds the underlying fields this PR consumes); this diff will look smaller once #3448 merges and this branch rebases onto `main`.

## Type of change

- [x] New feature (`feat:`)
- [ ] Bug fix (`fix:`)
- [ ] Breaking change
- [ ] Docs / chore

## AWS Compatibility

Same `CreateDBCluster`/`DescribeDBClusters` element names and semantics verified in #3448; this PR only adds the CloudFormation-to-service plumbing, no new wire behavior.

## Checklist

- [x] `./mvnw test` passes locally (`RdsCfnProvisionerTest`, `CloudFormationRdsIntegrationTest`, `RdsServiceTest`, `RdsQueryHandlerTest`, all green)
- [x] New or updated integration test added (`provisionsDbClusterWithEngineModeAndStorageEncrypted`)
- [x] Commit messages follow Conventional Commits