### PR TITLE
fix(lambda): warn before runtime api port exhaustion

### DIFF
--- a/src/main/java/io/github/hectorvent/floci/core/common/port/PortAllocator.java
+++ b/src/main/java/io/github/hectorvent/floci/core/common/port/PortAllocator.java
@@ -3,9 +3,13 @@ package io.github.hectorvent.floci.core.common.port;
 import io.github.hectorvent.floci.config.EmulatorConfig;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
+import org.jboss.logging.Logger;
 
+import java.util.Locale;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.function.Consumer;
 
 /**
  * Hands out ports from a configured range for Lambda Runtime API servers.
@@ -15,9 +19,16 @@ import java.util.concurrent.ConcurrentHashMap;
 @ApplicationScoped
 public class PortAllocator {
 
+    private static final Logger LOG = Logger.getLogger(PortAllocator.class);
+    private static final int PRESSURE_WARNING_PERCENT = 90;
+
     private final int basePort;
     private final int maxPort;
+    private final int poolSize;
+    private final int pressureWarningThreshold;
     private final Set<Integer> inUse = ConcurrentHashMap.newKeySet();
+    private final AtomicBoolean pressureWarningEmitted = new AtomicBoolean();
+    private final Consumer<String> warningSink;
 
     @Inject
     public PortAllocator(EmulatorConfig config) {
@@ -26,13 +37,22 @@ public class PortAllocator {
     }
 
     PortAllocator(int basePort, int maxPort) {
+        this(basePort, maxPort, LOG::warn);
+    }
+
+    PortAllocator(int basePort, int maxPort, Consumer<String> warningSink) {
         this.basePort = basePort;
         this.maxPort = maxPort;
+        this.poolSize = maxPort - basePort + 1;
+        this.pressureWarningThreshold = Math.max(1,
+                (int) Math.ceil(poolSize * (PRESSURE_WARNING_PERCENT / 100.0)));
+        this.warningSink = warningSink;
     }
 
     public int allocate() {
         for (int p = basePort; p <= maxPort; p++) {
             if (inUse.add(p)) {
+                warnIfUnderPressure();
                 return p;
             }
         }
@@ -43,7 +63,7 @@ public class PortAllocator {
         // learn the knob exists is to find this class in the source (issue #2206).
         throw new IllegalStateException(
                 "Lambda Runtime API port pool exhausted: no free ports in range "
-                        + basePort + "-" + maxPort + " (" + (maxPort - basePort + 1)
+                        + basePort + "-" + maxPort + " (" + poolSize
                         + " ports, all in use). One port is held per running Lambda container, "
                         + "so this is the concurrent-execution ceiling. Widen it with "
                         + "floci.services.lambda.runtime-api-base-port / "
@@ -51,6 +71,24 @@ public class PortAllocator {
     }
 
     public void release(int port) {
-        inUse.remove(port);
+        if (!inUse.remove(port)) {
+            return;
+        }
+        if (inUse.size() < pressureWarningThreshold) {
+            pressureWarningEmitted.set(false);
+        }
+    }
+
+    private void warnIfUnderPressure() {
+        int allocated = inUse.size();
+        if (allocated < pressureWarningThreshold || !pressureWarningEmitted.compareAndSet(false, true)) {
+            return;
+        }
+        warningSink.accept(String.format(Locale.ROOT,
+                "Lambda Runtime API port pool is %d%% allocated (%d/%d ports in use, range %d-%d). "
+                        + "One port is held per running Lambda container. If this workload may grow, widen "
+                        + "floci.services.lambda.runtime-api-base-port / floci.services.lambda.runtime-api-max-port "
+                        + "before the pool is exhausted.",
+                (allocated * 100) / poolSize, allocated, poolSize, basePort, maxPort));
     }
 }

--- a/src/test/java/io/github/hectorvent/floci/core/common/port/PortAllocatorTest.java
+++ b/src/test/java/io/github/hectorvent/floci/core/common/port/PortAllocatorTest.java
@@ -2,14 +2,18 @@ package io.github.hectorvent.floci.core.common.port;
 
 import org.junit.jupiter.api.Test;
 
+import java.util.ArrayList;
 import java.util.HashSet;
+import java.util.List;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 class PortAllocatorTest {
 
@@ -51,13 +55,6 @@ class PortAllocatorTest {
         assertThrows(IllegalStateException.class, allocator::allocate);
     }
 
-    /**
-     * When the pool runs dry the exception is often the only artefact an operator ever sees —
-     * it reaches them second-hand as a CloudFormation rollback, with floci's own logs the only
-     * place the cause survives (issue #2206). "No free ports in range 9200-9299" does not say
-     * which pool ran dry or how to widen it, leaving the reader to find PortAllocator in the
-     * source to discover the knob exists. The message must carry its own diagnosis.
-     */
     @Test
     void exhaustionMessageNamesThePoolAndTheWideningProperty() {
         PortAllocator allocator = new PortAllocator(9200, 9200);
@@ -72,6 +69,37 @@ class PortAllocatorTest {
                 "message must name the property that widens the pool; got: " + message);
         assertTrue(message.contains("9200"),
                 "message must still report the exhausted range; got: " + message);
+    }
+
+    @Test
+    void warnsOnceWhenPoolCrossesNinetyPercent() {
+        List<String> warnings = new ArrayList<>();
+        PortAllocator allocator = new PortAllocator(9200, 9209, warnings::add);
+
+        for (int i = 0; i < 10; i++) {
+            allocator.allocate();
+        }
+
+        assertEquals(1, warnings.size());
+        assertTrue(warnings.getFirst().contains("90% allocated"));
+        assertTrue(warnings.getFirst().contains("9/10 ports"));
+        assertTrue(warnings.getFirst().contains("runtime-api-max-port"));
+    }
+
+    @Test
+    void warningRearmsAfterPressureDropsBelowThreshold() {
+        List<String> warnings = new ArrayList<>();
+        PortAllocator allocator = new PortAllocator(9200, 9209, warnings::add);
+        List<Integer> ports = new ArrayList<>();
+
+        for (int i = 0; i < 9; i++) {
+            ports.add(allocator.allocate());
+        }
+        allocator.release(ports.getLast());
+        ports.removeLast();
+        ports.add(allocator.allocate());
+
+        assertEquals(2, warnings.size());
     }
 
     @Test


