### PR TITLE
fix(sfn): treat null as falsy in JSONPath negation

### DIFF
--- a/src/main/java/io/github/hectorvent/floci/services/stepfunctions/AslExecutor.java
+++ b/src/main/java/io/github/hectorvent/floci/services/stepfunctions/AslExecutor.java
@@ -3287,13 +3287,140 @@ public class AslExecutor {
 
     private JsonNode resolveAdvancedJsonPath(String path, JsonNode root) {
         try {
-            Object result = JsonPath.using(jsonPathConfiguration).parse(root).read(path);
+            String compatiblePath = normalizeJsonPathNullNegation(path);
+            Object result = JsonPath.using(jsonPathConfiguration).parse(root).read(compatiblePath);
             return result instanceof JsonNode jsonNode ? jsonNode : objectMapper.valueToTree(result);
         } catch (PathNotFoundException e) {
             return MissingNode.getInstance();
         } catch (InvalidPathException e) {
             throw new FailStateException("States.Runtime", "Invalid JSONPath '" + path + "': " + e.getMessage());
         }
+    }
+
+    /**
+     * Jayway treats {@code !@.key} as a non-existence check. Step Functions also considers an
+     * explicit null value falsy, so expand only simple negated path operands to include that case.
+     */
+    private static String normalizeJsonPathNullNegation(String path) {
+        StringBuilder normalized = null;
+        int copiedThrough = 0;
+        char quote = 0;
+        boolean escaped = false;
+        for (int i = 0; i < path.length(); i++) {
+            char current = path.charAt(i);
+            if (quote != 0) {
+                if (escaped) {
+                    escaped = false;
+                } else if (current == '\\') {
+                    escaped = true;
+                } else if (current == quote) {
+                    quote = 0;
+                }
+                continue;
+            }
+            if (current == '\'' || current == '"') {
+                quote = current;
+                continue;
+            }
+            if (current != '!' || !isUnaryJsonPathNegation(path, i)) {
+                continue;
+            }
+
+            int operandStart = i + 1;
+            while (operandStart < path.length() && Character.isWhitespace(path.charAt(operandStart))) {
+                operandStart++;
+            }
+            if (operandStart >= path.length()
+                    || (path.charAt(operandStart) != '@' && path.charAt(operandStart) != '$')) {
+                continue;
+            }
+            int operandEnd = jsonPathOperandEnd(path, operandStart);
+            if (operandEnd < 0) {
+                continue;
+            }
+
+            if (normalized == null) {
+                normalized = new StringBuilder(path.length() + 32);
+            }
+            normalized.append(path, copiedThrough, i)
+                    .append('(')
+                    .append(path, i, operandEnd)
+                    .append(" || ")
+                    .append(path, operandStart, operandEnd)
+                    .append(" == null)");
+            copiedThrough = operandEnd;
+            i = operandEnd - 1;
+        }
+        return normalized == null ? path : normalized.append(path, copiedThrough, path.length()).toString();
+    }
+
+    private static boolean isUnaryJsonPathNegation(String path, int index) {
+        int previous = index - 1;
+        while (previous >= 0 && Character.isWhitespace(path.charAt(previous))) {
+            previous--;
+        }
+        return previous < 0 || "([?&|,".indexOf(path.charAt(previous)) >= 0;
+    }
+
+    private static int jsonPathOperandEnd(String path, int operandStart) {
+        int index = operandStart + 1;
+        boolean hasSegment = false;
+        while (index < path.length()) {
+            char current = path.charAt(index);
+            if (current == '.') {
+                int memberStart = ++index;
+                while (index < path.length() && !isJsonPathOperandDelimiter(path.charAt(index))) {
+                    index++;
+                }
+                if (index == memberStart) {
+                    return -1;
+                }
+                hasSegment = true;
+            } else if (current == '[') {
+                int bracketEnd = simpleJsonPathBracketEnd(path, index);
+                if (bracketEnd < 0) {
+                    return -1;
+                }
+                index = bracketEnd;
+                hasSegment = true;
+            } else {
+                break;
+            }
+        }
+        if (index < path.length() && path.charAt(index) == '(') {
+            return -1;
+        }
+        return hasSegment ? index : -1;
+    }
+
+    private static boolean isJsonPathOperandDelimiter(char value) {
+        return Character.isWhitespace(value) || ".[]()&|=!<>,".indexOf(value) >= 0;
+    }
+
+    private static int simpleJsonPathBracketEnd(String path, int openBracket) {
+        char quote = 0;
+        boolean escaped = false;
+        for (int i = openBracket + 1; i < path.length(); i++) {
+            char current = path.charAt(i);
+            if (quote != 0) {
+                if (escaped) {
+                    escaped = false;
+                } else if (current == '\\') {
+                    escaped = true;
+                } else if (current == quote) {
+                    quote = 0;
+                }
+                continue;
+            }
+            if (current == '\'' || current == '"') {
+                quote = current;
+            } else if (current == ']') {
+                return i + 1;
+            } else if (current == '[' || current == '?' || current == '(' || current == ')') {
+                return -1;
+            }
+        }
+        return -1;
     }
 
     private static FailStateException unresolvedPayloadTemplateReference(String path, String fieldKey,

--- a/src/test/java/io/github/hectorvent/floci/services/stepfunctions/AslExecutorPathIntrinsicsTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/stepfunctions/AslExecutorPathIntrinsicsTest.java
@@ -123,6 +123,74 @@ class AslExecutorPathIntrinsicsTest {
     }
 
     @Test
+    void filterNegationTreatsExplicitNullAndMissingPropertiesAsFalsy() throws Exception {
+        JsonNode root = mapper.readTree("""
+                {"items":[
+                  {"id":1,"session":null},
+                  {"id":2,"session":{"token":"active"}},
+                  {"id":3}
+                ]}
+                """);
+
+        assertEquals(mapper.readTree("[{\"id\":1,\"session\":null},{\"id\":3}]"),
+                executor.resolvePath("$.items[?(!@.session)]", root));
+    }
+
+    @Test
+    void filterNegationWorksInsideCompoundPredicates() throws Exception {
+        JsonNode root = mapper.readTree("""
+                {"items":[
+                  {"id":1,"student_programme":"A","archived_at":null},
+                  {"id":2,"student_programme":"B"},
+                  {"id":3,"student_programme":"C","archived_at":"2026-09-01"},
+                  {"id":4,"archived_at":null}
+                ]}
+                """);
+
+        assertEquals(mapper.readTree("""
+                        [{"id":1,"student_programme":"A","archived_at":null},
+                          {"id":2,"student_programme":"B"}]
+                        """),
+                executor.resolvePath("$.items[?(@.student_programme && !@.archived_at)]", root));
+    }
+
+    @Test
+    void filterNegationSupportsBracketQuotedMembers() throws Exception {
+        JsonNode root = mapper.readTree("""
+                {"items":[
+                  {"id":1,"archived-at":null},
+                  {"id":2,"archived-at":"2026-09-01"},
+                  {"id":3}
+                ]}
+                """);
+
+        assertEquals(mapper.readTree("[{\"id\":1,\"archived-at\":null},{\"id\":3}]"),
+                executor.resolvePath("$.items[?(!@['archived-at'])]", root));
+    }
+
+    @Test
+    void filterNegationCompatibilityDoesNotRewriteComparisonsOrStringLiterals() throws Exception {
+        JsonNode root = mapper.readTree("""
+                {"items":[
+                  {"id":1,"session":null,"label":"!@.session"},
+                  {"id":2,"session":"active","label":"other"},
+                  {"id":3,"label":"!@.session"}
+                ]}
+                """);
+
+        assertEquals(mapper.readTree("""
+                        [{"id":2,"session":"active","label":"other"},
+                          {"id":3,"label":"!@.session"}]
+                        """),
+                executor.resolvePath("$.items[?(@.session != null)]", root));
+        assertEquals(mapper.readTree("""
+                        [{"id":1,"session":null,"label":"!@.session"},
+                          {"id":3,"label":"!@.session"}]
+                        """),
+                executor.resolvePath("$.items[?(@.label == '!@.session')]", root));
+    }
+
+    @Test
     void recursiveDescentPreservesAndFlattensNestedArrayMatches() throws Exception {
         JsonNode root = mapper.readTree("{\"d\":{\"x\":{\"a\":[1,2]}}}");
 


### PR DESCRIPTION
## Summary
- align Step Functions JSONPath negation with Step Functions Local by treating explicit `null` like a missing property
- limit the compatibility expansion to simple `@` and `$` path operands, leaving comparisons, string literals, grouped expressions, and function paths untouched
- add regression coverage for direct, compound, bracket-member, and non-rewrite cases

Closes #3480

## Type of change

- [x] Bug fix (`fix:`)
- [ ] New feature (`feat:`)
- [ ] Breaking change (`feat!:` or `fix!:`)
- [ ] Docs / chore

## AWS Compatibility

Floci currently implements `!@.key` as an existence-only check through Jayway JSONPath, which drops objects whose key is explicitly `null`. Step Functions Local 2.0.0 treats both explicit `null` and a missing key as falsy. This change expands only simple negated path operands before Jayway evaluation so both cases match, while error messages continue to report the original JSONPath.

## Testing

- `./mvnw -Dtest=AslExecutorPathIntrinsicsTest test` (21 tests)
- `./mvnw -Dtest=AslExecutorPathIntrinsicsTest,AslExecutorStatePathTest test` (34 tests)
- `git diff --check`

## Checklist

- [ ] `./mvnw test` passes locally (focused Step Functions tests pass; full suite left to CI)
- [ ] New or updated integration test added (focused unit regression coverage added)
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)