### PR TITLE
feat(ec2): support snapshot block public access

### DIFF
--- a/docs/services/ec2.md
+++ b/docs/services/ec2.md
@@ -645,6 +645,8 @@ This is an account-level setting scoped per region, not a resource, so there is 
 
 Only `GetSnapshotBlockPublicAccessState` returns `managedBy`, and it always reports `account` because Floci has no declarative-policy layer that could take the setting over. Nothing here changes snapshot permissions: no snapshot's `createVolumePermission` is rewritten when the block goes on or off.
 
+All three actions honor `DryRun`. A request that would otherwise succeed returns `DryRunOperation` with HTTP 412 and leaves the stored state untouched. `EnableSnapshotBlockPublicAccess` validates `State` first, so an invalid or missing `State` is still rejected on its own error even when `DryRun=true` is set.
+
 ### IPAM
 
 | Action | Description |

--- a/docs/services/ec2.md
+++ b/docs/services/ec2.md
@@ -633,6 +633,18 @@ These are account-level settings scoped per region, not per volume, and nothing 
 
 An account that has never set a key reports `alias/aws/ebs`, the AWS-managed EBS key every account starts with, rather than an empty value — the module runner fails hard on a missing `KmsKeyId`, so the fallback is what keeps it running. `ResetEbsDefaultKmsKeyId` returns to that same alias. `ModifyEbsDefaultKmsKeyId` requires `KmsKeyId` and rejects a blank one with `MissingParameter`; the key is stored as given and is not checked against KMS.
 
+### Snapshot Block Public Access
+
+| Action | Description |
+|--------|-------------|
+| EnableSnapshotBlockPublicAccess | Sets the region's snapshot sharing block to `block-all-sharing` or `block-new-sharing`. |
+| DisableSnapshotBlockPublicAccess | Returns the region to `unblocked`. |
+| GetSnapshotBlockPublicAccessState | Reads the region's current state. |
+
+This is an account-level setting scoped per region, not a resource, so there is no id and nothing to tag. A region that was never configured reads back `unblocked`. `EnableSnapshotBlockPublicAccess` accepts only `block-all-sharing` and `block-new-sharing`, and rejects `unblocked` with `InvalidParameterValue` the way AWS does: disabling goes through `DisableSnapshotBlockPublicAccess`, which returns the resulting `unblocked` rather than the prior state. A missing `State` is rejected with `MissingParameter`.
+
+Only `GetSnapshotBlockPublicAccessState` returns `managedBy`, and it always reports `account` because Floci has no declarative-policy layer that could take the setting over. Nothing here changes snapshot permissions: no snapshot's `createVolumePermission` is rewritten when the block goes on or off.
+
 ### IPAM
 
 | Action | Description |