### PR DESCRIPTION
## Summary

Warn when the Lambda Runtime API port pool reaches 90% utilization, before the existing hard exhaustion path is hit.

The main capacity fix from #2206 already landed in #2646: the default pool is now 500 ports and the exhaustion error names the pool and the properties used to widen it. This PR completes the remaining observability item from the issue:

- emit one warning when an allocation crosses the 90% threshold;
- include the used/total count, configured range, and the two relevant configuration properties;
- avoid log spam while the pool remains above the threshold;
- re-arm the warning after utilization drops below 90%, so a later pressure episode is visible again.

Closes #2206

## Type of change

- [x] Bug fix (`fix:`)
- [ ] New feature (`feat:`)
- [ ] Breaking change (`feat!:` or `fix!:`)
- [ ] Docs / chore

## AWS Compatibility

No AWS wire protocol changes. This only improves operator visibility around the local Runtime API capacity used by Lambda execution environments.

The implementation uses the project's existing JBoss Logging stack at `WARN` level. Quarkus documents WARN for non-critical service problems that may require attention:
https://quarkus.io/guides/logging/#use-log-levels

Validation:

- `./mvnw -q -Dtest=io.github.hectorvent.floci.core.common.port.PortAllocatorTest,io.github.hectorvent.floci.core.common.port.RuntimeApiPortPoolDefaultTest test`
- `./mvnw -q -DskipTests package`
- `git diff --check`

I also ran `ContainerLauncherTest` while checking the consumer path. It currently has one unrelated failure on this base (`launchFunction_injectsOwningAccountAsAccessKeyAndFallsBackForTheRest`: expected a derived secret but received `test`); the port allocator tests themselves are green.

## Checklist

- [ ] `./mvnw test` passes locally
- [x] New or updated integration test added
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
