### PR TITLE
perf(build): keep the managed policy catalog files out of the native image

### DIFF
--- a/compatibility-tests/sdk-test-java/src/test/java/com/floci/test/IamTest.java
+++ b/compatibility-tests/sdk-test-java/src/test/java/com/floci/test/IamTest.java
@@ -35,6 +35,7 @@ import software.amazon.awssdk.services.iam.model.GetInstanceProfileRequest;
 import software.amazon.awssdk.services.iam.model.GetInstanceProfileResponse;
 import software.amazon.awssdk.services.iam.model.GetPolicyRequest;
 import software.amazon.awssdk.services.iam.model.GetPolicyResponse;
+import software.amazon.awssdk.services.iam.model.GetPolicyVersionRequest;
 import software.amazon.awssdk.services.iam.model.GetRoleRequest;
 import software.amazon.awssdk.services.iam.model.GetRoleResponse;
 import software.amazon.awssdk.services.iam.model.GetRolePolicyRequest;
@@ -58,6 +59,7 @@ import software.amazon.awssdk.services.iam.model.ListUserTagsRequest;
 import software.amazon.awssdk.services.iam.model.ListUserTagsResponse;
 import software.amazon.awssdk.services.iam.model.ListUsersResponse;
 import software.amazon.awssdk.services.iam.model.NoSuchEntityException;
+import software.amazon.awssdk.services.iam.model.PolicyScopeType;
 import software.amazon.awssdk.services.iam.model.PutRolePolicyRequest;
 import software.amazon.awssdk.services.iam.model.RemoveRoleFromInstanceProfileRequest;
 import software.amazon.awssdk.services.iam.model.RemoveUserFromGroupRequest;
@@ -66,6 +68,9 @@ import software.amazon.awssdk.services.iam.model.StatusType;
 import software.amazon.awssdk.services.iam.model.TagUserRequest;
 import software.amazon.awssdk.services.iam.model.UntagUserRequest;
 import software.amazon.awssdk.services.iam.model.UpdateAccessKeyRequest;
+
+import java.net.URLDecoder;
+import java.nio.charset.StandardCharsets;
 
 import static org.assertj.core.api.Assertions.*;
 
@@ -79,6 +84,11 @@ class IamTest {
     private static final String ROLE_NAME = "sdk-test-role";
     private static final String POLICY_NAME = "sdk-test-policy";
     private static final String INSTANCE_PROFILE_NAME = "sdk-test-profile";
+    private static final String AWS_MANAGED_POLICY_PREFIX = "arn:aws:iam::aws:policy/";
+    private static final String ADMIN_POLICY_ARN = AWS_MANAGED_POLICY_PREFIX + "AdministratorAccess";
+    private static final String READ_ONLY_POLICY_ARN = AWS_MANAGED_POLICY_PREFIX + "ReadOnlyAccess";
+    private static final String LAMBDA_BASIC_POLICY_ARN =
+            AWS_MANAGED_POLICY_PREFIX + "service-role/AWSLambdaBasicExecutionRole";
     private static final String TRUST_POLICY = "{\"Version\":\"2012-10-17\",\"Statement\":[{\"Effect\":\"Allow\","
             + "\"Principal\":{\"Service\":\"lambda.amazonaws.com\"},\"Action\":\"sts:AssumeRole\"}]}";
     private static final String POLICY_DOCUMENT = "{\"Version\":\"2012-10-17\",\"Statement\":[{\"Effect\":\"Allow\","
@@ -131,6 +141,10 @@ class IamTest {
                     iam.deletePolicy(DeletePolicyRequest.builder().policyArn(policyArn).build());
                 } catch (Exception ignored) {}
             }
