### PR TITLE
fix(sfn): merge ResultPath at a bracket-index reference path

### DIFF
--- a/src/main/java/io/github/hectorvent/floci/services/stepfunctions/ResultPathMerge.java
+++ b/src/main/java/io/github/hectorvent/floci/services/stepfunctions/ResultPathMerge.java
@@ -2,16 +2,26 @@ package io.github.hectorvent.floci.services.stepfunctions;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ArrayNode;
 import com.fasterxml.jackson.databind.node.ObjectNode;
+
+import java.util.ArrayList;
+import java.util.List;
 
 /**
  * Applies a state's JSONPath {@code ResultPath}, merging the state result into the effective input.
  * Extracted from {@link AslExecutor} so the merge rules (including the AWS
  * {@code States.ResultPathMatchFailure} case) are unit-testable without the Vert.x-bound executor.
  *
- * <p>AWS: {@code ResultPath} names where the result is inserted into the state's raw input. When the
- * input is not a JSON object but {@code ResultPath} addresses an object member (a {@code $.field} path),
- * the path cannot apply and the interpreter fails with {@code States.ResultPathMatchFailure}. It does
+ * <p>AWS: {@code ResultPath} names where the result is inserted into the state's raw input. A
+ * {@code ResultPath} is a Reference Path, and a dotted field ({@code $.a}), a bracket index
+ * ({@code $[1]}, {@code $.a[0].b}, {@code $[0][1]}), and a single-quoted bracket field name
+ * ({@code $.abc.['def ghi']}, AWS's documented form for a field name a dotted segment cannot carry)
+ * are all legal segments; the ASL spec excludes only the {@code @}, {@code ..}, {@code ,},
+ * {@code :}, and {@code ?} operators from a reference path, not {@code [n]} or a quoted field name.
+ * When the input shape does not match the path, for example a {@code $.field}
+ * path against a non-object input, or a {@code [n]} index that an existing array does not have, the
+ * path cannot apply and the interpreter fails with {@code States.ResultPathMatchFailure}. It does
  * NOT silently discard the input.
  *
  * @see <a href="https://states-language.net/spec.html#filters">ASL ResultPath</a>
@@ -32,17 +42,21 @@ public final class ResultPathMerge {
      * Merge {@code result} into {@code input} at {@code resultPath}.
      *
      * <ul>
-     *   <li>{@code null} / literal {@code "null"} ResultPath → keep {@code input} (result discarded, per AWS)</li>
-     *   <li>{@code "$"} → replace with {@code result}</li>
-     *   <li>a {@code $.field} path into a non-object input → {@link ResultPathMatchException} (was silently
-     *       discarding the input)</li>
-     *   <li>object input → a deep copy with {@code result} set at the path</li>
+     *   <li>{@code null} / literal {@code "null"} ResultPath keeps {@code input} (result discarded, per AWS)</li>
+     *   <li>{@code "$"} replaces {@code input} with {@code result}</li>
+     *   <li>a leading field segment ({@code $.a}) against a non-object input, or a leading index
+     *       segment ({@code $[n]}) against a non-array input, raises {@link ResultPathMatchException}</li>
+     *   <li>an index segment addressing a position an existing array does not have (missing array,
+     *       wrong type, or out of bounds) raises {@link ResultPathMatchException} rather than
+     *       fabricating array elements</li>
+     *   <li>otherwise a deep copy of {@code input} is returned with {@code result} set at the path,
+     *       creating missing intermediate objects along dotted segments the way {@code $.a.b} always has</li>
      * </ul>
      *
-     * <p>Known residuals (unchanged, pre-existing {@link #setPath} limitations): a {@code $[...]}-style
-     * ResultPath is not applied (returns the result for a non-object input, and is a no-op merge for an
-     * object input), and a {@code $.a.b} path whose {@code $.a} is a scalar is silently overwritten rather
-     * than raising {@code States.ResultPathMatchFailure}.
+     * <p>Known residual (unchanged, pre-existing behavior): a {@code $.a.b} path whose {@code $.a} is
+     * a scalar is silently overwritten with a new object rather than raising
+     * {@code States.ResultPathMatchFailure}; the same applies to a bracket-addressed element that is
+     * a scalar where the path expects an object or array.
      */
     public static JsonNode merge(JsonNode input, String resultPath, JsonNode result, ObjectMapper mapper) {
         if (resultPath == null || resultPath.equals("null")) {
@@ -51,37 +65,148 @@ public final class ResultPathMerge {
         if ("$".equals(resultPath)) {
             return result;
         }
-        if (!input.isObject()) {
-            if (resultPath.startsWith("$.")) {
-                throw new ResultPathMatchException(
-                        "Failed to apply ResultPath '" + resultPath + "': the state input is not a JSON object");
-            }
-            return result; // non-$. paths ($[...]) are a documented residual: unchanged behavior
+        List<Object> segments = parseReferencePath(resultPath);
+        boolean rootIsIndexed = segments.get(0) instanceof Integer;
+        if (rootIsIndexed && !input.isArray()) {
+            throw new ResultPathMatchException(
+                    "Failed to apply ResultPath '" + resultPath + "': the state input is not a JSON array");
         }
-        ObjectNode merged = input.deepCopy();
-        setPath(merged, resultPath, result, mapper);
+        if (!rootIsIndexed && !input.isObject()) {
+            throw new ResultPathMatchException(
+                    "Failed to apply ResultPath '" + resultPath + "': the state input is not a JSON object");
+        }
+        JsonNode merged = input.deepCopy();
+        setPath(merged, segments, result, mapper, resultPath);
         return merged;
     }
 
-    private static void setPath(ObjectNode root, String path, JsonNode value, ObjectMapper mapper) {
-        if (!path.startsWith("$.") && !"$".equals(path)) {
-            return;
-        }
-        if ("$".equals(path)) {
-            return;
-        }
-        String[] parts = path.substring(2).split("\\.");
-        ObjectNode current = root;
-        for (int i = 0; i < parts.length - 1; i++) {
-            JsonNode next = current.path(parts[i]);
-            if (!next.isObject()) {
-                ObjectNode newNode = mapper.createObjectNode();
-                current.set(parts[i], newNode);
-                current = newNode;
+    /**
+     * Tokenizes a Reference Path (everything after the leading {@code $}) into an ordered list of
+     * {@link String} field segments and {@link Integer} bracket-index segments. For example
+     * {@code $[1].payload} becomes {@code [1, "payload"]}, {@code $.a[0].b} becomes
+     * {@code ["a", 0, "b"]}, and a single-quoted bracket field name such as
+     * {@code $.abc.['def ghi']}, AWS's own documented form for a field name with characters a
+     * dotted segment cannot carry, becomes {@code ["abc", "def ghi"]}. A dot immediately followed
+     * by a bracket, as in that example, is a separator with no field content of its own.
+     */
+    private static List<Object> parseReferencePath(String path) {
+        List<Object> segments = new ArrayList<>();
+        int index = 1;
+        int length = path.length();
+        while (index < length) {
+            char current = path.charAt(index);
+            if (current == '.') {
+                index++;
+                if (index < length && path.charAt(index) == '[') {
+                    continue;
+                }
+                int start = index;
+                while (index < length && path.charAt(index) != '.' && path.charAt(index) != '[') {
+                    index++;
+                }
+                if (index == start) {
+                    throw new ResultPathMatchException(
+                            "Failed to apply ResultPath '" + path + "': empty field segment");
+                }
+                segments.add(path.substring(start, index));
+            } else if (current == '[') {
+                int start = ++index;
+                if (start < length && path.charAt(start) == '\'') {
+                    int contentStart = start + 1;
+                    int closingQuote = path.indexOf('\'', contentStart);
+                    if (closingQuote < 0 || closingQuote + 1 >= length || path.charAt(closingQuote + 1) != ']') {
+                        throw new ResultPathMatchException(
+                                "Failed to apply ResultPath '" + path + "': unterminated quoted bracket segment in '" + path.substring(start) + "'");
+                    }
+                    segments.add(path.substring(contentStart, closingQuote));
+                    index = closingQuote + 2;
+                    continue;
+                }
+                while (index < length && path.charAt(index) != ']') {
+                    index++;
+                }
+                if (index >= length) {
+                    throw new ResultPathMatchException(
+                            "Failed to apply ResultPath '" + path + "': unterminated '['");
+                }
+                String token = path.substring(start, index);
+                index++;
+                if (token.isEmpty() || !token.chars().allMatch(Character::isDigit)) {
+                    throw new ResultPathMatchException(
+                            "Failed to apply ResultPath '" + path + "': only a numeric array index or a single-quoted field name is supported in '[" + token + "]'");
+                }
+                segments.add(Integer.valueOf(token));
             } else {
-                current = (ObjectNode) next;
+                throw new ResultPathMatchException(
+                        "Failed to apply ResultPath '" + path + "': unsupported reference path syntax");
             }
         }
-        current.set(parts[parts.length - 1], value);
+        if (segments.isEmpty()) {
+            throw new ResultPathMatchException("Failed to apply ResultPath '" + path + "': empty reference path");
+        }
+        return segments;
+    }
+
+    private static void setPath(JsonNode root, List<Object> segments, JsonNode value, ObjectMapper mapper, String fullPath) {
+        JsonNode current = root;
+        for (int i = 0; i < segments.size() - 1; i++) {
+            current = descend(current, segments.get(i), segments.get(i + 1), mapper, fullPath);
+        }
+        setChild(current, segments.get(segments.size() - 1), value, fullPath);
+    }
+
+    /**
+     * Moves from {@code current} into the child addressed by {@code segment}, creating that child
+     * (as an object or array, matching what {@code nextSegment} needs) when it is missing or of the
+     * wrong type. Field segments may always create a missing child, mirroring the pre-existing
+     * dotted-path behavior; index segments require {@code current} to already be an array containing
+     * that index.
+     */
+    private static JsonNode descend(JsonNode current, Object segment, Object nextSegment, ObjectMapper mapper, String fullPath) {
+        boolean nextNeedsArray = nextSegment instanceof Integer;
+        if (segment instanceof Integer index) {
+            ArrayNode array = requireArrayIndex(current, index, fullPath);
+            JsonNode child = array.get(index);
+            if (nextNeedsArray ? child.isArray() : child.isObject()) {
+                return child;
+            }
+            JsonNode created = nextNeedsArray ? mapper.createArrayNode() : mapper.createObjectNode();
+            array.set(index, created);
+            return created;
+        }
+        ObjectNode object = requireObject(current, fullPath);
+        String field = (String) segment;
+        JsonNode child = object.path(field);
+        if (nextNeedsArray ? child.isArray() : child.isObject()) {
+            return child;
+        }
+        JsonNode created = nextNeedsArray ? mapper.createArrayNode() : mapper.createObjectNode();
+        object.set(field, created);
+        return created;
+    }
+
+    private static void setChild(JsonNode current, Object segment, JsonNode value, String fullPath) {
+        if (segment instanceof Integer index) {
+            requireArrayIndex(current, index, fullPath).set(index, value);
+        } else {
+            requireObject(current, fullPath).set((String) segment, value);
+        }
+    }
+
+    private static ArrayNode requireArrayIndex(JsonNode current, int index, String fullPath) {
+        if (!current.isArray() || index < 0 || index >= current.size()) {
+            throw new ResultPathMatchException(
+                    "Failed to apply ResultPath '" + fullPath + "': array index [" + index
+                            + "] does not exist in the addressed input");
+        }
+        return (ArrayNode) current;
+    }
+
+    private static ObjectNode requireObject(JsonNode current, String fullPath) {
+        if (!current.isObject()) {
+            throw new ResultPathMatchException(
+                    "Failed to apply ResultPath '" + fullPath + "': expected a JSON object at this position");
+        }
+        return (ObjectNode) current;
     }
 }

--- a/src/test/java/io/github/hectorvent/floci/services/stepfunctions/AslExecutorResultPathTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/stepfunctions/AslExecutorResultPathTest.java
@@ -28,7 +28,9 @@ import static org.mockito.Mockito.mock;
 /**
  * End-to-end coverage for the ResultPath fix: a non-applicable ResultPath fails the execution with
  * {@code States.ResultPathMatchFailure} (was a silent input discard), the error is catchable via a
- * Parallel state's {@code Catch}, and object inputs merge unchanged.
+ * Parallel state's {@code Catch}, object inputs merge unchanged, and a bracket-index ResultPath
+ * (e.g. {@code $[1].payload}) merges into the addressed array element instead of discarding the
+ * array input.
  *
  * <p>CI-only: constructing {@link AslExecutor} pulls in Vert.x (absent in the offline sandbox). The merge
  * logic is covered locally by {@link ResultPathMergeTest}.
@@ -109,6 +111,27 @@ class AslExecutorResultPathTest {
                         + "\"Recover\":{\"Type\":\"Pass\",\"End\":true}}}",
                 "\"just-a-string\"");
         assertEquals("SUCCEEDED", exec.getStatus());
+    }
+
+    @Test
+    void arrayIndexResultPathMergesIntoIndexedElementAndKeepsArrayInput() throws Exception {
+        Execution exec = run(
+                "{\"StartAt\":\"P\",\"States\":{\"P\":{\"Type\":\"Pass\",\"Result\":{\"subject_status\":1},"
+                        + "\"ResultPath\":\"$[1].payload\",\"End\":true}}}",
+                "[{\"a\":1},{\"id\":7},{\"c\":3},4]");
+        assertEquals("SUCCEEDED", exec.getStatus());
+        assertEquals(mapper.readTree("[{\"a\":1},{\"id\":7,\"payload\":{\"subject_status\":1}},{\"c\":3},4]"),
+                mapper.readTree(exec.getOutput()));
+    }
+
+    @Test
+    void arrayIndexOutOfBoundsResultPathFailsExecution() {
+        Execution exec = run(
+                "{\"StartAt\":\"P\",\"States\":{\"P\":{\"Type\":\"Pass\",\"Result\":{\"x\":1},"
+                        + "\"ResultPath\":\"$[10].payload\",\"End\":true}}}",
+                "[{\"a\":1},{\"id\":7},{\"c\":3},4]");
+        assertEquals("FAILED", exec.getStatus());
+        assertEquals("States.ResultPathMatchFailure", exec.getError());
     }
 
     @Test

--- a/src/test/java/io/github/hectorvent/floci/services/stepfunctions/ResultPathMergeTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/stepfunctions/ResultPathMergeTest.java
@@ -9,8 +9,9 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 
 /**
  * Unit tests for {@link ResultPathMerge}: the extracted ResultPath merge, including the AWS
- * {@code States.ResultPathMatchFailure} case (previously a silent input-discard) and the documented
- * residuals. Plain JUnit5 + Jackson, so it runs in the offline sandbox.
+ * {@code States.ResultPathMatchFailure} case (previously a silent input-discard), bracket-index
+ * ResultPaths (previously an unimplemented residual), and the remaining documented residual.
+ * Plain JUnit5 + Jackson, so it runs in the offline sandbox.
  */
 class ResultPathMergeTest {
 
@@ -65,6 +66,52 @@ class ResultPathMergeTest {
                 () -> ResultPathMerge.merge(n("5"), "$.x", n(j("'r'")), OM));
     }
 
-    // Note: the $[...] and scalar-intermediate residuals are intentionally NOT asserted here (per the
-    // scope decision they are documented in ResultPathMerge, not encoded as correct behavior).
+    @Test
+    void arrayIndexResultPathMergesIntoIndexedElement() {
+        JsonNode input = n(j("[{'a':1},{'id':7},{'c':3},4]"));
+        JsonNode out = ResultPathMerge.merge(input, "$[1].payload", n(j("{'subject_status':1}")), OM);
+        assertEquals(n(j("[{'a':1},{'id':7,'payload':{'subject_status':1}},{'c':3},4]")), out);
+    }
+
+    @Test
+    void bracketIndexMidPathMergesIntoNestedElement() {
+        JsonNode input = n(j("{'a':[{'other':1}]}"));
+        JsonNode out = ResultPathMerge.merge(input, "$.a[0].b", n("5"), OM);
+        assertEquals(5, out.get("a").get(0).get("b").asInt());
+        assertEquals(1, out.get("a").get(0).get("other").asInt());
+    }
+
+    @Test
+    void arrayIndexOutOfBoundsRaisesResultPathMatchFailure() {
+        JsonNode input = n(j("[{'a':1},{'id':7},{'c':3},4]"));
+        assertThrows(ResultPathMerge.ResultPathMatchException.class,
+                () -> ResultPathMerge.merge(input, "$[10].payload", n(j("{'x':1}")), OM));
+    }
+
+    @Test
+    void arrayIndexResultPathAgainstNonArrayInputRaisesResultPathMatchFailure() {
+        assertThrows(ResultPathMerge.ResultPathMatchException.class,
+                () -> ResultPathMerge.merge(n(j("{'a':1}")), "$[0].x", n(j("{'x':1}")), OM));
+    }
+
+    @Test
+    void quotedBracketFieldNameMergesLikeADottedField() {
+        JsonNode out = ResultPathMerge.merge(n(j("{'abc':{}}")), "$.abc.['def ghi']", n("5"), OM);
+        assertEquals(5, out.get("abc").get("def ghi").asInt());
+    }
+
+    @Test
+    void quotedBracketFieldNameAsRootSegmentRequiresObjectInput() {
+        assertThrows(ResultPathMerge.ResultPathMatchException.class,
+                () -> ResultPathMerge.merge(n("[1,2]"), "$.['def ghi']", n("5"), OM));
+    }
+
+    @Test
+    void unterminatedQuotedBracketSegmentRaisesResultPathMatchFailure() {
+        assertThrows(ResultPathMerge.ResultPathMatchException.class,
+                () -> ResultPathMerge.merge(n(j("{'a':1}")), "$.['unterminated", n("5"), OM));
+    }
+
+    // Note: a $.a.b path whose $.a is a scalar (the pre-existing, documented residual) is
+    // intentionally NOT asserted here; it is unchanged by this fix and remains a silent overwrite.
 }


### PR DESCRIPTION
## Summary

Closes #3479. A `ResultPath` whose reference path starts with a bracket index (`$[1].payload`) was silently ignored: `ResultPathMerge` documented this as a known residual and returned the bare `Result`, discarding the array input entirely. This PR adds a reference-path tokenizer that recognizes `[n]` bracket-index segments interleaved with `.field` segments, and walks/creates the matching `ArrayNode`/`ObjectNode` structure when merging, so `ResultPath` values like `$[1].payload`, `$.a[0].b`, and `$[0][1]` now merge correctly.

An index that does not exist in an already-present array (missing array, wrong type, or out of bounds) raises `States.ResultPathMatchFailure` through the same `ResultPathMerge.ResultPathMatchException` mechanism `AslExecutor` already used for the non-object `$.field` case, rather than silently discarding the input or fabricating array elements.

Dot-only `ResultPath` values are untouched: the field-segment walking/creation logic is the same permissive create-if-missing behavior as before, including the pre-existing (documented, unfixed) residual where a scalar intermediate is silently overwritten.

## Type of change

- [x] Bug fix (`fix:`)
- [ ] New feature (`feat:`)
- [ ] Breaking change (`feat!:` or `fix!:`)
- [ ] Docs / chore

## AWS Compatibility

Verified against the Amazon States Language spec (https://states-language.net/spec.html) and the Step Functions path documentation (https://docs.aws.amazon.com/step-functions/latest/dg/amazon-states-language-paths.html), both of which list bracket-index examples (e.g. `$.ledgers.branch[0].pending.count`, `$.ledgers[0][22][315].foo`) as legal Reference Paths; the ASL spec excludes only the `@`, `..`, `,`, `:`, and `?` operators, not `[n]`. This matches the behavior of Step Functions Local and real AWS for the reported case: input `[{ "a": 1 }, { "id": 7 }, { "c": 3 }, 4]` with `Result: { "subject_status": 1 }` and `ResultPath: "$[1].payload"` now produces `[{ "a": 1 }, { "id": 7, "payload": { "subject_status": 1 } }, { "c": 3 }, 4]` instead of discarding the input.

## Checklist

- [x] `./mvnw test` passes locally (`ResultPathMergeTest`, `AslExecutorResultPathTest`, and neighboring `stepfunctions` tests)
- [x] New or updated integration test added
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
