### PR TITLE
fix(storage): log effective storage mode at boot

### DIFF
--- a/src/main/java/io/github/hectorvent/floci/core/storage/PersistentPathValidator.java
+++ b/src/main/java/io/github/hectorvent/floci/core/storage/PersistentPathValidator.java
@@ -5,6 +5,7 @@ import io.github.hectorvent.floci.core.common.ResolvedServiceCatalog;
 import io.github.hectorvent.floci.core.common.ServiceDescriptor;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
+import org.jboss.logging.Logger;
 
 import java.io.IOException;
 import java.nio.file.Files;
@@ -19,6 +20,8 @@ import java.util.List;
  */
 @ApplicationScoped
 public class PersistentPathValidator {
+
+    private static final Logger LOG = Logger.getLogger(PersistentPathValidator.class);
 
     private final ResolvedServiceCatalog catalog;
     private final EmulatorConfig config;
@@ -37,10 +40,13 @@ public class PersistentPathValidator {
                 .filter(d -> d.enabled() && d.supportsStorage() && !"memory".equals(d.storageMode()))
                 .toList();
         if (persistent.isEmpty()) {
+            LOG.info("Storage mode: memory (state is NOT persisted across restarts)");
             return;
         }
 
         Path root = Path.of(config.storage().persistentPath());
+        LOG.infov("Storage mode: persistent (state for {0} is written to {1})",
+                describe(persistent), root.toAbsolutePath());
         try {
             probeWritable(root);
             Path s3Root = root.resolve("s3");
@@ -49,18 +55,21 @@ public class PersistentPathValidator {
                 probeWritable(s3Root);
             }
         } catch (IOException | SecurityException e) {
-            String services = persistent.stream()
-                    .map(d -> d.storageKey() + "=" + d.storageMode())
-                    .distinct()
-                    .limit(8)
-                    .reduce((a, b) -> a + ", " + b)
-                    .orElse("");
             throw new IllegalStateException(
                     "Persistent storage path '" + root.toAbsolutePath()
-                            + "' is not writable, but non-memory storage is enabled (" + services
+                            + "' is not writable, but non-memory storage is enabled (" + describe(persistent)
                             + "). Fix the volume mount permissions (it may be read-only or root-owned),"
                             + " or point FLOCI_STORAGE_PERSISTENT_PATH at a writable directory.", e);
         }
+    }
+
+    private static String describe(List<ServiceDescriptor> persistent) {
+        return persistent.stream()
+                .map(d -> d.storageKey() + "=" + d.storageMode())
+                .distinct()
+                .limit(8)
+                .reduce((a, b) -> a + ", " + b)
+                .orElse("");
     }
 
     static void probeWritable(Path dir) throws IOException {

--- a/src/test/java/io/github/hectorvent/floci/core/storage/PersistentPathValidatorTest.java
+++ b/src/test/java/io/github/hectorvent/floci/core/storage/PersistentPathValidatorTest.java
@@ -16,8 +16,12 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Set;
+import java.util.logging.Handler;
+import java.util.logging.Level;
+import java.util.logging.LogRecord;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
@@ -110,5 +114,65 @@ class PersistentPathValidatorTest {
         when(catalog.all()).thenReturn(List.of(descriptor("s3", false, "s3", "hybrid")));
 
         validator().validateAtBoot();
+    }
+
+    @Test
+    void memoryModeLogsThatStateIsNotPersisted() {
+        when(catalog.all()).thenReturn(List.of(
+                descriptor("s3", true, "s3", "memory"),
+                descriptor("sqs", true, "sqs", "memory")));
+
+        List<LogRecord> records = captureLogs(() -> validator().validateAtBoot());
+
+        assertTrue(records.stream().anyMatch(r -> r.getMessage() != null
+                        && r.getMessage().contains("memory")
+                        && r.getMessage().contains("NOT persisted")),
+                "expected a boot log announcing memory mode, got: " + records);
+    }
+
+    @Test
+    void hybridModeLogsThatStateIsPersisted() {
+        Path root = tempDir.resolve("data");
+        when(catalog.all()).thenReturn(List.of(descriptor("sqs", true, "sqs", "hybrid")));
+        when(storageConfig.persistentPath()).thenReturn(root.toString());
+
+        List<LogRecord> records = captureLogs(() -> validator().validateAtBoot());
+
+        assertTrue(records.stream().anyMatch(r -> r.getMessage() != null
+                        && r.getMessage().contains("persistent")
+                        && r.getParameters() != null
+                        && r.getParameters().length == 2
+                        && String.valueOf(r.getParameters()[0]).contains("sqs=hybrid")
+                        && String.valueOf(r.getParameters()[1]).contains(root.toString())),
+                "expected a boot log announcing persistent mode with the effective path, got: " + records);
+    }
+
+    private static List<LogRecord> captureLogs(Runnable action) {
+        java.util.logging.Logger julLogger =
+                java.util.logging.Logger.getLogger(PersistentPathValidator.class.getName());
+        julLogger.setLevel(Level.ALL);
+        List<LogRecord> records = new ArrayList<>();
+        Handler handler = new Handler() {
+            @Override
+            public void publish(LogRecord record) {
+                records.add(record);
+            }
+
+            @Override
+            public void flush() {
+            }
+
+            @Override
+            public void close() {
+            }
+        };
+        handler.setLevel(Level.ALL);
+        julLogger.addHandler(handler);
+        try {
+            action.run();
+        } finally {
+            julLogger.removeHandler(handler);
+        }
+        return records;
     }
 }


### PR DESCRIPTION
## Summary

Memory-mode storage silently discards all state on restart, with no signal to the operator that this is happening. `PersistentPathValidator` now logs the effective storage mode once at boot: which mode is active, and for memory mode, an explicit warning that state is not persisted.

Closes #2225

## Type of change

- [x] Bug fix (`fix:`)

## AWS Compatibility

Not applicable, this is a Floci operational/observability concern, not an AWS API behavior.

## Checklist

- [x] `./mvnw test` passes locally
- [x] New or updated integration test added
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