--- a/src/main/java/io/github/hectorvent/floci/core/common/AwsQueryController.java
+++ b/src/main/java/io/github/hectorvent/floci/core/common/AwsQueryController.java
@@ -157,6 +157,8 @@ public class AwsQueryController {
             "CreateKeyPair", "DescribeKeyPairs", "DeleteKeyPair", "ImportKeyPair",
             "DescribeImages", "RegisterImage", "DeregisterImage", "CreateImage", "CopyImage",
             "DescribeSnapshots",
+            "EnableSnapshotBlockPublicAccess", "DisableSnapshotBlockPublicAccess",
+            "GetSnapshotBlockPublicAccessState",
             "CreateTags", "DeleteTags", "DescribeTags",
             "CreateInternetGateway", "DescribeInternetGateways", "DeleteInternetGateway",
             "AttachInternetGateway", "DetachInternetGateway",

--- a/src/main/java/io/github/hectorvent/floci/services/ec2/Ec2QueryHandler.java
+++ b/src/main/java/io/github/hectorvent/floci/services/ec2/Ec2QueryHandler.java
@@ -41,15 +41,19 @@ public class Ec2QueryHandler {
     private final EmulatorConfig config;
     private final FlowLogService flowLogService;
     private final Ec2EbsEncryptionService ebsEncryptionService;
+    private final Ec2SnapshotBlockPublicAccessService snapshotBlockPublicAccessService;
     private final Ec2IpamService ipamService;
 
     @Inject
     public Ec2QueryHandler(Ec2Service service, EmulatorConfig config, FlowLogService flowLogService,
-                           Ec2EbsEncryptionService ebsEncryptionService, Ec2IpamService ipamService) {
+                           Ec2EbsEncryptionService ebsEncryptionService,
+                           Ec2SnapshotBlockPublicAccessService snapshotBlockPublicAccessService,
+                           Ec2IpamService ipamService) {
         this.service = service;
         this.config = config;
         this.flowLogService = flowLogService;
         this.ebsEncryptionService = ebsEncryptionService;
+        this.snapshotBlockPublicAccessService = snapshotBlockPublicAccessService;
         this.ipamService = ipamService;
     }
 
@@ -80,6 +84,10 @@ public class Ec2QueryHandler {
                 case "GetEbsDefaultKmsKeyId" -> handleGetEbsDefaultKmsKeyId(region);
                 case "ModifyEbsDefaultKmsKeyId" -> handleModifyEbsDefaultKmsKeyId(params, region);
                 case "ResetEbsDefaultKmsKeyId" -> handleResetEbsDefaultKmsKeyId(region);
+                // Snapshot block public access
+                case "EnableSnapshotBlockPublicAccess" -> handleEnableSnapshotBlockPublicAccess(params, region);
+                case "DisableSnapshotBlockPublicAccess" -> handleDisableSnapshotBlockPublicAccess(region);
+                case "GetSnapshotBlockPublicAccessState" -> handleGetSnapshotBlockPublicAccessState(region);
                 // VPCs
                 case "CreateVpc" -> handleCreateVpc(params, region);
                 case "DescribeVpcs" -> handleDescribeVpcs(params, region);
@@ -577,6 +585,34 @@ public class Ec2QueryHandler {
                 .start(rootElement, AwsNamespaces.EC2)
                 .elem("requestId", UUID.randomUUID().toString())
                 .elem("ebsEncryptionByDefault", String.valueOf(enabled))
+                .end(rootElement);
+        return xmlResponse(xml.build());
+    }
+
+    private Response handleEnableSnapshotBlockPublicAccess(MultivaluedMap<String, String> p, String region) {
+        return snapshotBlockPublicAccessResponse("EnableSnapshotBlockPublicAccessResponse",
+                snapshotBlockPublicAccessService.enableSnapshotBlockPublicAccess(region, p.getFirst("State")),
+                null);
+    }
+
+    private Response handleDisableSnapshotBlockPublicAccess(String region) {
+        return snapshotBlockPublicAccessResponse("DisableSnapshotBlockPublicAccessResponse",
+                snapshotBlockPublicAccessService.disableSnapshotBlockPublicAccess(region), null);
+    }
+
+    private Response handleGetSnapshotBlockPublicAccessState(String region) {
+        // Only GetSnapshotBlockPublicAccessState carries managedBy, and Floci has no
+        // declarative-policy layer, so the account always owns the state.
+        return snapshotBlockPublicAccessResponse("GetSnapshotBlockPublicAccessStateResponse",
+                snapshotBlockPublicAccessService.getSnapshotBlockPublicAccessState(region), "account");
+    }
+
+    private Response snapshotBlockPublicAccessResponse(String rootElement, String state, String managedBy) {
+        XmlBuilder xml = new XmlBuilder()
+                .start(rootElement, AwsNamespaces.EC2)
+                .elem("requestId", UUID.randomUUID().toString())
+                .elem("state", state)
+                .elem("managedBy", managedBy)
                 .end(rootElement);
         return xmlResponse(xml.build());
     }

--- a/src/main/java/io/github/hectorvent/floci/services/ec2/Ec2QueryHandler.java
+++ b/src/main/java/io/github/hectorvent/floci/services/ec2/Ec2QueryHandler.java
@@ -86,8 +86,8 @@ public class Ec2QueryHandler {
                 case "ResetEbsDefaultKmsKeyId" -> handleResetEbsDefaultKmsKeyId(region);
                 // Snapshot block public access
                 case "EnableSnapshotBlockPublicAccess" -> handleEnableSnapshotBlockPublicAccess(params, region);
-                case "DisableSnapshotBlockPublicAccess" -> handleDisableSnapshotBlockPublicAccess(region);
-                case "GetSnapshotBlockPublicAccessState" -> handleGetSnapshotBlockPublicAccessState(region);
+                case "DisableSnapshotBlockPublicAccess" -> handleDisableSnapshotBlockPublicAccess(params, region);
+                case "GetSnapshotBlockPublicAccessState" -> handleGetSnapshotBlockPublicAccessState(params, region);
                 // VPCs
                 case "CreateVpc" -> handleCreateVpc(params, region);
                 case "DescribeVpcs" -> handleDescribeVpcs(params, region);
@@ -590,19 +590,26 @@ public class Ec2QueryHandler {
     }
 
     private Response handleEnableSnapshotBlockPublicAccess(MultivaluedMap<String, String> p, String region) {
+        // Validate State before honoring DryRun. AWS returns DryRunOperation only once the
+        // request would otherwise have succeeded, so a bad State still fails on its own error.
+        String state = p.getFirst("State");
+        snapshotBlockPublicAccessService.validateEnableState(state);
+        checkDryRun(p);
         return snapshotBlockPublicAccessResponse("EnableSnapshotBlockPublicAccessResponse",
-                snapshotBlockPublicAccessService.enableSnapshotBlockPublicAccess(region, p.getFirst("State")),
+                snapshotBlockPublicAccessService.enableSnapshotBlockPublicAccess(region, state),
                 null);
     }
 
-    private Response handleDisableSnapshotBlockPublicAccess(String region) {
+    private Response handleDisableSnapshotBlockPublicAccess(MultivaluedMap<String, String> p, String region) {
+        checkDryRun(p);
         return snapshotBlockPublicAccessResponse("DisableSnapshotBlockPublicAccessResponse",
                 snapshotBlockPublicAccessService.disableSnapshotBlockPublicAccess(region), null);
     }
 
-    private Response handleGetSnapshotBlockPublicAccessState(String region) {
+    private Response handleGetSnapshotBlockPublicAccessState(MultivaluedMap<String, String> p, String region) {
         // Only GetSnapshotBlockPublicAccessState carries managedBy, and Floci has no
         // declarative-policy layer, so the account always owns the state.
+        checkDryRun(p);
         return snapshotBlockPublicAccessResponse("GetSnapshotBlockPublicAccessStateResponse",
                 snapshotBlockPublicAccessService.getSnapshotBlockPublicAccessState(region), "account");
     }

--- a/src/main/java/io/github/hectorvent/floci/services/ec2/Ec2SnapshotBlockPublicAccessService.java
+++ b/src/main/java/io/github/hectorvent/floci/services/ec2/Ec2SnapshotBlockPublicAccessService.java
@@ -52,7 +52,12 @@ public class Ec2SnapshotBlockPublicAccessService {
         this.states = states;
     }
 
-    public String enableSnapshotBlockPublicAccess(String region, String state) {
+    /**
+     * Validate the requested State without touching stored state, so a caller can reject a
+     * bad request before it honors DryRun. AWS reports an invalid parameter ahead of
+     * DryRunOperation, which it only returns once the request could otherwise succeed.
+     */
+    public void validateEnableState(String state) {
         if (state == null || state.isBlank()) {
             throw new AwsException("MissingParameter",
                     "The request must contain the parameter State", 400);
@@ -62,6 +67,10 @@ public class Ec2SnapshotBlockPublicAccessService {
                     "Value (" + state + ") for parameter State is invalid. Valid values are "
                             + BLOCK_ALL_SHARING + " and " + BLOCK_NEW_SHARING, 400);
         }
+    }
+
+    public String enableSnapshotBlockPublicAccess(String region, String state) {
+        validateEnableState(state);
         states.put(region, state);
         LOG.infov("Snapshot block public access in {0} set to {1}", region, state);
         return state;

--- a/src/main/java/io/github/hectorvent/floci/services/ec2/Ec2SnapshotBlockPublicAccessService.java
+++ b/src/main/java/io/github/hectorvent/floci/services/ec2/Ec2SnapshotBlockPublicAccessService.java
@@ -1,0 +1,79 @@
+package io.github.hectorvent.floci.services.ec2;
+
+import com.fasterxml.jackson.core.type.TypeReference;
+import io.github.hectorvent.floci.core.common.AwsException;
+import io.github.hectorvent.floci.core.storage.StorageBackend;
+import io.github.hectorvent.floci.core.storage.StorageFactory;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
+import org.jboss.logging.Logger;
+
+import java.util.Map;
+import java.util.Set;
+
+/**
+ * Block public access for snapshots: an account-level setting scoped to one region,
+ * not a resource, so the region is the whole key and there is nothing to tag or
+ * describe by id. The storage backend namespaces keys by the calling account, which
+ * is what makes the setting account-and-region scoped.
+ *
+ * <p>A region that was never configured reads back {@code unblocked}, matching the
+ * value AWS reports for an account that never enabled the setting.</p>
+ */
+@ApplicationScoped
+public class Ec2SnapshotBlockPublicAccessService {
+
+    private static final Logger LOG = Logger.getLogger(Ec2SnapshotBlockPublicAccessService.class);
+
+    /** The state AWS reports for an account and region that never enabled the setting. */
+    public static final String UNBLOCKED = "unblocked";
+
+    static final String BLOCK_ALL_SHARING = "block-all-sharing";
+    static final String BLOCK_NEW_SHARING = "block-new-sharing";
+
+    /**
+     * SnapshotBlockPublicAccessState also carries {@code unblocked}, but the EC2 model
+     * documents it as invalid for EnableSnapshotBlockPublicAccess. Disabling goes through
+     * DisableSnapshotBlockPublicAccess instead.
+     */
+    private static final Set<String> BLOCKING_STATES = Set.of(BLOCK_ALL_SHARING, BLOCK_NEW_SHARING);
+
+    // region -> SnapshotBlockPublicAccessState
+    private final StorageBackend<String, String> states;
+
+    @Inject
+    public Ec2SnapshotBlockPublicAccessService(StorageFactory storageFactory) {
+        this(storageFactory.create("ec2", "ec2-snapshot-block-public-access.json",
+                new TypeReference<Map<String, String>>() {}));
+    }
+
+    // Package-private for hermetic tests (pass an in-memory StorageBackend directly).
+    Ec2SnapshotBlockPublicAccessService(StorageBackend<String, String> states) {
+        this.states = states;
+    }
+
+    public String enableSnapshotBlockPublicAccess(String region, String state) {
+        if (state == null || state.isBlank()) {
+            throw new AwsException("MissingParameter",
+                    "The request must contain the parameter State", 400);
+        }
+        if (!BLOCKING_STATES.contains(state)) {
+            throw new AwsException("InvalidParameterValue",
+                    "Value (" + state + ") for parameter State is invalid. Valid values are "
+                            + BLOCK_ALL_SHARING + " and " + BLOCK_NEW_SHARING, 400);
+        }
+        states.put(region, state);
+        LOG.infov("Snapshot block public access in {0} set to {1}", region, state);
+        return state;
+    }
+
+    public String disableSnapshotBlockPublicAccess(String region) {
+        states.put(region, UNBLOCKED);
+        LOG.infov("Snapshot block public access in {0} set to {1}", region, UNBLOCKED);
+        return UNBLOCKED;
+    }
+
+    public String getSnapshotBlockPublicAccessState(String region) {
+        return states.get(region).orElse(UNBLOCKED);
+    }
+}

--- a/src/test/java/io/github/hectorvent/floci/services/ec2/Ec2CreateFleetRollbackTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/ec2/Ec2CreateFleetRollbackTest.java
@@ -49,7 +49,8 @@ class Ec2CreateFleetRollbackTest {
         when(service.terminateInstances(REGION, List.of("i-second"))).thenReturn(List.of());
 
         Ec2QueryHandler handler = new Ec2QueryHandler(service, mock(EmulatorConfig.class),
-                mock(FlowLogService.class), mock(Ec2EbsEncryptionService.class), mock(Ec2IpamService.class));
+                mock(FlowLogService.class), mock(Ec2EbsEncryptionService.class),
+                mock(Ec2SnapshotBlockPublicAccessService.class), mock(Ec2IpamService.class));
         Response response = handler.handle("CreateFleet", params(), REGION);
 
         assertEquals(400, response.getStatus());

--- a/src/test/java/io/github/hectorvent/floci/services/ec2/Ec2RunInstancesPublicIpParamTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/ec2/Ec2RunInstancesPublicIpParamTest.java
@@ -63,7 +63,7 @@ class Ec2RunInstancesPublicIpParamTest {
 
         Ec2QueryHandler handler = new Ec2QueryHandler(service, mock(EmulatorConfig.class),
                 mock(FlowLogService.class), mock(Ec2EbsEncryptionService.class),
-                mock(Ec2IpamService.class));
+                mock(Ec2SnapshotBlockPublicAccessService.class), mock(Ec2IpamService.class));
         handler.handle("RunInstances", p, REGION);
 
         ArgumentCaptor<Boolean> associatePublicIp = ArgumentCaptor.forClass(Boolean.class);

--- a/src/test/java/io/github/hectorvent/floci/services/ec2/Ec2SnapshotBlockPublicAccessIntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/ec2/Ec2SnapshotBlockPublicAccessIntegrationTest.java
@@ -200,4 +200,109 @@ class Ec2SnapshotBlockPublicAccessIntegrationTest {
             .statusCode(200)
             .body("GetSnapshotBlockPublicAccessStateResponse.state", equalTo("block-all-sharing"));
     }
+
+    @Test
+    @Order(8)
+    void dryRunGetReturnsDryRunOperation() {
+        given()
+            .formParam("Action", "GetSnapshotBlockPublicAccessState")
+            .formParam("DryRun", "true")
+            .header("Authorization", AUTH_HEADER)
+        .when()
+            .post("/")
+        .then()
+            .statusCode(412)
+            .body("Response.Errors.Error.Code", equalTo("DryRunOperation"));
+    }
+
+    @Test
+    @Order(9)
+    void dryRunEnableLeavesTheStoredStateAlone() {
+        given()
+            .formParam("Action", "EnableSnapshotBlockPublicAccess")
+            .formParam("State", "block-all-sharing")
+            .header("Authorization", AUTH_HEADER)
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200)
+            .body("EnableSnapshotBlockPublicAccessResponse.state", equalTo("block-all-sharing"));
+
+        given()
+            .formParam("Action", "EnableSnapshotBlockPublicAccess")
+            .formParam("State", "block-new-sharing")
+            .formParam("DryRun", "true")
+            .header("Authorization", AUTH_HEADER)
+        .when()
+            .post("/")
+        .then()
+            .statusCode(412)
+            .body("Response.Errors.Error.Code", equalTo("DryRunOperation"));
+
+        given()
+            .formParam("Action", "GetSnapshotBlockPublicAccessState")
+            .header("Authorization", AUTH_HEADER)
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200)
+            .body("GetSnapshotBlockPublicAccessStateResponse.state", equalTo("block-all-sharing"));
+    }
+
+    @Test
+    @Order(10)
+    void dryRunEnableRejectsAnInvalidStateBeforeReportingDryRun() {
+        given()
+            .formParam("Action", "EnableSnapshotBlockPublicAccess")
+            .formParam("State", "unblocked")
+            .formParam("DryRun", "true")
+            .header("Authorization", AUTH_HEADER)
+        .when()
+            .post("/")
+        .then()
+            .statusCode(400)
+            .body("Response.Errors.Error.Code", equalTo("InvalidParameterValue"));
+
+        given()
+            .formParam("Action", "EnableSnapshotBlockPublicAccess")
+            .formParam("DryRun", "true")
+            .header("Authorization", AUTH_HEADER)
+        .when()
+            .post("/")
+        .then()
+            .statusCode(400)
+            .body("Response.Errors.Error.Code", equalTo("MissingParameter"));
+
+        given()
+            .formParam("Action", "GetSnapshotBlockPublicAccessState")
+            .header("Authorization", AUTH_HEADER)
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200)
+            .body("GetSnapshotBlockPublicAccessStateResponse.state", equalTo("block-all-sharing"));
+    }
+
+    @Test
+    @Order(11)
+    void dryRunDisableLeavesTheStoredStateAlone() {
+        given()
+            .formParam("Action", "DisableSnapshotBlockPublicAccess")
+            .formParam("DryRun", "true")
+            .header("Authorization", AUTH_HEADER)
+        .when()
+            .post("/")
+        .then()
+            .statusCode(412)
+            .body("Response.Errors.Error.Code", equalTo("DryRunOperation"));
+
+        given()
+            .formParam("Action", "GetSnapshotBlockPublicAccessState")
+            .header("Authorization", AUTH_HEADER)
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200)
+            .body("GetSnapshotBlockPublicAccessStateResponse.state", equalTo("block-all-sharing"));
+    }
 }

--- a/src/test/java/io/github/hectorvent/floci/services/ec2/Ec2SnapshotBlockPublicAccessIntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/ec2/Ec2SnapshotBlockPublicAccessIntegrationTest.java
@@ -1,0 +1,203 @@
+package io.github.hectorvent.floci.services.ec2;
+
+import static io.restassured.RestAssured.given;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.not;
+
+import io.quarkus.test.junit.QuarkusTest;
+import org.junit.jupiter.api.MethodOrderer;
+import org.junit.jupiter.api.Order;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestMethodOrder;
+
+/**
+ * Integration tests for block public access for snapshots over the EC2 Query Protocol
+ * (form-encoded POST, XML response).
+ *
+ * <p>The setting is account-and-region scoped state rather than a resource: there is no id
+ * and nothing to tag, only one value that Enable and Disable move and Get reads back. Only
+ * the Get response carries {@code managedBy}.</p>
+ */
+@QuarkusTest
+@TestMethodOrder(MethodOrderer.OrderAnnotation.class)
+class Ec2SnapshotBlockPublicAccessIntegrationTest {
+
+    private static final String AUTH_HEADER =
+            "AWS4-HMAC-SHA256 Credential=test/20260205/us-east-1/ec2/aws4_request";
+
+    private static final String OTHER_REGION_AUTH_HEADER =
+            "AWS4-HMAC-SHA256 Credential=test/20260205/eu-west-1/ec2/aws4_request";
+
+    @Test
+    @Order(1)
+    void unconfiguredRegionReportsUnblocked() {
+        given()
+            .formParam("Action", "GetSnapshotBlockPublicAccessState")
+            .header("Authorization", AUTH_HEADER)
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200)
+            .contentType("application/xml")
+            .body("GetSnapshotBlockPublicAccessStateResponse.state", equalTo("unblocked"))
+            .body("GetSnapshotBlockPublicAccessStateResponse.managedBy", equalTo("account"));
+    }
+
+    @Test
+    @Order(2)
+    void enableStoresBlockAllSharing() {
+        String body = given()
+            .formParam("Action", "EnableSnapshotBlockPublicAccess")
+            .formParam("State", "block-all-sharing")
+            .header("Authorization", AUTH_HEADER)
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200)
+            .contentType("application/xml")
+            .body("EnableSnapshotBlockPublicAccessResponse.state", equalTo("block-all-sharing"))
+            .extract().asString();
+
+        // EnableSnapshotBlockPublicAccessResult carries State alone.
+        assertThat(body, not(containsString("managedBy")));
+
+        given()
+            .formParam("Action", "GetSnapshotBlockPublicAccessState")
+            .header("Authorization", AUTH_HEADER)
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200)
+            .body("GetSnapshotBlockPublicAccessStateResponse.state", equalTo("block-all-sharing"));
+    }
+
+    @Test
+    @Order(3)
+    void enableNarrowsTheBlockToNewSharing() {
+        given()
+            .formParam("Action", "EnableSnapshotBlockPublicAccess")
+            .formParam("State", "block-new-sharing")
+            .header("Authorization", AUTH_HEADER)
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200)
+            .body("EnableSnapshotBlockPublicAccessResponse.state", equalTo("block-new-sharing"));
+
+        given()
+            .formParam("Action", "GetSnapshotBlockPublicAccessState")
+            .header("Authorization", AUTH_HEADER)
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200)
+            .body("GetSnapshotBlockPublicAccessStateResponse.state", equalTo("block-new-sharing"));
+    }
+
+    @Test
+    @Order(4)
+    void enableRejectsUnblocked() {
+        given()
+            .formParam("Action", "EnableSnapshotBlockPublicAccess")
+            .formParam("State", "unblocked")
+            .header("Authorization", AUTH_HEADER)
+        .when()
+            .post("/")
+        .then()
+            .statusCode(400)
+            .body("Response.Errors.Error.Code", equalTo("InvalidParameterValue"));
+
+        given()
+            .formParam("Action", "GetSnapshotBlockPublicAccessState")
+            .header("Authorization", AUTH_HEADER)
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200)
+            .body("GetSnapshotBlockPublicAccessStateResponse.state", equalTo("block-new-sharing"));
+    }
+
+    @Test
+    @Order(5)
+    void enableRequiresState() {
+        given()
+            .formParam("Action", "EnableSnapshotBlockPublicAccess")
+            .header("Authorization", AUTH_HEADER)
+        .when()
+            .post("/")
+        .then()
+            .statusCode(400)
+            .body("Response.Errors.Error.Code", equalTo("MissingParameter"));
+    }
+
+    @Test
+    @Order(6)
+    void anotherRegionKeepsItsOwnState() {
+        given()
+            .formParam("Action", "GetSnapshotBlockPublicAccessState")
+            .header("Authorization", OTHER_REGION_AUTH_HEADER)
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200)
+            .body("GetSnapshotBlockPublicAccessStateResponse.state", equalTo("unblocked"));
+
+        given()
+            .formParam("Action", "EnableSnapshotBlockPublicAccess")
+            .formParam("State", "block-all-sharing")
+            .header("Authorization", OTHER_REGION_AUTH_HEADER)
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200)
+            .body("EnableSnapshotBlockPublicAccessResponse.state", equalTo("block-all-sharing"));
+
+        given()
+            .formParam("Action", "GetSnapshotBlockPublicAccessState")
+            .header("Authorization", AUTH_HEADER)
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200)
+            .body("GetSnapshotBlockPublicAccessStateResponse.state", equalTo("block-new-sharing"));
+    }
+
+    @Test
+    @Order(7)
+    void disableReturnsAndStoresUnblocked() {
+        String body = given()
+            .formParam("Action", "DisableSnapshotBlockPublicAccess")
+            .header("Authorization", AUTH_HEADER)
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200)
+            .contentType("application/xml")
+            .body("DisableSnapshotBlockPublicAccessResponse.state", equalTo("unblocked"))
+            .extract().asString();
+
+        // DisableSnapshotBlockPublicAccessResult carries State alone.
+        assertThat(body, not(containsString("managedBy")));
+
+        given()
+            .formParam("Action", "GetSnapshotBlockPublicAccessState")
+            .header("Authorization", AUTH_HEADER)
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200)
+            .body("GetSnapshotBlockPublicAccessStateResponse.state", equalTo("unblocked"));
+
+        // Disabling one region leaves the other alone.
+        given()
+            .formParam("Action", "GetSnapshotBlockPublicAccessState")
+            .header("Authorization", OTHER_REGION_AUTH_HEADER)
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200)
+            .body("GetSnapshotBlockPublicAccessStateResponse.state", equalTo("block-all-sharing"));
+    }
+}

