### PR TITLE
fix(core): prevent REST JSON requests from falling through to S3

### DIFF
--- a/src/main/java/io/github/hectorvent/floci/core/common/AwsProtocolClaimFilter.java
+++ b/src/main/java/io/github/hectorvent/floci/core/common/AwsProtocolClaimFilter.java
@@ -107,7 +107,7 @@ public class AwsProtocolClaimFilter implements ContainerRequestFilter {
         }
     }
 
-    private Response unknownOperationResponse(int status, String message) {
+    static Response unknownOperationResponse(int status, String message) {
         return Response.status(status)
                 .type(MediaType.APPLICATION_JSON)
                 .header("x-amzn-query-error", "UnknownOperationException;Sender")

--- a/src/main/java/io/github/hectorvent/floci/core/common/AwsRestRouteScopeFilter.java
+++ b/src/main/java/io/github/hectorvent/floci/core/common/AwsRestRouteScopeFilter.java
@@ -1,0 +1,67 @@
+package io.github.hectorvent.floci.core.common;
+
+import io.github.hectorvent.floci.config.EmulatorConfig;
+import io.github.hectorvent.floci.services.s3.S3Controller;
+import jakarta.annotation.Priority;
+import jakarta.inject.Inject;
+import jakarta.ws.rs.Priorities;
+import jakarta.ws.rs.container.ContainerRequestContext;
+import jakarta.ws.rs.container.ContainerRequestFilter;
+import jakarta.ws.rs.container.ResourceInfo;
+import jakarta.ws.rs.core.Context;
+import jakarta.ws.rs.ext.Provider;
+import org.jboss.logging.Logger;
+
+/**
+ * Stops a known REST JSON service request from being handled by S3's path-style wildcard routes.
+ * This runs after route matching so {@link ResourceInfo} identifies a genuine S3 endpoint match,
+ * complementing the pre-matching unknown-scope guard in {@link AwsProtocolClaimFilter}.
+ */
+@Provider
+@Priority(Priorities.ENTITY_CODER + 100)
+public class AwsRestRouteScopeFilter implements ContainerRequestFilter {
+
+    private static final Logger LOG = Logger.getLogger(AwsRestRouteScopeFilter.class);
+
+    @Context
+    ResourceInfo resourceInfo;
+
+    private final ResolvedServiceCatalog catalog;
+    private final jakarta.inject.Provider<EmulatorConfig> configProvider;
+
+    @Inject
+    public AwsRestRouteScopeFilter(ResolvedServiceCatalog catalog,
+                                   jakarta.inject.Provider<EmulatorConfig> configProvider) {
+        this.catalog = catalog;
+        this.configProvider = configProvider;
+    }
+
+    @Override
+    public void filter(ContainerRequestContext ctx) {
+        Object claimValue = ctx.getProperty(AwsProtocolClaimFilter.CLAIM_PROPERTY);
+        if (!(claimValue instanceof ProtocolClaim claim) || claim.protocol() != WireProtocol.REST
+                || resourceInfo == null || resourceInfo.getResourceClass() != S3Controller.class) {
+            return;
+        }
+
+        SigV4CredentialScope.serviceName(ctx.getHeaderString("Authorization"))
+                .flatMap(catalog::byCredentialScope)
+                .filter(descriptor -> descriptor.supportsProtocol(ServiceProtocol.REST_JSON))
+                .filter(descriptor -> !"s3".equals(descriptor.externalKey()))
+                .ifPresent(descriptor -> rejectS3Fallthrough(ctx, descriptor));
+    }
+
+    private void rejectS3Fallthrough(ContainerRequestContext ctx, ServiceDescriptor descriptor) {
+        if (!configProvider.get().protocols().rejectUnknownServiceScope()) {
+            LOG.debugv("Known REST JSON service {0} matched an S3 wildcard route; rejection disabled by config",
+                    descriptor.externalKey());
+            return;
+        }
+        String method = ctx.getMethod();
+        String path = ctx.getUriInfo().getPath();
+        LOG.infov("Rejecting {0} request that matched an S3 wildcard route: {1} {2}",
+                descriptor.externalKey(), method, path);
+        ctx.abortWith(AwsProtocolClaimFilter.unknownOperationResponse(404,
+                "Unknown operation: " + method + " " + path));
+    }
+}

--- a/src/test/java/io/github/hectorvent/floci/core/common/UnknownServiceScopeGuardDisabledIntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/core/common/UnknownServiceScopeGuardDisabledIntegrationTest.java
@@ -1,8 +1,10 @@
 package io.github.hectorvent.floci.core.common;
 
+import io.github.hectorvent.floci.testing.RestAssuredJsonUtils;
 import io.quarkus.test.junit.QuarkusTest;
 import io.quarkus.test.junit.QuarkusTestProfile;
 import io.quarkus.test.junit.TestProfile;
+import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 
 import java.util.Map;
@@ -19,6 +21,11 @@ import static org.hamcrest.Matchers.containsString;
 @TestProfile(UnknownServiceScopeGuardDisabledIntegrationTest.GuardDisabledProfile.class)
 class UnknownServiceScopeGuardDisabledIntegrationTest {
 
+    @BeforeAll
+    static void configureRestAssured() {
+        RestAssuredJsonUtils.configureAwsContentTypes();
+    }
+
     @Test
     void unsupportedScopeFallsThroughWhenRejectionDisabled() {
         given()
@@ -31,6 +38,20 @@ class UnknownServiceScopeGuardDisabledIntegrationTest {
             // named "accounts", instead of the guard's UnknownOperationException.
             .statusCode(404)
             .body(containsString("<Code>NoSuchBucket</Code>"));
+    }
+
+    @Test
+    void knownRestJsonScopeFallsThroughWhenRejectionDisabled() {
+        given()
+            .header("Authorization", "AWS4-HMAC-SHA256 Credential=test/20260707/us-east-1/bedrock"
+                    + "/aws4_request, SignedHeaders=host;x-amz-date, Signature=deadbeef")
+            .contentType("application/x-amz-json-1.1")
+            .body("{\"name\":\"probe\"}")
+        .when()
+            .post("/prompts")
+        .then()
+            .statusCode(400)
+            .body(containsString("<Code>InvalidArgument</Code>"));
     }
 
     public static final class GuardDisabledProfile implements QuarkusTestProfile {

--- a/src/test/java/io/github/hectorvent/floci/core/common/UnknownServiceScopeGuardIntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/core/common/UnknownServiceScopeGuardIntegrationTest.java
@@ -1,6 +1,8 @@
 package io.github.hectorvent.floci.core.common;
 
+import io.github.hectorvent.floci.testing.RestAssuredJsonUtils;
 import io.quarkus.test.junit.QuarkusTest;
+import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 
 import static io.restassured.RestAssured.given;
@@ -16,6 +18,11 @@ import static org.hamcrest.Matchers.not;
  */
 @QuarkusTest
 class UnknownServiceScopeGuardIntegrationTest {
+
+    @BeforeAll
+    static void configureRestAssured() {
+        RestAssuredJsonUtils.configureAwsContentTypes();
+    }
 
     private static String authorization(String service) {
         return "AWS4-HMAC-SHA256 Credential=test/20260707/us-east-1/" + service
@@ -36,6 +43,35 @@ class UnknownServiceScopeGuardIntegrationTest {
             .header("X-Amzn-Errortype", "UnknownOperationException")
             .header("x-amzn-query-error", "UnknownOperationException;Sender")
             .body("__type", equalTo("UnknownOperationException"));
+    }
+
+    @Test
+    void knownRestJsonScopeCannotFallThroughToS3Wildcard() {
+        given()
+            .header("Authorization", authorization("bedrock"))
+            .contentType("application/x-amz-json-1.1")
+            .body("{\"name\":\"probe\"}")
+        .when()
+            .post("/prompts")
+        .then()
+            .statusCode(404)
+            .contentType(containsString("application/json"))
+            .header("X-Amzn-Errortype", "UnknownOperationException")
+            .body("__type", equalTo("UnknownOperationException"))
+            .body("message", equalTo("Unknown operation: POST /prompts"));
+    }
+
+    @Test
+    void bedrockScopeStillReachesBedrockRuntimeRoutes() {
+        given()
+            .header("Authorization", authorization("bedrock"))
+            .contentType("application/json")
+            .body("{\"prompt\":\"hello\"}")
+        .when()
+            .post("/model/test-model/invoke")
+        .then()
+            .statusCode(200)
+            .contentType(containsString("application/json"));
     }
 
     @Test


### PR DESCRIPTION
## Summary

- add a post-route scope filter that detects when a known REST-JSON request was matched by an S3 wildcard route
- return the existing JSON UnknownOperationException response instead of misleading S3 XML
- preserve real Bedrock Runtime routes, genuine S3 traffic, and the reject-unknown-service-scope compatibility switch

Closes #3194

## Type of change

- [x] Bug fix (fix:)
- [ ] New feature (feat:)
- [ ] Breaking change (feat!: or fix!:)
- [ ] Docs / chore

## AWS Compatibility

A request signed with the bedrock scope for an unsupported REST-JSON operation such as POST /prompts previously fell through to S3 path-style wildcard routing and returned an application/xml InvalidArgument error. It now returns a 404 application/json UnknownOperationException while implemented Bedrock Runtime routes and S3-scoped requests retain their existing behavior.

## Testing

- JAVA_HOME=/opt/homebrew/opt/openjdk@25 ./mvnw -Dtest=UnknownServiceScopeGuardIntegrationTest,UnknownServiceScopeGuardDisabledIntegrationTest test
- 12 tests passed, 0 failures

## Checklist

- [ ] ./mvnw test passes locally
- [x] New or updated integration test added
- [x] Commit messages follow Conventional Commits