### PR TITLE
fix(build): copy the sidecar sources into the image build context

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -8,6 +8,7 @@ COPY pom.xml .
 RUN mvn dependency:go-offline -q
 
 COPY src/ src/
+COPY sidecars/ sidecars/
 RUN mvn clean package -DskipTests -q
 
 # Stage 2: Runtime

--- a/docker/Dockerfile.native
+++ b/docker/Dockerfile.native
@@ -10,6 +10,7 @@ RUN curl -fsSL https://archive.apache.org/dist/maven/maven-3/3.9.12/binaries/apa
 COPY pom.xml .
 RUN mvn dependency:go-offline -B
 COPY src ./src
+COPY sidecars ./sidecars
 
 # Quarkus 3.39 switches on -H:+AOTSingleCallsiteInline for Mandrel 25.0.4+. The generated
 # REST invokers for AwsQueryController.dispatch and AwsJson11Controller.handle are each the


### PR DESCRIPTION
## Summary

`docker/Dockerfile` and `docker/Dockerfile.native` cannot build `main`.

The pom adds `sidecars/cedar/src/main/java` as a test source root (`build-helper-maven-plugin`, `add-cedar-sidecar-test-source`), and `.dockerignore` already whitelists `!sidecars/cedar/**`, but neither Dockerfile copies the directory into the build context. `mvn package -DskipTests` still compiles tests, so the build dies at `testCompile`:

```
ERROR .../VerifiedPermissionsIntegrationTest.java:[6,40] package io.github.hectorvent.floci.cedar does not exist
ERROR .../VerifiedPermissionsServiceTest.java:[39,23] cannot find symbol
  symbol: variable CedarSidecarServer
```

This fix copies `sidecars` alongside `src` in the two Dockerfiles that build from source.

`docker/Dockerfile.compat` and `docker/Dockerfile.native-package` consume a prebuilt native image rather than building from source, so they are unaffected — which is why `nightly.yml` has stayed green. `docker/Dockerfile` is referenced by `release.yml`, which runs on a tag, so the breakage would first show up at the next release cut.

Introduced by #3128, which added the sidecar and the `.dockerignore` entry.

## Type of change

- [x] Bug fix (`fix:`)
- [ ] New feature (`feat:`)
- [ ] Breaking change (`feat!:` or `fix!:`)
- [ ] Docs / chore

## AWS Compatibility

No emulated behaviour changes — this only restores the image build. The runtime image content is unchanged: the sidecar sources are a test source root, so nothing new is packaged into `quarkus-app/`.

## Checklist

- [x] New or updated integration test added — n/a, this is a build fix with no runtime behaviour
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)

Verified by building `docker/Dockerfile` from `main` at `c1277941`: it fails with the error above before the change and succeeds after.