### PR TITLE
fix(ec2): store and validate CreateVpcEndpoint SubnetConfiguration

### DIFF
--- a/docs/services/ec2.md
+++ b/docs/services/ec2.md
@@ -189,9 +189,9 @@ Floci seeds the following resources on first use in each region so Terraform, th
 | ModifyVpcAttribute | Updates supported VPC attributes. |
 | DescribeVpcAttribute | Returns a supported VPC attribute. |
 | DescribeVpcEndpointServices | Returns an empty local VPC endpoint service catalog. |
-| CreateVpcEndpoint | Creates a VPC endpoint record, including its `PolicyDocument`. |
+| CreateVpcEndpoint | Creates a VPC endpoint record, including its `PolicyDocument` and the per-subnet IPv4 and IPv6 addresses named by `SubnetConfiguration.N`. |
 | DescribeVpcEndpoints | Lists or returns stored VPC endpoints. |
-| ModifyVpcEndpoint | Associates or disassociates route tables, subnets and security groups, and sets or resets the endpoint policy. `DnsOptions`, `IpAddressType` and `SubnetConfiguration.N` are accepted and ignored. |
+| ModifyVpcEndpoint | Associates or disassociates route tables, subnets and security groups, and sets or resets the endpoint policy. `SubnetConfiguration.N` replaces the addresses pinned for a subnet. `DnsOptions` and `IpAddressType` are accepted and ignored. |
 | DeleteVpcEndpoints | Deletes VPC endpoint records. |
 | CreateDefaultVpc | Creates or returns the default VPC for the region. |
 | AssociateVpcCidrBlock | Adds a secondary CIDR block association to a VPC. |

--- a/docs/services/ec2.md
+++ b/docs/services/ec2.md
@@ -189,9 +189,9 @@ Floci seeds the following resources on first use in each region so Terraform, th
 | ModifyVpcAttribute | Updates supported VPC attributes. |
 | DescribeVpcAttribute | Returns a supported VPC attribute. |
 | DescribeVpcEndpointServices | Returns an empty local VPC endpoint service catalog. |
-| CreateVpcEndpoint | Creates a VPC endpoint record, including its `PolicyDocument` and the per-subnet IPv4 and IPv6 addresses named by `SubnetConfiguration.N`. |
+| CreateVpcEndpoint | Creates a VPC endpoint record, including its `PolicyDocument` and the per-subnet IPv4 and IPv6 addresses named by `SubnetConfiguration.N`. An `Ipv4` value outside the named subnet's CIDR, or among the first four or the last address AWS reserves in it, is rejected with `InvalidParameterValue`. |
 | DescribeVpcEndpoints | Lists or returns stored VPC endpoints. |
-| ModifyVpcEndpoint | Associates or disassociates route tables, subnets and security groups, and sets or resets the endpoint policy. `SubnetConfiguration.N` replaces the addresses pinned for a subnet. `DnsOptions` and `IpAddressType` are accepted and ignored. |
+| ModifyVpcEndpoint | Associates or disassociates route tables, subnets and security groups, and sets or resets the endpoint policy. `SubnetConfiguration.N` replaces the addresses pinned for a subnet, under the same address validation as CreateVpcEndpoint. `DnsOptions` and `IpAddressType` are accepted and ignored. |
 | DeleteVpcEndpoints | Deletes VPC endpoint records. |
 | CreateDefaultVpc | Creates or returns the default VPC for the region. |
 | AssociateVpcCidrBlock | Adds a secondary CIDR block association to a VPC. |

--- a/src/main/java/io/github/hectorvent/floci/services/ec2/Ec2QueryHandler.java
+++ b/src/main/java/io/github/hectorvent/floci/services/ec2/Ec2QueryHandler.java
@@ -517,6 +517,27 @@ public class Ec2QueryHandler {
         return tags;
     }
 
+    /**
+     * Reads the {@code SubnetConfiguration.N} list shared by CreateVpcEndpoint and
+     * ModifyVpcEndpoint. The EC2 query protocol flattens the list under the member's
+     * locationName, so the wire form is {@code SubnetConfiguration.1.SubnetId} alongside
+     * {@code .Ipv4} and {@code .Ipv6}, numbered from 1. An entry carrying only addresses and no
+     * subnet ends the list, since the subnet is what an address is assigned within.
+     */
+    private List<VpcEndpointSubnetConfiguration> parseSubnetConfigurations(MultivaluedMap<String, String> p) {
+        List<VpcEndpointSubnetConfiguration> configurations = new ArrayList<>();
+        for (int i = 1; ; i++) {
+            String prefix = "SubnetConfiguration." + i;
+            String subnetId = p.getFirst(prefix + ".SubnetId");
+            if (subnetId == null) {
+                break;
+            }
+            configurations.add(new VpcEndpointSubnetConfiguration(
+                    subnetId, p.getFirst(prefix + ".Ipv4"), p.getFirst(prefix + ".Ipv6")));
+        }
+        return configurations;
+    }
+
     // Apply tags supplied inline on a create call (TagSpecification) to the resource, so
     // they round-trip on the next Describe* — otherwise the provider sees phantom tag drift.
     private void applyResourceTags(MultivaluedMap<String, String> p, String region, String resourceType, String resourceId) {
@@ -1930,7 +1951,8 @@ public class Ec2QueryHandler {
                 getList(p, "SecurityGroupId"),
                 p.getFirst("PrivateDnsEnabled") != null ? Boolean.valueOf(p.getFirst("PrivateDnsEnabled")) : null,
                 p.getFirst("PolicyDocument"),
-                parseTagsForResource(p, "vpc-endpoint"));
+                parseTagsForResource(p, "vpc-endpoint"),
+                parseSubnetConfigurations(p));
         XmlBuilder xml = new XmlBuilder()
                 .start("CreateVpcEndpointResponse", AwsNamespaces.EC2)
                 .elem("requestId", UUID.randomUUID().toString())
@@ -1951,7 +1973,8 @@ public class Ec2QueryHandler {
                 getList(p, "RemoveSecurityGroupId"),
                 p.getFirst("PolicyDocument"),
                 p.getFirst("ResetPolicy") != null ? Boolean.valueOf(p.getFirst("ResetPolicy")) : null,
-                p.getFirst("PrivateDnsEnabled") != null ? Boolean.valueOf(p.getFirst("PrivateDnsEnabled")) : null);
+                p.getFirst("PrivateDnsEnabled") != null ? Boolean.valueOf(p.getFirst("PrivateDnsEnabled")) : null,
+                parseSubnetConfigurations(p));
         // ModifyVpcEndpoint returns only a boolean; the caller re-reads the endpoint
         // through DescribeVpcEndpoints to see the result.
         XmlBuilder xml = new XmlBuilder()

--- a/src/main/java/io/github/hectorvent/floci/services/ec2/Ec2Service.java
+++ b/src/main/java/io/github/hectorvent/floci/services/ec2/Ec2Service.java
@@ -99,6 +99,7 @@ import io.github.hectorvent.floci.services.ec2.model.Vpc;
 import io.github.hectorvent.floci.services.ec2.model.VpcCidrBlockAssociation;
 import io.github.hectorvent.floci.services.ec2.model.VpcIpv6CidrBlockAssociation;
 import io.github.hectorvent.floci.services.ec2.model.VpcEndpoint;