+            try {
+                iam.detachUserPolicy(DetachUserPolicyRequest.builder()
+                        .userName(USER_NAME).policyArn(READ_ONLY_POLICY_ARN).build());
+            } catch (Exception ignored) {}
             try {
                 iam.removeUserFromGroup(RemoveUserFromGroupRequest.builder()
                         .groupName(GROUP_NAME).userName(USER_NAME).build());
@@ -522,6 +536,81 @@ class IamTest {
     void getUserNotFoundThrows() {
         assertThatThrownBy(() -> iam.getUser(GetUserRequest.builder()
                 .userName("nonexistent-user-xyz").build()))
+                .isInstanceOf(NoSuchEntityException.class);
+    }
+
+    // ── AWS managed policies ───────────────────────────────────────────
+    // The catalog is parsed while the native image is built and lives in its
+    // heap, so only a run against a native binary proves the documents survived.
+
+    @Test
+    @Order(33)
+    void getAwsManagedPolicy() {
+        var response = iam.getPolicy(GetPolicyRequest.builder().policyArn(ADMIN_POLICY_ARN).build());
+
+        assertThat(response.policy().policyName()).isEqualTo("AdministratorAccess");
+        assertThat(response.policy().arn()).isEqualTo(ADMIN_POLICY_ARN);
+        assertThat(response.policy().path()).isEqualTo("/");
+        assertThat(response.policy().defaultVersionId()).matches("v[1-9][0-9]*");
+        assertThat(response.policy().isAttachable()).isTrue();
+    }
+
+    @Test
+    @Order(34)
+    void getAwsManagedPolicyWithServiceRolePath() {
+        var response = iam.getPolicy(GetPolicyRequest.builder().policyArn(LAMBDA_BASIC_POLICY_ARN).build());
+
+        assertThat(response.policy().policyName()).isEqualTo("AWSLambdaBasicExecutionRole");
+        assertThat(response.policy().path()).isEqualTo("/service-role/");
+    }
+
+    @Test
+    @Order(35)
+    void getAwsManagedPolicyVersionDocument() {
+        var versionId = iam.getPolicy(GetPolicyRequest.builder().policyArn(ADMIN_POLICY_ARN).build())
+                .policy().defaultVersionId();
+        var response = iam.getPolicyVersion(GetPolicyVersionRequest.builder()
+                .policyArn(ADMIN_POLICY_ARN).versionId(versionId).build());
+
+        assertThat(response.policyVersion().versionId()).isEqualTo(versionId);
+        assertThat(response.policyVersion().isDefaultVersion()).isTrue();
+        var document = URLDecoder.decode(response.policyVersion().document(), StandardCharsets.UTF_8);
+        assertThat(document).startsWith("{").contains("\"Statement\"").contains("\"Effect\"");
+    }
+
+    @Test
+    @Order(36)
+    void listAwsManagedPolicies() {
+        var names = iam.listPoliciesPaginator(request -> request.scope(PolicyScopeType.AWS))
+                .policies().stream().map(policy -> policy.policyName()).toList();
+
+        assertThat(names).hasSizeGreaterThan(1000)
+                .contains("AdministratorAccess", "ReadOnlyAccess", "AWSLambdaBasicExecutionRole");
+    }
+
+    @Test
+    @Order(37)
+    void attachAwsManagedPolicyToUser() {
+        iam.attachUserPolicy(AttachUserPolicyRequest.builder()
+                .userName(USER_NAME).policyArn(READ_ONLY_POLICY_ARN).build());
+
+        var response = iam.listAttachedUserPolicies(ListAttachedUserPoliciesRequest.builder()
+                .userName(USER_NAME).build());
+
+        assertThat(response.attachedPolicies())
+                .anyMatch(p -> READ_ONLY_POLICY_ARN.equals(p.policyArn())
+                        && "ReadOnlyAccess".equals(p.policyName()));
+
+        iam.detachUserPolicy(DetachUserPolicyRequest.builder()
+                .userName(USER_NAME).policyArn(READ_ONLY_POLICY_ARN).build());
+    }
+
+    @Test
+    @Order(38)
+    void attachUnknownAwsManagedPolicyThrows() {
+        assertThatThrownBy(() -> iam.attachUserPolicy(AttachUserPolicyRequest.builder()
+                .userName(USER_NAME)
+                .policyArn(AWS_MANAGED_POLICY_PREFIX + "NoSuchManagedPolicyXyz").build()))
                 .isInstanceOf(NoSuchEntityException.class);
     }
 }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -37,20 +37,20 @@ quarkus:
   native:
     resources:
       # The Pricing service reads its bundled snapshot, EC2 reads its image
-      # catalog (ec2/image-catalog.yaml), IAM reads its AWS managed-policy
-      # catalog (iam/managed-policies.yaml, iam/managed-policy-documents.json and
-      # iam/managed-policy-versions.json), AppSync's GraphQL parser reads its
+      # catalog (ec2/image-catalog.yaml), AppSync's GraphQL parser reads its
       # message bundles, and API Gateway's Velocity engine reads its default
-      # properties at runtime via
-      # ClassLoader#getResourceAsStream. Quarkus's static resource analysis
-      # cannot detect these dynamically-built paths, so they are registered
-      # explicitly to ensure GraalVM includes every file in the native image.
+      # properties at runtime via ClassLoader#getResourceAsStream. Quarkus's
+      # static resource analysis cannot detect these dynamically-built paths,
+      # so they are registered explicitly to ensure GraalVM includes every
+      # file in the native image.
+      # The IAM managed-policy catalog (iam/*) is not listed on purpose.
+      # AwsManagedPolicies parses it while the image is built and the parsed
+      # catalog lives in the image heap, so the 3.5 MB of source files would
+      # only be a second copy of the same data.
       includes:
         - pricing-snapshots/**
         - ui/*.html
         - ec2/*.yaml
-        - iam/*.yaml
-        - iam/*.json
         - i18n/*.properties
         - org/apache/velocity/runtime/defaults/*.properties
       # snappy-java registers 27 JNI libraries, one per platform. Only the one


### PR DESCRIPTION
## Summary


`AwsManagedPolicies` reads `iam/managed-policies.yaml`, `iam/managed-policy-documents.json` and `iam/managed-policy-versions.json` in its static initializer. Quarkus runs that at build time, so the parsed catalog is already in the image heap as `String`s. The three files were also listed under `quarkus.native.resources.includes`, which embedded a second copy of the same 3.5 MB as `byte[]` that nothing reads at run time. This PR drops them from the includes.

Format | BEFORE | AFTER | Change
---|---:|---:|---:
Uncompressed | 215.9 MB | 212.2 MB | -3.7 MB (-1.7%)
GZIP | 82.3 MB | 81.9 MB | -0.4 MB (-0.5%)

(macOS aarch64, Oracle GraalVM 25.0.4.1, default flags)

Image heap goes from 102.4 MB to 98.6 MB, resources from 386 to 383.
Reachable types and methods are unchanged.

If the class is ever moved to run-time initialization the native binary fails at startup with the existing "catalog not found" error, so the missing files cannot go unnoticed.

## Type of change

- [ ] Bug fix (`fix:`)
- [ ] New feature (`feat:`)
- [ ] Breaking change (`feat!:` or `fix!:`)
- [x] Docs / chore

## AWS Compatibility

No emulated surface changes.
The catalog served by the native binary is the same object graph as before,  verified via new tests

## Checklist

- [x] `./mvnw test` passes locally
- [x] New or updated integration test added
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
