### PR TITLE
fix(iam): enforce temporary credential lifecycle

### DIFF
--- a/src/main/java/io/github/hectorvent/floci/services/elasticache/proxy/SigV4Validator.java
+++ b/src/main/java/io/github/hectorvent/floci/services/elasticache/proxy/SigV4Validator.java
@@ -115,7 +115,9 @@ public class SigV4Validator {
             if (LEGACY_ACCESS_KEY_ID.equals(accessKeyId)) {
                 secretKey = LEGACY_SECRET_KEY;
             } else {
-                Optional<String> registeredSecretKey = iamService.findSecretKey(accessKeyId);
+                String sessionToken = findRawParam(rawPairs, "X-Amz-Security-Token");
+                Optional<String> registeredSecretKey = iamService.findSecretKey(
+                        accessKeyId, sessionToken == null ? null : urlDecode(sessionToken));
                 if (registeredSecretKey.isEmpty()) {
                     LOG.debugv("IAM token references unregistered access key={0}", sanitizeForLog(accessKeyId));
                     return false;

--- a/src/main/java/io/github/hectorvent/floci/services/iam/IamService.java
+++ b/src/main/java/io/github/hectorvent/floci/services/iam/IamService.java
@@ -1931,8 +1931,8 @@ public class IamService implements SessionAccountLookup, ResourceProvider {
     }
 
     /**
-     * Stores an assumed-role session including the temporary secret access key so that
-     * {@link #findSecretKey(String)} can resolve it for RDS/ElastiCache IAM token validation.
+     * Stores an assumed-role session including the temporary secret access key. Token-aware
+     * authentication paths use the overload that also records the session token.
      */
     public void registerSession(String sessionAccessKeyId, String secretAccessKey, String roleArn,
                                 java.time.Instant expiration, String sessionPolicyDocument) {

--- a/src/main/java/io/github/hectorvent/floci/services/rds/proxy/RdsSigV4Validator.java
+++ b/src/main/java/io/github/hectorvent/floci/services/rds/proxy/RdsSigV4Validator.java
@@ -115,7 +115,9 @@ public class RdsSigV4Validator {
             if (LEGACY_ACCESS_KEY_ID.equals(accessKeyId)) {
                 secretKey = LEGACY_SECRET_KEY;
             } else {
-                Optional<String> registeredSecretKey = iamService.findSecretKey(accessKeyId);
+                String sessionToken = findRawParam(rawPairs, "X-Amz-Security-Token");
+                Optional<String> registeredSecretKey = iamService.findSecretKey(
+                        accessKeyId, sessionToken == null ? null : urlDecode(sessionToken));
                 if (registeredSecretKey.isEmpty()) {
                     LOG.debugv("RDS IAM token references unregistered access key={0}", sanitizeForLog(accessKeyId));
                     return false;

--- a/src/main/java/io/github/hectorvent/floci/services/s3/PreSignedUrlFilter.java
+++ b/src/main/java/io/github/hectorvent/floci/services/s3/PreSignedUrlFilter.java
@@ -115,7 +115,7 @@ public class PreSignedUrlFilter implements ContainerRequestFilter {
             }
 
             String accessKeyId = credParts[0];
-            String secretKey = resolveSecretKey(accessKeyId);
+            String secretKey = resolveSecretKey(accessKeyId, queryParams.getFirst("X-Amz-Security-Token"));
             if (secretKey == null) {
                 requestContext.abortWith(errorResponse(403, "InvalidAccessKeyId",
                         "The AWS Access Key Id you provided does not exist in our records."));
@@ -217,11 +217,15 @@ public class PreSignedUrlFilter implements ContainerRequestFilter {
     }
 
     private String resolveSecretKey(String accessKeyId) {
+        return resolveSecretKey(accessKeyId, null);
+    }
+
+    private String resolveSecretKey(String accessKeyId, String sessionToken) {
         if (LEGACY_ACCESS_KEY_ID.equals(accessKeyId)) {
             return LEGACY_SECRET_KEY;
         }
         if (iamService != null) {
-            Optional<String> registered = iamService.findSecretKey(accessKeyId);
+            Optional<String> registered = iamService.findSecretKey(accessKeyId, sessionToken);
             if (registered.isPresent()) {
                 return registered.get();
             }

--- a/src/main/java/io/github/hectorvent/floci/services/s3/S3Controller.java
+++ b/src/main/java/io/github/hectorvent/floci/services/s3/S3Controller.java
@@ -3308,7 +3308,8 @@ public class S3Controller {
         }
 
         String accessKeyId = credential.split("/", 2)[0];
-        Optional<String> secretKey = S3PostPolicySigner.resolveSecretKey(iamService, accessKeyId);
+        Optional<String> secretKey = S3PostPolicySigner.resolveSecretKey(
+                iamService, accessKeyId, fields.get("x-amz-security-token"));
         if (secretKey.isEmpty()
                 || !S3PostPolicySigner.verifySignature(policy, credential, signature, secretKey.get())) {
             throw new AwsException("SignatureDoesNotMatch",
@@ -3322,7 +3323,7 @@ public class S3Controller {
         // known - strictly weaker than the signature check just performed above - but that will
         // change if authorizeObjectWrite grows real policy evaluation.
         s3Service.authorizeObjectWrite(bucket, key, "s3:PutObject",
-                new S3Service.RequestAuthorization(true, accessKeyId));
+                new S3Service.RequestAuthorization(true, accessKeyId, fields.get("x-amz-security-token")));
 
         validatePolicyExpiration(policy);
         validatePolicyConditions(policy, bucket, fields, contentLength);

--- a/src/main/java/io/github/hectorvent/floci/services/s3/S3PostPolicySigner.java
+++ b/src/main/java/io/github/hectorvent/floci/services/s3/S3PostPolicySigner.java
@@ -25,12 +25,12 @@ final class S3PostPolicySigner {
     private S3PostPolicySigner() {
     }
 
-    static Optional<String> resolveSecretKey(IamService iamService, String accessKeyId) {
+    static Optional<String> resolveSecretKey(IamService iamService, String accessKeyId, String sessionToken) {
         if (LEGACY_ACCESS_KEY_ID.equals(accessKeyId)) {
             return Optional.of(LEGACY_SECRET_KEY);
         }
         if (iamService != null) {
-            return iamService.findSecretKey(accessKeyId);
+            return iamService.findSecretKey(accessKeyId, sessionToken);
         }
         return Optional.empty();
     }

--- a/src/main/java/io/github/hectorvent/floci/services/s3/S3RequestAuthorizationParser.java
+++ b/src/main/java/io/github/hectorvent/floci/services/s3/S3RequestAuthorizationParser.java
@@ -56,10 +56,16 @@ final class S3RequestAuthorizationParser {
     }
 
     static S3Service.RequestAuthorization parse(HttpHeaders httpHeaders, UriInfo uriInfo) {
-        return parse(httpHeaders.getHeaderString("Authorization"), uriInfo.getQueryParameters());
+        return parse(httpHeaders.getHeaderString("Authorization"), uriInfo.getQueryParameters(),
+                httpHeaders.getHeaderString("X-Amz-Security-Token"));
     }
 
     static S3Service.RequestAuthorization parse(String authorization, MultivaluedMap<String, String> queryParameters) {
+        return parse(authorization, queryParameters, null);
+    }
+
+    private static S3Service.RequestAuthorization parse(
+            String authorization, MultivaluedMap<String, String> queryParameters, String headerSessionToken) {
         if (authorization != null && !authorization.isBlank()) {
             String accessKeyId = extractAuthorizationHeaderAccessKeyId(authorization);
             if (accessKeyId == null) {
@@ -67,7 +73,10 @@ final class S3RequestAuthorizationParser {
                 String message = "The authorization header is malformed; the credential scope is invalid.";
                 throw new AwsException("AuthorizationHeaderMalformed", message, 400);
             }
-            return new S3Service.RequestAuthorization(true, accessKeyId);
+            String sessionToken = !isBlank(headerSessionToken)
+                    ? headerSessionToken
+                    : queryParameters.getFirst("X-Amz-Security-Token");
+            return new S3Service.RequestAuthorization(true, accessKeyId, sessionToken);
         }
 
         if (queryParameters.containsKey("X-Amz-Algorithm")) {
@@ -77,7 +86,8 @@ final class S3RequestAuthorizationParser {
                         AUTHORIZATION_QUERY_PARAMETERS_ERROR_MESSAGE,
                         AUTHORIZATION_QUERY_PARAMETERS_ERROR_STATUS);
             }
-            return new S3Service.RequestAuthorization(true, accessKeyId);
+            return new S3Service.RequestAuthorization(
+                    true, accessKeyId, queryParameters.getFirst("X-Amz-Security-Token"));
         }
 
         return S3Service.RequestAuthorization.unsigned();

--- a/src/main/java/io/github/hectorvent/floci/services/s3/S3Service.java
+++ b/src/main/java/io/github/hectorvent/floci/services/s3/S3Service.java
@@ -71,9 +71,9 @@ public class S3Service implements Resettable, ResourceProvider {
 
     private static final Logger LOG = Logger.getLogger(S3Service.class);
 
-    record RequestAuthorization(boolean signed, String accessKeyId) {
+    record RequestAuthorization(boolean signed, String accessKeyId, String sessionToken) {
         static RequestAuthorization unsigned() {
-            return new RequestAuthorization(false, null);
+            return new RequestAuthorization(false, null, null);
         }
     }
 
@@ -852,7 +852,7 @@ public class S3Service implements Resettable, ResourceProvider {
         RequestAuthorization requestAuthorization = authorization != null
                 ? authorization
                 : RequestAuthorization.unsigned();
-        if (requestAuthorization.signed() && !isKnownAccessKey(requestAuthorization.accessKeyId())) {
+        if (requestAuthorization.signed() && !isKnownAccessKey(requestAuthorization)) {
             throw new AwsException("InvalidAccessKeyId",
                     "The AWS Access Key Id you provided does not exist in our records.", 403);
         }
@@ -878,7 +878,7 @@ public class S3Service implements Resettable, ResourceProvider {
                 : RequestAuthorization.unsigned();
 
         if (requestAuthorization.signed()) {
-            if (isKnownAccessKey(requestAuthorization.accessKeyId())) {
+            if (isKnownAccessKey(requestAuthorization)) {
                 return;
             }
             throw new AwsException("InvalidAccessKeyId",
@@ -935,14 +935,16 @@ public class S3Service implements Resettable, ResourceProvider {
         return authorization == null || !authorization.signed();
     }
 
-    private boolean isKnownAccessKey(String accessKeyId) {
+    private boolean isKnownAccessKey(RequestAuthorization authorization) {
+        String accessKeyId = authorization != null ? authorization.accessKeyId() : null;
         if (accessKeyId == null || accessKeyId.isBlank()) {
             return false;
         }
         if (LEGACY_ACCESS_KEY_ID.equals(accessKeyId)) {
             return true;
         }
-        return iamService != null && iamService.findSecretKey(accessKeyId).isPresent();
+        return iamService != null
+                && iamService.findSecretKey(accessKeyId, authorization.sessionToken()).isPresent();
     }
 
     private boolean publicBucketAclAllowsRead(Bucket bucket) {

--- a/src/test/java/io/github/hectorvent/floci/services/elasticache/proxy/SigV4ValidatorTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/elasticache/proxy/SigV4ValidatorTest.java
@@ -234,6 +234,63 @@ class SigV4ValidatorTest {
     }
 
     @Test
+    void validateAcceptsTokenSignedWithStsSessionCredentials() throws Exception {
+        String accessKeyId = "ASIAIOSFODNN7EXAMPLE";
+        String secretAccessKey = "sts-generated-secret-key";
+        IamService iamService = IamServiceTestHelper.iamServiceWithSessionCredential(accessKeyId, secretAccessKey);
+        SigV4Validator validator = new SigV4Validator(iamService);
+
+        String token = SigV4TokenTestHelper.createElastiCacheToken(
+                "cache-cluster-01", "default", accessKeyId, secretAccessKey,
+                Instant.now().minusSeconds(60), 900, "session-token");
+
+        assertTrue(validator.validate(token, "cache-cluster-01", "default"));
+    }
+
+    @Test
+    void validateRejectsStsCredentialWithoutIssuedSessionToken() throws Exception {
+        String accessKeyId = "ASIAIOSFODNN7EXAMPLE";
+        String secretAccessKey = "sts-generated-secret-key";
+        IamService iamService = IamServiceTestHelper.iamServiceWithSessionCredential(accessKeyId, secretAccessKey);
+        SigV4Validator validator = new SigV4Validator(iamService);
+
+        String token = SigV4TokenTestHelper.createElastiCacheToken(
+                "cache-cluster-01", "default", accessKeyId, secretAccessKey,
+                Instant.now().minusSeconds(60), 900);
+
+        assertFalse(validator.validate(token, "cache-cluster-01", "default"));
+    }
+
+    @Test
+    void validateRejectsStsCredentialWithMismatchedSessionToken() throws Exception {
+        String accessKeyId = "ASIAIOSFODNN7EXAMPLE";
+        String secretAccessKey = "sts-generated-secret-key";
+        IamService iamService = IamServiceTestHelper.iamServiceWithSessionCredential(accessKeyId, secretAccessKey);
+        SigV4Validator validator = new SigV4Validator(iamService);
+
+        String token = SigV4TokenTestHelper.createElastiCacheToken(
+                "cache-cluster-01", "default", accessKeyId, secretAccessKey,
+                Instant.now().minusSeconds(60), 900, "wrong-session-token");
+
+        assertFalse(validator.validate(token, "cache-cluster-01", "default"));
+    }
+
+    @Test
+    void validateRejectsExpiredStsCredentialEvenWithMatchingSessionToken() throws Exception {
+        String accessKeyId = "ASIAIOSFODNN7EXAMPLE";
+        String secretAccessKey = "sts-generated-secret-key";
+        IamService iamService = IamServiceTestHelper.iamServiceWithSessionCredential(
+                accessKeyId, secretAccessKey, "session-token", Instant.now().minusSeconds(1));
+        SigV4Validator validator = new SigV4Validator(iamService);
+
+        String token = SigV4TokenTestHelper.createElastiCacheToken(
+                "cache-cluster-01", "default", accessKeyId, secretAccessKey,
+                Instant.now().minusSeconds(60), 900, "session-token");
+
+        assertFalse(validator.validate(token, "cache-cluster-01", "default"));
+    }
+
+    @Test
     void validateRejectsTokenSelfSignedWithUnregisteredAccessKeyAsSecret() throws Exception {
         // Only "AKIDCACHE" is registered; the attacker picks an arbitrary, unregistered
         // access key and signs using that same access key as the secret. If the validator

--- a/src/test/java/io/github/hectorvent/floci/services/rds/proxy/RdsSigV4ValidatorTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/rds/proxy/RdsSigV4ValidatorTest.java
@@ -283,11 +283,55 @@ class RdsSigV4ValidatorTest {
                 accessKeyId,
                 secretAccessKey,
                 Instant.now().minusSeconds(60),
-                900
+                900,
+                "session-token"
         );
 
         assertTrue(validator.validate(token, "admin"),
                 "Validator must accept RDS IAM tokens signed with STS session credentials (ASIA… keys)");
+    }
+
+    @Test
+    void validateRejectsStsCredentialWithoutIssuedSessionToken() throws Exception {
+        String accessKeyId = "ASIAIOSFODNN7EXAMPLE";
+        String secretAccessKey = "sts-generated-secret-key";
+        IamService iamService = IamServiceTestHelper.iamServiceWithSessionCredential(accessKeyId, secretAccessKey);
+        RdsSigV4Validator validator = new RdsSigV4Validator(iamService);
+
+        String token = SigV4TokenTestHelper.createRdsToken(
+                "db.example.local", 5432, "admin", accessKeyId, secretAccessKey,
+                Instant.now().minusSeconds(60), 900);
+
+        assertFalse(validator.validate(token, "admin"));
+    }
+
+    @Test
+    void validateRejectsStsCredentialWithMismatchedSessionToken() throws Exception {
+        String accessKeyId = "ASIAIOSFODNN7EXAMPLE";
+        String secretAccessKey = "sts-generated-secret-key";
+        IamService iamService = IamServiceTestHelper.iamServiceWithSessionCredential(accessKeyId, secretAccessKey);
+        RdsSigV4Validator validator = new RdsSigV4Validator(iamService);
+
+        String token = SigV4TokenTestHelper.createRdsToken(
+                "db.example.local", 5432, "admin", accessKeyId, secretAccessKey,
+                Instant.now().minusSeconds(60), 900, "wrong-session-token");
+
+        assertFalse(validator.validate(token, "admin"));
+    }
+
+    @Test
+    void validateRejectsExpiredStsCredentialEvenWithMatchingSessionToken() throws Exception {
+        String accessKeyId = "ASIAIOSFODNN7EXAMPLE";
+        String secretAccessKey = "sts-generated-secret-key";
+        IamService iamService = IamServiceTestHelper.iamServiceWithSessionCredential(
+                accessKeyId, secretAccessKey, "session-token", Instant.now().minusSeconds(1));
+        RdsSigV4Validator validator = new RdsSigV4Validator(iamService);
+
+        String token = SigV4TokenTestHelper.createRdsToken(
+                "db.example.local", 5432, "admin", accessKeyId, secretAccessKey,
+                Instant.now().minusSeconds(60), 900, "session-token");
+
+        assertFalse(validator.validate(token, "admin"));
     }
 
     @Test

--- a/src/test/java/io/github/hectorvent/floci/services/s3/PreSignedUrlFilterTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/s3/PreSignedUrlFilterTest.java
@@ -27,12 +27,40 @@ class PreSignedUrlFilterTest {
         return (String) method.invoke(filter, accessKeyId);
     }
 
+    private static String resolveSecretKey(
+            PreSignedUrlFilter filter, String accessKeyId, String sessionToken) throws Exception {
+        Method method = PreSignedUrlFilter.class.getDeclaredMethod(
+                "resolveSecretKey", String.class, String.class);
+        method.setAccessible(true);
+        return (String) method.invoke(filter, accessKeyId, sessionToken);
+    }
+
     @Test
     void resolveSecretKeyRejectsUnregisteredNumericAccessKeyId() throws Exception {
         IamService iamService = IamServiceTestHelper.iamServiceWithAccessKey("AKIDUNRELATED", "unrelated-secret");
         PreSignedUrlFilter filter = new PreSignedUrlFilter(null, null, iamService);
 
         assertNull(resolveSecretKey(filter, "123456789012"));
+    }
+
+    @Test
+    void temporaryCredentialRequiresMatchingSessionToken() throws Exception {
+        IamService iamService = IamServiceTestHelper.iamServiceWithSessionCredential(
+                "ASIAS3EXAMPLE", "temporary-secret", "issued-token", java.time.Instant.now().plusSeconds(3600));
+        PreSignedUrlFilter filter = new PreSignedUrlFilter(null, null, iamService);
+
+        assertEquals("temporary-secret", resolveSecretKey(filter, "ASIAS3EXAMPLE", "issued-token"));
+        assertNull(resolveSecretKey(filter, "ASIAS3EXAMPLE", null));
+        assertNull(resolveSecretKey(filter, "ASIAS3EXAMPLE", "wrong-token"));
+    }
+
+    @Test
+    void temporaryCredentialIsRejectedAfterExpiration() throws Exception {
+        IamService iamService = IamServiceTestHelper.iamServiceWithSessionCredential(
+                "ASIAS3EXPIRED", "temporary-secret", "issued-token", java.time.Instant.now().minusSeconds(1));
+        PreSignedUrlFilter filter = new PreSignedUrlFilter(null, null, iamService);
+
+        assertNull(resolveSecretKey(filter, "ASIAS3EXPIRED", "issued-token"));
     }
 
     private static MultivaluedMap<String, String> params() {

--- a/src/test/java/io/github/hectorvent/floci/services/s3/S3AuthEnforcementIntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/s3/S3AuthEnforcementIntegrationTest.java
@@ -1,8 +1,10 @@
 package io.github.hectorvent.floci.services.s3;
 
+import io.github.hectorvent.floci.services.iam.IamService;
 import io.quarkus.test.junit.QuarkusTest;
 import io.quarkus.test.junit.QuarkusTestProfile;
 import io.quarkus.test.junit.TestProfile;
+import jakarta.inject.Inject;
 import org.junit.jupiter.api.MethodOrderer;
 import org.junit.jupiter.api.Order;
 import org.junit.jupiter.api.Test;
@@ -29,6 +31,9 @@ import static org.hamcrest.Matchers.not;
 @TestProfile(S3AuthEnforcementIntegrationTest.S3AuthProfile.class)
 @TestMethodOrder(MethodOrderer.OrderAnnotation.class)
 class S3AuthEnforcementIntegrationTest {
+
+    @Inject
+    IamService iamService;
 
     private static final String PUBLIC_BUCKET = "auth-public-bucket";
     private static final String PRIVATE_BUCKET = "auth-private-bucket";
@@ -1424,6 +1429,33 @@ class S3AuthEnforcementIntegrationTest {
 
     private static String credential(String accessKeyId) {
         return accessKeyId + "/" + SIGNING_DATE + "/us-east-1/s3/aws4_request";
+    }
+
+    @Test
+    @Order(45)
+    void signedRequestWithTemporaryCredentialRequiresIssuedSessionToken() {
+        String accessKeyId = "ASIAS3NORMALREQUEST";
+        String sessionToken = "issued-session-token";
+        iamService.registerSession(
+                accessKeyId,
+                "temp-key-material",
+                sessionToken,
+                null,
+                Instant.now().plusSeconds(3600),
+                null);
+        String authorization = authorizationHeader(accessKeyId);
+        String path = "/" + PRIVATE_BUCKET + "/" + PRIVATE_KEY;
+
+        given().header("Authorization", authorization)
+                .header("X-Amz-Security-Token", sessionToken)
+                .when().get(path).then().statusCode(200).body(equalTo("private body"));
+
+        given().header("Authorization", authorization)
+                .when().get(path).then().statusCode(403).body(containsString("InvalidAccessKeyId"));
+
+        given().header("Authorization", authorization)
+                .header("X-Amz-Security-Token", "other-session-token")
+                .when().get(path).then().statusCode(403).body(containsString("InvalidAccessKeyId"));
     }
 
     private static String presignedSignature(String method, String path,

--- a/src/test/java/io/github/hectorvent/floci/services/s3/S3RequestAuthorizationParserTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/s3/S3RequestAuthorizationParserTest.java
@@ -35,6 +35,18 @@ class S3RequestAuthorizationParserTest {
 
         assertTrue(authorization.signed());
         assertEquals("bad-key", authorization.accessKeyId());
+        assertNull(authorization.sessionToken());
+    }
+
+    @Test
+    void parsesPresignedQuerySessionToken() {
+        MultivaluedMap<String, String> query = presignedQuery("ASIAEXAMPLE");
+        query.add("X-Amz-Security-Token", "issued-session-token");
+
+        S3Service.RequestAuthorization authorization = parse(null, query);
+
+        assertEquals("ASIAEXAMPLE", authorization.accessKeyId());
+        assertEquals("issued-session-token", authorization.sessionToken());
     }
 
     @Test

--- a/src/test/java/io/github/hectorvent/floci/services/s3/S3ServiceTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/s3/S3ServiceTest.java
@@ -656,7 +656,7 @@ class S3ServiceTest {
     // =========================================================================
 
     private static final S3Service.RequestAuthorization UNSIGNED =
-            new S3Service.RequestAuthorization(false, null);
+            new S3Service.RequestAuthorization(false, null, null);
 
     private void websiteBucket(String index, String errorDoc) {
         s3Service.createBucket("site", "us-east-1");

--- a/src/test/java/io/github/hectorvent/floci/testutil/SigV4TokenTestHelper.java
+++ b/src/test/java/io/github/hectorvent/floci/testutil/SigV4TokenTestHelper.java
@@ -31,9 +31,24 @@ public final class SigV4TokenTestHelper {
             Instant timestamp,
             int expiresSeconds
     ) throws Exception {
+        return createElastiCacheToken(clusterId, user, accessKeyId, secretKey, timestamp, expiresSeconds, null);
+    }
+
+    public static String createElastiCacheToken(
+            String clusterId,
+            String user,
+            String accessKeyId,
+            String secretKey,
+            Instant timestamp,
+            int expiresSeconds,
+            String sessionToken
+    ) throws Exception {
         Map<String, String> params = new LinkedHashMap<>();
         params.put("Action", "connect");
         params.put("User", user);
+        if (sessionToken != null) {
+            params.put("X-Amz-Security-Token", sessionToken);
+        }
         return signToken(clusterId, null, accessKeyId, secretKey, "us-east-1",
                 "elasticache", timestamp, expiresSeconds, params, Map.of("host", clusterId));
     }
@@ -60,9 +75,25 @@ public final class SigV4TokenTestHelper {
             Instant timestamp,
             int expiresSeconds
     ) throws Exception {
+        return createRdsToken(host, port, dbUser, accessKeyId, secretKey, timestamp, expiresSeconds, null);
+    }
+
+    public static String createRdsToken(
+            String host,
+            int port,
+            String dbUser,
+            String accessKeyId,
+            String secretKey,
+            Instant timestamp,
+            int expiresSeconds,
+            String sessionToken
+    ) throws Exception {
         Map<String, String> params = new LinkedHashMap<>();
         params.put("Action", "connect");
         params.put("DBUser", dbUser);
+        if (sessionToken != null) {
+            params.put("X-Amz-Security-Token", sessionToken);
+        }
         return signToken(host, port, accessKeyId, secretKey, "us-east-1",
                 "rds-db", timestamp, expiresSeconds, params, Map.of("host", host + ":" + port));
     }


### PR DESCRIPTION
## Summary

- require the issued STS session token on S3, RDS IAM auth, and ElastiCache IAM auth requests that use temporary credentials
- preserve the existing lifecycle checks for inactive IAM access keys and expired sessions
- carry `X-Amz-Security-Token` through S3 header, presigned-query, and presigned-POST authorization paths
- keep long-term IAM credentials and the documented local `test` credential behavior unchanged

Closes #1934

## Type of change

- [x] Bug fix (`fix:`)
- [ ] New feature (`feat:`)
- [ ] Breaking change (`feat!:` or `fix!:`)
- [ ] Docs / chore

## AWS Compatibility

Current `main` already rejects inactive IAM access keys and expired temporary sessions in `IamService`, and already stores STS session tokens. This change closes the remaining authentication gaps where service validators still resolved a temporary credential by access-key ID and secret alone.

AWS references used for the implementation and senior review:

- IAM UpdateAccessKey: https://docs.aws.amazon.com/IAM/latest/APIReference/API_UpdateAccessKey.html
- Temporary security credentials: https://docs.aws.amazon.com/IAM/latest/UserGuide/id_credentials_temp_request.html
- SigV4 with temporary credentials: https://docs.aws.amazon.com/IAM/latest/UserGuide/reference_sigv-create-signed-request.html
- S3 temporary credentials: https://docs.aws.amazon.com/AmazonS3/latest/dev/RESTAuthentication.html
- S3 SigV4 query authentication: https://docs.aws.amazon.com/AmazonS3/latest/API/sigv4-query-string-auth.html
- S3 browser POST with SigV4: https://docs.aws.amazon.com/AmazonS3/latest/API/sigv4-HTTPPOSTForms.html
- RDS IAM database authentication: https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/UsingWithRDS.IAMDBAuth.html
- ElastiCache IAM authentication: https://docs.aws.amazon.com/AmazonElastiCache/latest/dg/auth-iam.html

Focused validation:

`./mvnw -q -Dtest=IamServiceTest,RdsSigV4ValidatorTest,SigV4ValidatorTest,S3RequestAuthorizationParserTest,PreSignedUrlFilterTest,S3AuthEnforcementIntegrationTest,S3PresignedPostAuthEnforcementIntegrationTest test`

`make docs-check`

`git diff --check origin/main...HEAD`

## Checklist

- [ ] `./mvnw test` passes locally
- [x] New or updated integration test added
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