+import io.github.hectorvent.floci.services.ec2.model.VpcEndpointSubnetConfiguration;
 import io.github.hectorvent.floci.services.ec2.model.VpcPeeringConnection;
 import io.github.hectorvent.floci.services.ec2.model.VpcPeeringConnectionStateReason;
 import io.github.hectorvent.floci.services.ec2.model.VpcPeeringConnectionVpcInfo;
@@ -3314,14 +3315,34 @@ public class Ec2Service implements ContainerTeardown, ResourceProvider {
                                          List<String> routeTableIds, List<String> subnetIds,
                                          List<String> securityGroupIds, Boolean privateDnsEnabled,
                                          String policyDocument, List<Tag> endpointTags) {
+        return createVpcEndpoint(region, vpcId, serviceName, endpointType, routeTableIds, subnetIds,
+                securityGroupIds, privateDnsEnabled, policyDocument, endpointTags, List.of());
+    }
+
+    public VpcEndpoint createVpcEndpoint(String region, String vpcId, String serviceName, String endpointType,
+                                         List<String> routeTableIds, List<String> subnetIds,
+                                         List<String> securityGroupIds, Boolean privateDnsEnabled,
+                                         String policyDocument, List<Tag> endpointTags,
+                                         List<VpcEndpointSubnetConfiguration> subnetConfigurations) {
         ensureDefaultResources(region);
         getRequiredVpc(region, vpcId);
         for (String routeTableId : routeTableIds) {
             getRequiredRouteTable(region, routeTableId);
         }
-        for (String subnetId : subnetIds) {
+        // Every subnet a SubnetConfiguration names gets an endpoint interface, so it belongs to
+        // the endpoint whether or not the flat SubnetId list repeats it. AWS expects the two to
+        // agree; taking the union keeps a request that names a subnet only through its
+        // configuration from losing that subnet altogether.
+        List<String> effectiveSubnetIds = new ArrayList<>(subnetIds);
+        for (VpcEndpointSubnetConfiguration config : subnetConfigurations) {
+            if (config.getSubnetId() != null && !effectiveSubnetIds.contains(config.getSubnetId())) {
+                effectiveSubnetIds.add(config.getSubnetId());
+            }
+        }
+        for (String subnetId : effectiveSubnetIds) {
             requireSubnet(region, subnetId);
         }
+        validateSubnetConfigurations(region, subnetConfigurations);
         for (String securityGroupId : securityGroupIds) {
             getRequiredSecurityGroup(region, securityGroupId);
         }
@@ -3336,8 +3357,9 @@ public class Ec2Service implements ContainerTeardown, ResourceProvider {
         endpoint.setCreationTimestamp(Instant.now());
         endpoint.setRegion(region);
         endpoint.setRouteTableIds(new ArrayList<>(routeTableIds));
-        endpoint.setSubnetIds(new ArrayList<>(subnetIds));
+        endpoint.setSubnetIds(effectiveSubnetIds);
         endpoint.setSecurityGroupIds(new ArrayList<>(securityGroupIds));
+        endpoint.setSubnetConfigurations(new ArrayList<>(subnetConfigurations));
         endpoint.setPolicyDocument(policyDocument);
         if (endpointTags != null && !endpointTags.isEmpty()) {
             endpoint.setTags(new ArrayList<>(endpointTags));
@@ -3361,6 +3383,17 @@ public class Ec2Service implements ContainerTeardown, ResourceProvider {
                                          List<String> addSubnetIds, List<String> removeSubnetIds,
                                          List<String> addSecurityGroupIds, List<String> removeSecurityGroupIds,
                                          String policyDocument, Boolean resetPolicy, Boolean privateDnsEnabled) {
+        return modifyVpcEndpoint(region, endpointId, addRouteTableIds, removeRouteTableIds,
+                addSubnetIds, removeSubnetIds, addSecurityGroupIds, removeSecurityGroupIds,
+                policyDocument, resetPolicy, privateDnsEnabled, List.of());
+    }
+
+    public VpcEndpoint modifyVpcEndpoint(String region, String endpointId,
+                                         List<String> addRouteTableIds, List<String> removeRouteTableIds,
+                                         List<String> addSubnetIds, List<String> removeSubnetIds,
+                                         List<String> addSecurityGroupIds, List<String> removeSecurityGroupIds,
+                                         String policyDocument, Boolean resetPolicy, Boolean privateDnsEnabled,
+                                         List<VpcEndpointSubnetConfiguration> subnetConfigurations) {
         // VpcEndpointId is the one required member of ModifyVpcEndpointRequest. The model
         // requires it to be present, not to be non-empty, so only an absent value is a
         // MissingParameter; a present-but-unknown id is an InvalidVpcEndpointId.NotFound.
@@ -3379,7 +3412,7 @@ public class Ec2Service implements ContainerTeardown, ResourceProvider {
             return modifyVpcEndpointLocked(region, endpointId,
                     addRouteTableIds, removeRouteTableIds, addSubnetIds, removeSubnetIds,
                     addSecurityGroupIds, removeSecurityGroupIds,
-                    policyDocument, resetPolicy, privateDnsEnabled);
+                    policyDocument, resetPolicy, privateDnsEnabled, subnetConfigurations);
         }
     }
 
@@ -3388,7 +3421,8 @@ public class Ec2Service implements ContainerTeardown, ResourceProvider {
                                                 List<String> addSubnetIds, List<String> removeSubnetIds,
                                                 List<String> addSecurityGroupIds, List<String> removeSecurityGroupIds,
                                                 String policyDocument, Boolean resetPolicy,
-                                                Boolean privateDnsEnabled) {
+                                                Boolean privateDnsEnabled,
+                                                List<VpcEndpointSubnetConfiguration> subnetConfigurations) {
         VpcEndpoint endpoint = getRequiredVpcEndpoint(region, endpointId);
 
         // Validate every referenced id before mutating anything, so a request naming one
@@ -3402,10 +3436,12 @@ public class Ec2Service implements ContainerTeardown, ResourceProvider {
         for (String securityGroupId : addSecurityGroupIds) {
             getRequiredSecurityGroup(region, securityGroupId);
         }
+        validateSubnetConfigurations(region, subnetConfigurations);
 
         applyIdChanges(endpoint.getRouteTableIds(), addRouteTableIds, removeRouteTableIds);
         applyIdChanges(endpoint.getSubnetIds(), addSubnetIds, removeSubnetIds);
         applyIdChanges(endpoint.getSecurityGroupIds(), addSecurityGroupIds, removeSecurityGroupIds);
+        applySubnetConfigurations(endpoint, subnetConfigurations, removeSubnetIds);
 
         if (Boolean.TRUE.equals(resetPolicy)) {
             endpoint.setPolicyDocument(null);
@@ -3418,6 +3454,53 @@ public class Ec2Service implements ContainerTeardown, ResourceProvider {
 
         vpcEndpoints.put(key(region, endpointId), endpoint);
         return endpoint;
+    }
+
+    /**
+     * Checks a {@code SubnetConfiguration} list before anything is stored. The named subnet has to
+     * exist, and an IPv4 address has to be one the endpoint's interface in that subnet could
+     * actually take, which means inside the subnet's own CIDR. AWS rejects an address outside it
+     * with {@code InvalidParameterValue}; accepting it here would hand back an interface address
+     * that belongs to a different subnet.
+     *
+     * <p>IPv6 is stored as given. Floci's subnets carry no IPv6 CIDR to check an address against.
+     */
+    private void validateSubnetConfigurations(String region,
+                                              List<VpcEndpointSubnetConfiguration> subnetConfigurations) {
+        for (VpcEndpointSubnetConfiguration config : subnetConfigurations) {
+            Subnet subnet = requireSubnet(region, config.getSubnetId());
+            String ipv4 = config.getIpv4();
+            if (ipv4 == null || ipv4.isBlank()) {
+                continue;
+            }
+            String host = ipv4 + "/32";
+            if (!Ipv4Cidrs.isIpv4(host)) {
+                throw new AwsException("InvalidParameterValue",
+                        "Invalid IPv4 address: " + ipv4, 400);
+            }
+            if (subnet.getCidrBlock() == null || !Ipv4Cidrs.contains(subnet.getCidrBlock(), host)) {
+                throw new AwsException("InvalidParameterValue",
+                        "Address " + ipv4 + " does not fall within the address range of subnet "
+                                + subnet.getSubnetId(), 400);
+            }
+        }
+    }
+
+    /**
+     * Applies a ModifyVpcEndpoint {@code SubnetConfiguration} list. Each entry replaces the
+     * configuration for its subnet, which is what AWS does when it rebuilds that subnet's endpoint
+     * interface around the new address. A subnet the same request removes keeps no configuration:
+     * it has no interface left to address.
+     */
+    private static void applySubnetConfigurations(VpcEndpoint endpoint,
+                                                  List<VpcEndpointSubnetConfiguration> subnetConfigurations,
+                                                  List<String> removeSubnetIds) {
+        List<VpcEndpointSubnetConfiguration> current = endpoint.getSubnetConfigurations();
+        current.removeIf(config -> removeSubnetIds.contains(config.getSubnetId()));
+        for (VpcEndpointSubnetConfiguration config : subnetConfigurations) {
+            current.removeIf(existing -> existing.getSubnetId().equals(config.getSubnetId()));
+            current.add(config);
+        }
     }
 
     /** Removals apply before additions, and an id is never added twice. */
@@ -3484,7 +3567,7 @@ public class Ec2Service implements ContainerTeardown, ResourceProvider {
                 ni.setAvailabilityZone(subnet.getAvailabilityZone());
                 ni.setDescription("VPC Endpoint Interface " + endpoint.getVpcEndpointId());
                 ni.setInterfaceType("vpc_endpoint");
-                ni.setPrivateIpAddress(endpointPrivateIp(subnet, endpoint.getVpcEndpointId()));
+                ni.setPrivateIpAddress(endpointPrivateIp(subnet, endpoint, subnetId));
                 result.add(ni);
             }
         }
@@ -3498,12 +3581,24 @@ public class Ec2Service implements ContainerTeardown, ResourceProvider {
         return "eni-" + hex.substring(0, 17);
     }
 
-    /** Stable host address near the top of the subnet range, clear of the instance counter (starts at 10). */
-    private static String endpointPrivateIp(Subnet subnet, String endpointId) {
+    /**
+     * The interface address for one of the endpoint's subnets. An address the caller pinned
+     * through {@code SubnetConfiguration} wins outright: AWS fixes that address on the interface,
+     * and falling back to a synthesized one would answer a later describe with an address the
+     * caller never asked for. Otherwise it is a stable host address near the top of the subnet
+     * range, clear of the instance counter (starts at 10).
+     */
+    private static String endpointPrivateIp(Subnet subnet, VpcEndpoint endpoint, String subnetId) {
+        for (VpcEndpointSubnetConfiguration config : endpoint.getSubnetConfigurations()) {
+            if (subnetId.equals(config.getSubnetId())
+                    && config.getIpv4() != null && !config.getIpv4().isBlank()) {
+                return config.getIpv4();
+            }
+        }
         String cidr = subnet.getCidrBlock();
         String baseIp = cidr != null ? cidr.split("/")[0] : "172.31.0.0";
         String[] parts = baseIp.split("\\.");
-        int host = 200 + Math.floorMod(endpointId.hashCode(), 50);
+        int host = 200 + Math.floorMod(endpoint.getVpcEndpointId().hashCode(), 50);
         return parts[0] + "." + parts[1] + "." + parts[2] + "." + host;
     }
 

--- a/src/main/java/io/github/hectorvent/floci/services/ec2/Ec2Service.java
+++ b/src/main/java/io/github/hectorvent/floci/services/ec2/Ec2Service.java
@@ -3459,9 +3459,14 @@ public class Ec2Service implements ContainerTeardown, ResourceProvider {
     /**
      * Checks a {@code SubnetConfiguration} list before anything is stored. The named subnet has to
      * exist, and an IPv4 address has to be one the endpoint's interface in that subnet could
-     * actually take, which means inside the subnet's own CIDR. AWS rejects an address outside it
-     * with {@code InvalidParameterValue}; accepting it here would hand back an interface address
-     * that belongs to a different subnet.
+     * actually take. That means inside the subnet's own CIDR, and outside the five addresses AWS
+     * keeps in every subnet. AWS rejects both with {@code InvalidParameterValue}; accepting either
+     * here would hand back an interface address no real endpoint could hold.
+     *
+     * <p>The reserved five are the first four addresses of the subnet and the last one, per the
+     * CreateSubnet documentation in ec2/2016-11-15. Since {@code SubnetConfiguration.Ipv4} is the
+     * address assigned to the endpoint network interface, a reserved value is as unusable as one
+     * from a different subnet.
      *
      * <p>IPv6 is stored as given. Floci's subnets carry no IPv6 CIDR to check an address against.
      */
@@ -3482,6 +3487,11 @@ public class Ec2Service implements ContainerTeardown, ResourceProvider {
                 throw new AwsException("InvalidParameterValue",
                         "Address " + ipv4 + " does not fall within the address range of subnet "
                                 + subnet.getSubnetId(), 400);
+            }
+            if (Ipv4Cidrs.isSubnetReserved(subnet.getCidrBlock(), host)) {
+                throw new AwsException("InvalidParameterValue",
+                        "Address " + ipv4 + " is reserved by AWS in subnet " + subnet.getSubnetId()
+                                + " and cannot be assigned", 400);
             }
         }
     }

--- a/src/main/java/io/github/hectorvent/floci/services/ec2/Ipv4Cidrs.java
+++ b/src/main/java/io/github/hectorvent/floci/services/ec2/Ipv4Cidrs.java
@@ -26,6 +26,31 @@ final class Ipv4Cidrs {
         return x[0] <= y[1] && y[0] <= x[1];
     }
 
+    /**
+     * True when {@code host} is one of the addresses AWS keeps for itself inside {@code cidr}.
+     *
+     * <p>The reserved set is the first four addresses of the subnet plus the last one. CreateSubnet
+     * states it directly in ec2/2016-11-15: "Amazon Web Services reserves both the first four and
+     * the last IPv4 address in each subnet's CIDR block. They're not available for your use."
+     * None of the five can be assigned to a resource, so anything asking for a specific interface
+     * address has to refuse them.
+     *
+     * <p>Small blocks need no special case. A /28, the smallest subnet AWS accepts, keeps 11 of its
+     * 16 addresses, a /29 keeps three, and a block of four addresses or fewer keeps none, which is
+     * the arithmetic working rather than failing. The two ends are clamped so they cannot cross,
+     * and an address outside {@code cidr} is not reserved by it.
+     *
+     * @param host a single address as "a.b.c.d/32"
+     */
+    static boolean isSubnetReserved(String cidr, String host) {
+        long[] block = parse(cidr);
+        long address = parse(host)[0];
+        if (address < block[0] || address > block[1]) {
+            return false;
+        }
+        return address <= Math.min(block[0] + 3, block[1]) || address == block[1];
+    }
+
     /** True when {@code cidr} parses as an IPv4 block, so the other checks can be applied to it. */
     static boolean isIpv4(String cidr) {
         try {

--- a/src/main/java/io/github/hectorvent/floci/services/ec2/model/VpcEndpoint.java
+++ b/src/main/java/io/github/hectorvent/floci/services/ec2/model/VpcEndpoint.java
@@ -23,6 +23,13 @@ public class VpcEndpoint {
     private List<String> securityGroupIds = new ArrayList<>();
     private boolean privateDnsEnabled;
     private String policyDocument;
+    /**
+     * The addresses the caller pinned per subnet through {@code SubnetConfiguration}. AWS assigns
+     * each one to the endpoint's network interface in that subnet, so this is read back from the
+     * interfaces rather than from the endpoint. A subnet with no entry keeps the address floci
+     * synthesizes for it.
+     */
+    private List<VpcEndpointSubnetConfiguration> subnetConfigurations = new ArrayList<>();
     private List<Tag> tags = new ArrayList<>();
 
     public VpcEndpoint() {}
@@ -62,6 +69,11 @@ public class VpcEndpoint {
 
     public String getPolicyDocument() { return policyDocument; }
     public void setPolicyDocument(String policyDocument) { this.policyDocument = policyDocument; }
+
+    public List<VpcEndpointSubnetConfiguration> getSubnetConfigurations() { return subnetConfigurations; }
+    public void setSubnetConfigurations(List<VpcEndpointSubnetConfiguration> subnetConfigurations) {
+        this.subnetConfigurations = subnetConfigurations;
+    }
 
     public List<Tag> getTags() { return tags; }
     public void setTags(List<Tag> tags) { this.tags = tags; }

--- a/src/main/java/io/github/hectorvent/floci/services/ec2/model/VpcEndpointSubnetConfiguration.java
+++ b/src/main/java/io/github/hectorvent/floci/services/ec2/model/VpcEndpointSubnetConfiguration.java
@@ -1,0 +1,41 @@
+package io.github.hectorvent.floci.services.ec2.model;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import io.quarkus.runtime.annotations.RegisterForReflection;
+
+/**
+ * One {@code SubnetConfiguration} entry from {@code CreateVpcEndpoint} or
+ * {@code ModifyVpcEndpoint}: the addresses to assign to the endpoint's network interface in a
+ * given subnet.
+ *
+ * <p>{@code SubnetConfiguration} is request-only. No EC2 output shape carries it, so a caller
+ * reads the addresses back from the endpoint's network interfaces rather than from the endpoint
+ * itself, which is why this is stored on the endpoint and consumed when its interfaces are built.
+ *
+ * @see <a href="https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_SubnetConfiguration.html">SubnetConfiguration</a>
+ */
+@RegisterForReflection
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class VpcEndpointSubnetConfiguration {
+
+    private String subnetId;
+    private String ipv4;
+    private String ipv6;
+
+    public VpcEndpointSubnetConfiguration() {}
+
+    public VpcEndpointSubnetConfiguration(String subnetId, String ipv4, String ipv6) {
+        this.subnetId = subnetId;
+        this.ipv4 = ipv4;
+        this.ipv6 = ipv6;
+    }
+
+    public String getSubnetId() { return subnetId; }
+    public void setSubnetId(String subnetId) { this.subnetId = subnetId; }
+
+    public String getIpv4() { return ipv4; }
+    public void setIpv4(String ipv4) { this.ipv4 = ipv4; }
+
+    public String getIpv6() { return ipv6; }
+    public void setIpv6(String ipv6) { this.ipv6 = ipv6; }
+}

--- a/src/test/java/io/github/hectorvent/floci/services/ec2/Ec2ServiceTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/ec2/Ec2ServiceTest.java
@@ -43,6 +43,7 @@ import io.github.hectorvent.floci.services.ec2.model.TransitGatewayVpcAttachment
 import io.github.hectorvent.floci.services.ec2.model.TransitGatewayVpcAttachmentOptions;
 import io.github.hectorvent.floci.services.ec2.model.Vpc;
 import io.github.hectorvent.floci.services.ec2.model.VpcEndpoint;
+import io.github.hectorvent.floci.services.ec2.model.VpcEndpointSubnetConfiguration;
 import io.github.hectorvent.floci.services.ec2.model.Volume;
 import io.github.hectorvent.floci.services.ec2.model.VolumeAttachment;
 import org.bouncycastle.openssl.PEMKeyPair;
@@ -53,6 +54,7 @@ import org.junit.jupiter.api.Test;
 import java.io.StringReader;
 import java.security.interfaces.RSAPrivateCrtKey;
 import java.time.Duration;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -746,6 +748,81 @@ class Ec2ServiceTest {
 
         assertTrue(service.endpointNetworkInterfaces("eu-west-1").isEmpty(),
                 "endpoints are regional");
+    }
+
+    @Test
+    void subnetConfigurationPinsTheEndpointInterfaceAddress() {
+        Ec2Service service = new Ec2Service(mockConfig(true), mock(Ec2ContainerManager.class),
+                mock(Ec2PortForwardManager.class),
+                mock(AmiImageResolver.class), mock(Ec2ImageCatalog.class), new Ec2InstanceTypeCatalog(),
+                new InMemoryStorageFactory());
+        String vpcId = service.createVpc("us-east-1", "10.60.0.0/16", false).getVpcId();
+        String pinned = service.createSubnet("us-east-1", vpcId, "10.60.1.0/24", "us-east-1a").getSubnetId();
+        String unpinned = service.createSubnet("us-east-1", vpcId, "10.60.2.0/24", "us-east-1b").getSubnetId();
+
+        VpcEndpoint endpoint = service.createVpcEndpoint("us-east-1", vpcId,
+                "com.amazonaws.us-east-1.ecs", "Interface",
+                List.of(), List.of(pinned, unpinned), List.of(), null, null, List.of(),
+                List.of(new VpcEndpointSubnetConfiguration(pinned, "10.60.1.10", "2600:1f18::10")));
+
+        Map<String, String> addresses = endpointAddressesBySubnet(service);
+        assertEquals("10.60.1.10", addresses.get(pinned),
+                "the pinned address must be the one the interface reports");
+        assertNotEquals("10.60.2.10", addresses.get(unpinned),
+                "a subnet with no configuration keeps the synthesized address");
+        assertEquals(addresses, endpointAddressesBySubnet(service),
+                "a second read must answer with the same addresses");
+        assertEquals("2600:1f18::10", endpoint.getSubnetConfigurations().getFirst().getIpv6(),
+                "Ipv6 is stored even though no floci interface field carries it yet");
+    }
+
+    @Test
+    void subnetConfigurationRejectsAnAddressOutsideTheSubnet() {
+        Ec2Service service = new Ec2Service(mockConfig(true), mock(Ec2ContainerManager.class),
+                mock(Ec2PortForwardManager.class),
+                mock(AmiImageResolver.class), mock(Ec2ImageCatalog.class), new Ec2InstanceTypeCatalog(),
+                new InMemoryStorageFactory());
+        String vpcId = service.createVpc("us-east-1", "10.61.0.0/16", false).getVpcId();
+        String subnetId = service.createSubnet("us-east-1", vpcId, "10.61.1.0/24", "us-east-1a").getSubnetId();
+
+        AwsException error = assertThrows(AwsException.class, () ->
+                service.createVpcEndpoint("us-east-1", vpcId, "com.amazonaws.us-east-1.ecs", "Interface",
+                        List.of(), List.of(subnetId), List.of(), null, null, List.of(),
+                        List.of(new VpcEndpointSubnetConfiguration(subnetId, "10.61.9.10", null))));
+        assertEquals("InvalidParameterValue", error.getErrorCode());
+        assertTrue(service.describeVpcEndpoints("us-east-1", List.of(), Map.of()).isEmpty(),
+                "a rejected configuration must not leave an endpoint behind");
+    }
+
+    @Test
+    void modifyVpcEndpointReplacesTheConfigurationForOneSubnet() {
+        Ec2Service service = new Ec2Service(mockConfig(true), mock(Ec2ContainerManager.class),
+                mock(Ec2PortForwardManager.class),
+                mock(AmiImageResolver.class), mock(Ec2ImageCatalog.class), new Ec2InstanceTypeCatalog(),
+                new InMemoryStorageFactory());
+        String vpcId = service.createVpc("us-east-1", "10.62.0.0/16", false).getVpcId();
+        String subnetId = service.createSubnet("us-east-1", vpcId, "10.62.1.0/24", "us-east-1a").getSubnetId();
+        VpcEndpoint endpoint = service.createVpcEndpoint("us-east-1", vpcId,
+                "com.amazonaws.us-east-1.ecs", "Interface",
+                List.of(), List.of(subnetId), List.of(), null, null, List.of(),
+                List.of(new VpcEndpointSubnetConfiguration(subnetId, "10.62.1.10", null)));
+
+        service.modifyVpcEndpoint("us-east-1", endpoint.getVpcEndpointId(),
+                List.of(), List.of(), List.of(), List.of(), List.of(), List.of(), null, null, null,
+                List.of(new VpcEndpointSubnetConfiguration(subnetId, "10.62.1.40", null)));
+
+        assertEquals(1, service.describeVpcEndpoints("us-east-1", List.of(endpoint.getVpcEndpointId()), Map.of())
+                .getFirst().getSubnetConfigurations().size(),
+                "a second configuration for the same subnet replaces the first");
+        assertEquals("10.62.1.40", endpointAddressesBySubnet(service).get(subnetId));
+    }
+
+    private static Map<String, String> endpointAddressesBySubnet(Ec2Service service) {
+        Map<String, String> addresses = new HashMap<>();
+        for (NetworkInterface eni : service.endpointNetworkInterfaces("us-east-1")) {
+            addresses.put(eni.getSubnetId(), eni.getPrivateIpAddress());
+        }
+        return addresses;
     }
 
     @Test

--- a/src/test/java/io/github/hectorvent/floci/services/ec2/Ec2ServiceTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/ec2/Ec2ServiceTest.java
@@ -795,6 +795,90 @@ class Ec2ServiceTest {
     }
 
     @Test
+    void subnetConfigurationRejectsTheAddressesAwsReservesInTheSubnet() {
+        Ec2Service service = new Ec2Service(mockConfig(true), mock(Ec2ContainerManager.class),
+                mock(Ec2PortForwardManager.class),
+                mock(AmiImageResolver.class), mock(Ec2ImageCatalog.class), new Ec2InstanceTypeCatalog(),
+                new InMemoryStorageFactory());
+        String vpcId = service.createVpc("us-east-1", "10.63.0.0/16", false).getVpcId();
+        String subnetId = service.createSubnet("us-east-1", vpcId, "10.63.1.0/24", "us-east-1a").getSubnetId();
+
+        for (String reserved : List.of("10.63.1.0", "10.63.1.1", "10.63.1.2", "10.63.1.3", "10.63.1.255")) {
+            AwsException error = assertThrows(AwsException.class, () ->
+                    service.createVpcEndpoint("us-east-1", vpcId, "com.amazonaws.us-east-1.ecs", "Interface",
+                            List.of(), List.of(subnetId), List.of(), null, null, List.of(),
+                            List.of(new VpcEndpointSubnetConfiguration(subnetId, reserved, null))), reserved);
+            assertEquals("InvalidParameterValue", error.getErrorCode(), reserved);
+            assertTrue(error.getMessage().contains(reserved), reserved);
+        }
+        assertTrue(service.describeVpcEndpoints("us-east-1", List.of(), Map.of()).isEmpty(),
+                "none of the reserved addresses may leave an endpoint behind");
+
+        VpcEndpoint endpoint = service.createVpcEndpoint("us-east-1", vpcId,
+                "com.amazonaws.us-east-1.ecs", "Interface",
+                List.of(), List.of(subnetId), List.of(), null, null, List.of(),
+                List.of(new VpcEndpointSubnetConfiguration(subnetId, "10.63.1.4", null)));
+        assertEquals("10.63.1.4", endpointAddressesBySubnet(service).get(subnetId),
+                "the first host address above the reserved four is assignable");
+        assertNotNull(endpoint.getVpcEndpointId());
+    }
+
+    @Test
+    void subnetConfigurationKeepsTheUsableHostsOfASmallSubnet() {
+        Ec2Service service = new Ec2Service(mockConfig(true), mock(Ec2ContainerManager.class),
+                mock(Ec2PortForwardManager.class),
+                mock(AmiImageResolver.class), mock(Ec2ImageCatalog.class), new Ec2InstanceTypeCatalog(),
+                new InMemoryStorageFactory());
+        String vpcId = service.createVpc("us-east-1", "10.64.0.0/16", false).getVpcId();
+        // /28 is the smallest subnet AWS accepts, and five of its sixteen addresses are reserved.
+        String subnetId = service.createSubnet("us-east-1", vpcId, "10.64.1.16/28", "us-east-1a").getSubnetId();
+
+        for (String reserved : List.of("10.64.1.16", "10.64.1.17", "10.64.1.18", "10.64.1.19", "10.64.1.31")) {
+            AwsException error = assertThrows(AwsException.class, () ->
+                    service.createVpcEndpoint("us-east-1", vpcId, "com.amazonaws.us-east-1.ecs", "Interface",
+                            List.of(), List.of(subnetId), List.of(), null, null, List.of(),
+                            List.of(new VpcEndpointSubnetConfiguration(subnetId, reserved, null))), reserved);
+            assertEquals("InvalidParameterValue", error.getErrorCode(), reserved);
+        }
+
+        service.createVpcEndpoint("us-east-1", vpcId, "com.amazonaws.us-east-1.ecs", "Interface",
+                List.of(), List.of(subnetId), List.of(), null, null, List.of(),
+                List.of(new VpcEndpointSubnetConfiguration(subnetId, "10.64.1.30", null)));
+        assertEquals("10.64.1.30", endpointAddressesBySubnet(service).get(subnetId),
+                "the address below the broadcast address is still a host address");
+    }
+
+    @Test
+    void modifyVpcEndpointRejectsAReservedSubnetConfigurationAddress() {
+        Ec2Service service = new Ec2Service(mockConfig(true), mock(Ec2ContainerManager.class),
+                mock(Ec2PortForwardManager.class),
+                mock(AmiImageResolver.class), mock(Ec2ImageCatalog.class), new Ec2InstanceTypeCatalog(),
+                new InMemoryStorageFactory());
+        String vpcId = service.createVpc("us-east-1", "10.65.0.0/16", false).getVpcId();
+        String subnetId = service.createSubnet("us-east-1", vpcId, "10.65.1.0/24", "us-east-1a").getSubnetId();
+        VpcEndpoint endpoint = service.createVpcEndpoint("us-east-1", vpcId,
+                "com.amazonaws.us-east-1.ecs", "Interface",
+                List.of(), List.of(subnetId), List.of(), null, null, List.of(),
+                List.of(new VpcEndpointSubnetConfiguration(subnetId, "10.65.1.10", null)));
+
+        for (String reserved : List.of("10.65.1.0", "10.65.1.1", "10.65.1.2", "10.65.1.3", "10.65.1.255")) {
+            AwsException error = assertThrows(AwsException.class, () ->
+                    service.modifyVpcEndpoint("us-east-1", endpoint.getVpcEndpointId(),
+                            List.of(), List.of(), List.of(), List.of(), List.of(), List.of(), null, null, null,
+                            List.of(new VpcEndpointSubnetConfiguration(subnetId, reserved, null))), reserved);
+            assertEquals("InvalidParameterValue", error.getErrorCode(), reserved);
+        }
+        assertEquals("10.65.1.10", endpointAddressesBySubnet(service).get(subnetId),
+                "a rejected modify must leave the pinned address untouched");
+
+        service.modifyVpcEndpoint("us-east-1", endpoint.getVpcEndpointId(),
+                List.of(), List.of(), List.of(), List.of(), List.of(), List.of(), null, null, null,
+                List.of(new VpcEndpointSubnetConfiguration(subnetId, "10.65.1.254", null)));
+        assertEquals("10.65.1.254", endpointAddressesBySubnet(service).get(subnetId),
+                "an ordinary host address still goes through");
+    }
+
+    @Test
     void modifyVpcEndpointReplacesTheConfigurationForOneSubnet() {
         Ec2Service service = new Ec2Service(mockConfig(true), mock(Ec2ContainerManager.class),
                 mock(Ec2PortForwardManager.class),

--- a/src/test/java/io/github/hectorvent/floci/services/ec2/Ec2VpcEndpointSubnetConfigurationIntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/ec2/Ec2VpcEndpointSubnetConfigurationIntegrationTest.java
@@ -1,0 +1,208 @@
+package io.github.hectorvent.floci.services.ec2;
+
+import io.github.hectorvent.floci.services.ec2.model.NetworkInterface;
+import io.quarkus.test.junit.QuarkusTest;
+import io.restassured.specification.RequestSpecification;
+import jakarta.inject.Inject;
+import org.junit.jupiter.api.Test;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import static io.restassured.RestAssured.given;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.hasItem;
+import static org.hamcrest.xml.HasXPath.hasXPath;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+/**
+ * CreateVpcEndpoint and ModifyVpcEndpoint accept {@code SubnetConfiguration.N}, the per-subnet
+ * IPv4 and IPv6 addresses an interface endpoint takes on its network interfaces. Terraform's
+ * aws_vpc_endpoint sends the block on create and reads it back by following the endpoint to its
+ * interfaces, so an emulator that drops the parameter answers with an address the configuration
+ * never asked for and the endpoint replans as a replacement on every plan.
+ *
+ * <p>{@code SubnetConfiguration} is request-only in ec2/2016-11-15, so DescribeVpcEndpoints never
+ * echoes it. What the wire shows is the subnet set; the addresses themselves are asserted on the
+ * endpoint's interfaces.
+ *
+ * @see <a href="https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_SubnetConfiguration.html">SubnetConfiguration</a>
+ */
+@QuarkusTest
+class Ec2VpcEndpointSubnetConfigurationIntegrationTest {
+
+    @Inject
+    Ec2Service service;
+
+    private static final String AUTH_HEADER =
+            "AWS4-HMAC-SHA256 Credential=test/20260205/us-east-1/ec2/aws4_request";
+
+    private String ec2Value(String action, String element, String... formParams) {
+        RequestSpecification req = given().formParam("Action", action)
+                .header("Authorization", AUTH_HEADER);
+        for (int i = 0; i < formParams.length; i += 2) {
+            req = req.formParam(formParams[i], formParams[i + 1]);
+        }
+        return req.when().post("/").then().statusCode(200).extract().path(element);
+    }
+
+    private String createVpc(String cidr) {
+        return ec2Value("CreateVpc", "CreateVpcResponse.vpc.vpcId", "CidrBlock", cidr);
+    }
+
+    private String createSubnet(String vpcId, String cidr, String availabilityZone) {
+        return ec2Value("CreateSubnet", "CreateSubnetResponse.subnet.subnetId",
+                "VpcId", vpcId, "CidrBlock", cidr, "AvailabilityZone", availabilityZone);
+    }
+
+    private Map<String, String> endpointAddressesBySubnet() {
+        Map<String, String> addresses = new HashMap<>();
+        for (NetworkInterface eni : service.endpointNetworkInterfaces("us-east-1")) {
+            addresses.put(eni.getSubnetId(), eni.getPrivateIpAddress());
+        }
+        return addresses;
+    }
+
+    @Test
+    void createPinsTheAddressInEverySubnetItNames() {
+        String vpcId = createVpc("10.70.0.0/16");
+        String subnetA = createSubnet(vpcId, "10.70.1.0/24", "us-east-1a");
+        String subnetB = createSubnet(vpcId, "10.70.2.0/24", "us-east-1b");
+
+        String endpointId = ec2Value("CreateVpcEndpoint",
+                "CreateVpcEndpointResponse.vpcEndpoint.vpcEndpointId",
+                "VpcId", vpcId,
+                "ServiceName", "com.amazonaws.us-east-1.ecs",
+                "VpcEndpointType", "Interface",
+                "SubnetId.1", subnetA,
+                "SubnetId.2", subnetB,
+                "SubnetConfiguration.1.SubnetId", subnetA,
+                "SubnetConfiguration.1.Ipv4", "10.70.1.10",
+                "SubnetConfiguration.2.SubnetId", subnetB,
+                "SubnetConfiguration.2.Ipv4", "10.70.2.10");
+
+        // Two reads, the way an apply followed by a plan reads the endpoint back. Both must
+        // answer with the address the request pinned.
+        for (int round = 0; round < 2; round++) {
+            given()
+                .formParam("Action", "DescribeVpcEndpoints")
+                .formParam("VpcEndpointId.1", endpointId)
+                .header("Authorization", AUTH_HEADER)
+            .when()
+                .post("/")
+            .then()
+                .statusCode(200)
+                .contentType("application/xml")
+                .body("DescribeVpcEndpointsResponse.vpcEndpointSet.item.subnetIdSet.item",
+                        hasItem(subnetA))
+                .body("DescribeVpcEndpointsResponse.vpcEndpointSet.item.subnetIdSet.item",
+                        hasItem(subnetB));
+
+            Map<String, String> addresses = endpointAddressesBySubnet();
+            assertEquals("10.70.1.10", addresses.get(subnetA), "round " + round);
+            assertEquals("10.70.2.10", addresses.get(subnetB), "round " + round);
+        }
+    }
+
+    @Test
+    void aSubnetIsNamedThroughItsConfigurationAlone() {
+        String vpcId = createVpc("10.71.0.0/16");
+        String subnetId = createSubnet(vpcId, "10.71.1.0/24", "us-east-1a");
+
+        String endpointId = ec2Value("CreateVpcEndpoint",
+                "CreateVpcEndpointResponse.vpcEndpoint.vpcEndpointId",
+                "VpcId", vpcId,
+                "ServiceName", "com.amazonaws.us-east-1.ecr.api",
+                "VpcEndpointType", "Interface",
+                "SubnetConfiguration.1.SubnetId", subnetId,
+                "SubnetConfiguration.1.Ipv4", "10.71.1.20");
+
+        given()
+            .formParam("Action", "DescribeVpcEndpoints")
+            .formParam("VpcEndpointId.1", endpointId)
+            .header("Authorization", AUTH_HEADER)
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200)
+            .body(hasXPath("//*[local-name()='subnetIdSet']/*[local-name()='item']", equalTo(subnetId)));
+
+        assertEquals("10.71.1.20", endpointAddressesBySubnet().get(subnetId));
+    }
+
+    @Test
+    void anEndpointWithoutTheParameterKeepsItsSynthesizedAddress() {
+        String vpcId = createVpc("10.72.0.0/16");
+        String subnetId = createSubnet(vpcId, "10.72.1.0/24", "us-east-1a");
+
+        ec2Value("CreateVpcEndpoint", "CreateVpcEndpointResponse.vpcEndpoint.vpcEndpointId",
+                "VpcId", vpcId,
+                "ServiceName", "com.amazonaws.us-east-1.rds",
+                "VpcEndpointType", "Interface",
+                "SubnetId.1", subnetId);
+
+        String address = endpointAddressesBySubnet().get(subnetId);
+        assertEquals("10.72.1.", address.substring(0, address.lastIndexOf('.') + 1),
+                "the synthesized address still comes from the subnet's own range");
+        assertEquals(address, endpointAddressesBySubnet().get(subnetId),
+                "and it is stable across reads");
+    }
+
+    @Test
+    void modifyRewritesThePinnedAddress() {
+        String vpcId = createVpc("10.73.0.0/16");
+        String subnetId = createSubnet(vpcId, "10.73.1.0/24", "us-east-1a");
+
+        String endpointId = ec2Value("CreateVpcEndpoint",
+                "CreateVpcEndpointResponse.vpcEndpoint.vpcEndpointId",
+                "VpcId", vpcId,
+                "ServiceName", "com.amazonaws.us-east-1.ecs",
+                "VpcEndpointType", "Interface",
+                "SubnetId.1", subnetId,
+                "SubnetConfiguration.1.SubnetId", subnetId,
+                "SubnetConfiguration.1.Ipv4", "10.73.1.10");
+
+        given()
+            .formParam("Action", "ModifyVpcEndpoint")
+            .formParam("VpcEndpointId", endpointId)
+            .formParam("SubnetConfiguration.1.SubnetId", subnetId)
+            .formParam("SubnetConfiguration.1.Ipv4", "10.73.1.44")
+            .header("Authorization", AUTH_HEADER)
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200)
+            .body(hasXPath("//*[local-name()='ModifyVpcEndpointResponse']/*[local-name()='return']",
+                    equalTo("true")));
+
+        assertEquals("10.73.1.44", endpointAddressesBySubnet().get(subnetId));
+    }
+
+    @Test
+    void anAddressOutsideTheSubnetIsRejected() {
+        String vpcId = createVpc("10.74.0.0/16");
+        String subnetId = createSubnet(vpcId, "10.74.1.0/24", "us-east-1a");
+
+        given()
+            .formParam("Action", "CreateVpcEndpoint")
+            .formParam("VpcId", vpcId)
+            .formParam("ServiceName", "com.amazonaws.us-east-1.ecs")
+            .formParam("VpcEndpointType", "Interface")
+            .formParam("SubnetId.1", subnetId)
+            .formParam("SubnetConfiguration.1.SubnetId", subnetId)
+            .formParam("SubnetConfiguration.1.Ipv4", "10.74.9.10")
+            .header("Authorization", AUTH_HEADER)
+        .when()
+            .post("/")
+        .then()
+            .statusCode(400)
+            .body("Response.Errors.Error.Code", equalTo("InvalidParameterValue"));
+
+        List<String> subnets = service.describeVpcEndpoints("us-east-1", List.of(), Map.of()).stream()
+                .filter(endpoint -> vpcId.equals(endpoint.getVpcId()))
+                .flatMap(endpoint -> endpoint.getSubnetIds().stream())
+                .toList();
+        assertEquals(List.of(), subnets, "the rejected request must not have created an endpoint");
+    }
+}

--- a/src/test/java/io/github/hectorvent/floci/services/ec2/Ec2VpcEndpointSubnetConfigurationIntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/ec2/Ec2VpcEndpointSubnetConfigurationIntegrationTest.java
@@ -205,4 +205,36 @@ class Ec2VpcEndpointSubnetConfigurationIntegrationTest {
                 .toList();
         assertEquals(List.of(), subnets, "the rejected request must not have created an endpoint");
     }
+
+    @Test
+    void theSubnetReservedAddressesAreRejected() {
+        String vpcId = createVpc("10.75.0.0/16");
+        String subnetId = createSubnet(vpcId, "10.75.1.0/24", "us-east-1a");
+
+        for (String reserved : List.of("10.75.1.0", "10.75.1.1", "10.75.1.2", "10.75.1.3", "10.75.1.255")) {
+            given()
+                .formParam("Action", "CreateVpcEndpoint")
+                .formParam("VpcId", vpcId)
+                .formParam("ServiceName", "com.amazonaws.us-east-1.ecs")
+                .formParam("VpcEndpointType", "Interface")
+                .formParam("SubnetId.1", subnetId)
+                .formParam("SubnetConfiguration.1.SubnetId", subnetId)
+                .formParam("SubnetConfiguration.1.Ipv4", reserved)
+                .header("Authorization", AUTH_HEADER)
+            .when()
+                .post("/")
+            .then()
+                .statusCode(400)
+                .body("Response.Errors.Error.Code", equalTo("InvalidParameterValue"));
+        }
+
+        ec2Value("CreateVpcEndpoint", "CreateVpcEndpointResponse.vpcEndpoint.vpcEndpointId",
+                "VpcId", vpcId, "ServiceName", "com.amazonaws.us-east-1.ecs",
+                "VpcEndpointType", "Interface", "SubnetId.1", subnetId,
+                "SubnetConfiguration.1.SubnetId", subnetId,
+                "SubnetConfiguration.1.Ipv4", "10.75.1.4");
+
+        assertEquals("10.75.1.4", endpointAddressesBySubnet().get(subnetId),
+                "the first address above the reserved four is assignable");
+    }
 }

--- a/src/test/java/io/github/hectorvent/floci/services/ec2/Ipv4CidrsTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/ec2/Ipv4CidrsTest.java
@@ -37,6 +37,37 @@ class Ipv4CidrsTest {
     }
 
     @Test
+    void isSubnetReservedCoversTheFirstFourAddressesAndTheLast() {
+        for (String reserved : List.of("10.0.1.0", "10.0.1.1", "10.0.1.2", "10.0.1.3", "10.0.1.255")) {
+            assertTrue(Ipv4Cidrs.isSubnetReserved("10.0.1.0/24", reserved + "/32"), reserved);
+        }
+        assertFalse(Ipv4Cidrs.isSubnetReserved("10.0.1.0/24", "10.0.1.4/32"));
+        assertFalse(Ipv4Cidrs.isSubnetReserved("10.0.1.0/24", "10.0.1.254/32"));
+        assertFalse(Ipv4Cidrs.isSubnetReserved("10.0.1.0/24", "10.0.2.1/32"),
+                "an address outside the block is not reserved by it");
+    }
+
+    @Test
+    void isSubnetReservedLeavesTheHostsOfASmallSubnetAlone() {
+        // A /28 is the smallest subnet AWS accepts: five reserved, eleven usable.
+        assertTrue(Ipv4Cidrs.isSubnetReserved("10.0.1.16/28", "10.0.1.19/32"));
+        assertTrue(Ipv4Cidrs.isSubnetReserved("10.0.1.16/28", "10.0.1.31/32"));
+        assertFalse(Ipv4Cidrs.isSubnetReserved("10.0.1.16/28", "10.0.1.20/32"));
+        assertFalse(Ipv4Cidrs.isSubnetReserved("10.0.1.16/28", "10.0.1.30/32"));
+        // A /29 keeps three hosts between the two reserved ends.
+        assertFalse(Ipv4Cidrs.isSubnetReserved("10.0.1.8/29", "10.0.1.12/32"));
+        assertTrue(Ipv4Cidrs.isSubnetReserved("10.0.1.8/29", "10.0.1.15/32"));
+    }
+
+    @Test
+    void isSubnetReservedClaimsEveryAddressOfABlockTooSmallToHoldAHost() {
+        for (String address : List.of("10.0.1.0", "10.0.1.1", "10.0.1.2", "10.0.1.3")) {
+            assertTrue(Ipv4Cidrs.isSubnetReserved("10.0.1.0/30", address + "/32"), address);
+        }
+        assertTrue(Ipv4Cidrs.isSubnetReserved("10.0.1.0/32", "10.0.1.0/32"));
+    }
+
+    @Test
     void firstFreeBlockSkipsOccupiedSpaceInOrder() {
         assertEquals("10.0.1.0/24",
                 Ipv4Cidrs.firstFreeBlock(List.of("10.0.0.0/16"), List.of("10.0.0.0/24"), 24));


### PR DESCRIPTION
## Summary

Ports the VPC endpoint SubnetConfiguration handling from lex00/floci#113.

Terraform's `aws_vpc_endpoint` sends a `subnet_configuration` block to pin the IPv4 address an interface endpoint takes in each subnet. Floci accepted the parameter and dropped it. The pinned address was discarded and each interface got a synthesized one instead.

`SubnetConfiguration` is request-only and no EC2 output shape carries it. The addresses are therefore stored on the endpoint and applied when its interfaces are built. `Ec2QueryHandler` now parses the flattened list for `CreateVpcEndpoint` and for `ModifyVpcEndpoint`, which takes the same parameter. `Ec2Service` checks each entry against the subnet it names and rejects an IPv4 address outside that subnet's CIDR with `InvalidParameterValue`. A subnet named only through its configuration joins the endpoint's subnet set. `Ipv6` is stored as given, because Floci subnets carry no IPv6 CIDR to validate against.

This does not yet close the Terraform loop, and I would rather say so than imply otherwise. The provider reads the block back by following the endpoint to its network interfaces, which Floci cannot serve today. `DescribeVpcEndpoints` emits no `networkInterfaceIdSet`, and `DescribeNetworkInterfaces` excludes PrivateLink interfaces entirely. Exposing those interfaces alters an unrelated action's response for every existing interface endpoint, and the ordered pagination cases in `Ec2IntegrationTest` assert exact region-wide interface counts that would then move. That felt like its own change rather than a rider on this one. Say the word if you would rather have the whole path in this PR.

A new integration test drives the Query wire for create and modify and the rejection case. The pinned addresses are then read off the endpoint's interfaces through the service, since the wire cannot reach them yet. Three `Ec2ServiceTest` cases cover the same paths at the service level.

## Type of change

- [x] Bug fix (`fix:`)
- [ ] New feature (`feat:`)
- [ ] Breaking change (`feat!:` or `fix!:`)
- [ ] Docs / chore

## AWS Compatibility

Verified against botocore's `ec2/2016-11-15/service-2.json` as shipped with AWS CLI `2.35.24`. `SubnetConfiguration` carries a `SubnetId` with an `Ipv4` and an `Ipv6` address. It appears on `CreateVpcEndpointRequest` and on `ModifyVpcEndpointRequest`, which the EC2 Query protocol flattens to `SubnetConfiguration.1.SubnetId` and so on, numbered from 1. I enumerated every structure in the model carrying such a member and only those two came back, so no output shape has it.

## Checklist

- [ ] `./mvnw test` passes locally
- [x] New or updated integration test added
- [x] Commit messages follow Conventional Commits

Ran `./mvnw test -Dtest='Ec2*Test'` on the branch. It reports 919 tests run with 0 failures and 0 errors. `make docs-check` exits 0.