--- a/src/test/java/io/github/hectorvent/floci/services/ec2/Ec2SnapshotBlockPublicAccessServiceTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/ec2/Ec2SnapshotBlockPublicAccessServiceTest.java
@@ -65,6 +65,18 @@ class Ec2SnapshotBlockPublicAccessServiceTest {
     }
 
     @Test
+    void validateEnableStateRejectsWithoutStoringAnything() {
+        service.enableSnapshotBlockPublicAccess("us-east-1", "block-all-sharing");
+
+        assertThrows(AwsException.class, () -> service.validateEnableState("unblocked"));
+        assertThrows(AwsException.class, () -> service.validateEnableState(null));
+        assertEquals("block-all-sharing", service.getSnapshotBlockPublicAccessState("us-east-1"));
+
+        service.validateEnableState("block-new-sharing");
+        assertEquals("block-all-sharing", service.getSnapshotBlockPublicAccessState("us-east-1"));
+    }
+
+    @Test
     void disableReturnsUnblocked() {
         service.enableSnapshotBlockPublicAccess("us-east-1", "block-all-sharing");
 

--- a/src/test/java/io/github/hectorvent/floci/services/ec2/Ec2SnapshotBlockPublicAccessServiceTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/ec2/Ec2SnapshotBlockPublicAccessServiceTest.java
@@ -1,0 +1,89 @@
+package io.github.hectorvent.floci.services.ec2;
+
+import io.github.hectorvent.floci.core.common.AwsException;
+import io.github.hectorvent.floci.core.storage.InMemoryStorage;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+class Ec2SnapshotBlockPublicAccessServiceTest {
+
+    private Ec2SnapshotBlockPublicAccessService service;
+
+    @BeforeEach
+    void setUp() {
+        service = new Ec2SnapshotBlockPublicAccessService(new InMemoryStorage<>());
+    }
+
+    @Test
+    void unconfiguredRegionIsUnblocked() {
+        assertEquals("unblocked", service.getSnapshotBlockPublicAccessState("us-east-1"));
+    }
+
+    @Test
+    void enableStoresBlockAllSharing() {
+        assertEquals("block-all-sharing",
+                service.enableSnapshotBlockPublicAccess("us-east-1", "block-all-sharing"));
+        assertEquals("block-all-sharing", service.getSnapshotBlockPublicAccessState("us-east-1"));
+    }
+
+    @Test
+    void enableNarrowsAnExistingBlockToNewSharing() {
+        service.enableSnapshotBlockPublicAccess("us-east-1", "block-all-sharing");
+
+        assertEquals("block-new-sharing",
+                service.enableSnapshotBlockPublicAccess("us-east-1", "block-new-sharing"));
+        assertEquals("block-new-sharing", service.getSnapshotBlockPublicAccessState("us-east-1"));
+    }
+
+    @Test
+    void enableRejectsUnblocked() {
+        AwsException thrown = assertThrows(AwsException.class,
+                () -> service.enableSnapshotBlockPublicAccess("us-east-1", "unblocked"));
+        assertEquals("InvalidParameterValue", thrown.getErrorCode());
+        assertEquals("unblocked", service.getSnapshotBlockPublicAccessState("us-east-1"));
+    }
+
+    @Test
+    void enableRejectsAnUnknownState() {
+        AwsException thrown = assertThrows(AwsException.class,
+                () -> service.enableSnapshotBlockPublicAccess("us-east-1", "block-everything"));
+        assertEquals("InvalidParameterValue", thrown.getErrorCode());
+    }
+
+    @Test
+    void enableRequiresState() {
+        AwsException missing = assertThrows(AwsException.class,
+                () -> service.enableSnapshotBlockPublicAccess("us-east-1", null));
+        assertEquals("MissingParameter", missing.getErrorCode());
+
+        AwsException blank = assertThrows(AwsException.class,
+                () -> service.enableSnapshotBlockPublicAccess("us-east-1", " "));
+        assertEquals("MissingParameter", blank.getErrorCode());
+    }
+
+    @Test
+    void disableReturnsUnblocked() {
+        service.enableSnapshotBlockPublicAccess("us-east-1", "block-all-sharing");
+
+        assertEquals("unblocked", service.disableSnapshotBlockPublicAccess("us-east-1"));
+        assertEquals("unblocked", service.getSnapshotBlockPublicAccessState("us-east-1"));
+    }
+
+    @Test
+    void stateIsRegionScoped() {
+        service.enableSnapshotBlockPublicAccess("us-east-1", "block-all-sharing");
+
+        assertEquals("block-all-sharing", service.getSnapshotBlockPublicAccessState("us-east-1"));
+        assertEquals("unblocked", service.getSnapshotBlockPublicAccessState("eu-west-1"));
+
+        service.enableSnapshotBlockPublicAccess("eu-west-1", "block-new-sharing");
+        assertEquals("block-all-sharing", service.getSnapshotBlockPublicAccessState("us-east-1"));
+        assertEquals("block-new-sharing", service.getSnapshotBlockPublicAccessState("eu-west-1"));
+
+        service.disableSnapshotBlockPublicAccess("eu-west-1");
+        assertEquals("block-all-sharing", service.getSnapshotBlockPublicAccessState("us-east-1"));
+    }
+}


### PR DESCRIPTION
## Summary

Ports EC2 snapshot block public access from lex00/floci#118.

Terraform's `aws_ebs_snapshot_block_public_access` resource fails against Floci today. The provider calls `GetSnapshotBlockPublicAccessState` on read and `EnableSnapshotBlockPublicAccess` on create, and neither action existed. An SDK client sees the same gap. An unknown Query action falls through to the SQS handler and comes back as an error.

All three actions now run over the existing Query protocol path and return XML. The state lives in a small `Ec2SnapshotBlockPublicAccessService` keyed by region, which mirrors how `Ec2EbsEncryptionService` stores the EBS account defaults. Storage goes through `StorageFactory`, so the account-aware backend namespaces every key by the calling credential's account. A region nobody configured reads back `unblocked`. Enable takes `block-all-sharing` or `block-new-sharing` and rejects `unblocked` with `InvalidParameterValue`, matching the EC2 model, which documents that value as invalid for that operation. Disable returns the resulting `unblocked` rather than the prior state. Only the Get response carries `managedBy`, and it always reports `account` because Floci has no declarative-policy layer.

Coverage is a unit test over the service plus an integration test that asserts the XML wire response. Both exercise all three operations. They check the default an unconfigured region reports and they check that two regions hold separate values. Enable with `unblocked` and Enable with no `State` at all are covered as well.

## Type of change

- [ ] Bug fix (`fix:`)
- [x] New feature (`feat:`)
- [ ] Breaking change (`feat!:` or `fix!:`)
- [ ] Docs / chore

## AWS Compatibility

Verified against the botocore EC2 model, `ec2/2016-11-15/service-2.json`, as shipped with AWS CLI `2.35.24`.

## Checklist

- [ ] `./mvnw test` passes locally
- [x] New or updated integration test added
- [x] Commit messages follow Conventional Commits

I ran `./mvnw test -Dtest='Ec2*Test'` and it reported 926 tests run with 0 failures and 0 errors. `make docs-check` exits 0.
