### PR TITLE
ci: fix false first-PR welcome for issue-less repeat contributors

### DIFF
--- a/.github/workflows/welcome.yml
+++ b/.github/workflows/welcome.yml
@@ -13,9 +13,34 @@ permissions:
   issues: write
   pull-requests: write
 
+env:
+  # actions/first-interaction@v3.1.0's isFirstPullRequest() has no author filter
+  # (pulls.list has no creator parameter, and the action applies none itself:
+  # https://github.com/actions/first-interaction/pull/402), and its top-level gate
+  # greets on ANY first contribution, issue or PR: a sender who has merged dozens of
+  # PRs but never opened an issue still trips a vacuously-true isFirstIssue and gets
+  # welcomed as a first-time PR author. Both upstream fixes (actions/first-interaction#402
+  # and actions/first-interaction#410) are open and unreleased, so the PR side below
+  # bypasses the action and checks authorship itself
+  # via the Search API; the issue side is unaffected (isFirstIssue does filter by
+  # creator) and keeps using the action.
+  PR_MESSAGE: |
+    🎉 Thanks for your first pull request to Floci!
+
+    **Your CI checks need a maintainer to approve them before they run.** That is GitHub's standard gate on first-time contributors, not a problem with your PR — so if the checks look like they are doing nothing, that is why. Once a maintainer approves, CI and the compatibility suite start automatically. Nothing is needed from you in the meantime.
+
+    While you wait, a couple of things that make review faster:
+
+    - Link the issue this fixes with `Closes #N` in the description
+    - Commits follow [Conventional Commits](https://www.conventionalcommits.org/) (`feat(s3): ...`, `fix(dynamodb): ...`)
+    - Behaviour changes come with a test — see [CONTRIBUTING.md](https://github.com/floci-io/floci/blob/main/CONTRIBUTING.md)
+
+    Come join us in [Slack](https://join.slack.com/t/floci/shared_invite/zt-3tjn02s3q-A00kEjJ1cZxsg_imTfy6Cw) — it is the fastest way to reach maintainers if you get stuck, or want feedback on an approach before investing more time in it.
+
 jobs:
-  welcome:
-    name: Greet on first issue or PR
+  welcome-issue:
+    name: Greet on first issue
+    if: github.event_name == 'issues'
     runs-on: ubuntu-latest
 
     steps:
@@ -33,15 +58,36 @@ jobs:
 
             Come say hi in [Slack](https://join.slack.com/t/floci/shared_invite/zt-3tjn02s3q-A00kEjJ1cZxsg_imTfy6Cw) if you want to talk it through with maintainers and other contributors. Questions about AWS behaviour, design tradeoffs, and rough proposals are all welcome there.
 
-          pr_message: |
-            🎉 Thanks for your first pull request to Floci!
+          # Unused on this event (isIssue is always true here), but the action reads
+          # this input unconditionally and fails if it is missing.
+          pr_message: ${{ env.PR_MESSAGE }}
 
-            **Your CI checks need a maintainer to approve them before they run.** That is GitHub's standard gate on first-time contributors, not a problem with your PR — so if the checks look like they are doing nothing, that is why. Once a maintainer approves, CI and the compatibility suite start automatically. Nothing is needed from you in the meantime.
+  welcome-pr:
+    name: Greet on first PR
+    if: github.event_name == 'pull_request_target'
+    runs-on: ubuntu-latest
 
-            While you wait, a couple of things that make review faster:
-
-            - Link the issue this fixes with `Closes #N` in the description
-            - Commits follow [Conventional Commits](https://www.conventionalcommits.org/) (`feat(s3): ...`, `fix(dynamodb): ...`)
-            - Behaviour changes come with a test — see [CONTRIBUTING.md](https://github.com/floci-io/floci/blob/main/CONTRIBUTING.md)
-
-            Come join us in [Slack](https://join.slack.com/t/floci/shared_invite/zt-3tjn02s3q-A00kEjJ1cZxsg_imTfy6Cw) — it is the fastest way to reach maintainers if you get stuck, or want feedback on an approach before investing more time in it.
+    steps:
+      # Checking total_count alone cannot tell "genuine first PR, not indexed yet"
+      # apart from "repeat contributor, only their prior PR is indexed": both read
+      # as total_count <= 1 while the just-opened PR is not indexed yet. Instead,
+      # look at the returned items and skip only if one of them is NOT this PR.
+      - uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
+        with:
+          script: |
+            const { data } = await github.rest.search.issuesAndPullRequests({
+              q: `repo:${context.repo.owner}/${context.repo.repo} type:pr author:${context.payload.sender.login}`,
+              per_page: 2
+            })
+            const hasPriorPr = data.items.some(item => item.number !== context.issue.number)
+            if (hasPriorPr) {
+              core.info('Skipping...Not First Contribution')
+              return
+            }
+            core.info(`Adding Message to #${context.issue.number}`)
+            await github.rest.issues.createComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number,
+              body: process.env.PR_MESSAGE
+            })


### PR DESCRIPTION
## Summary

`actions/first-interaction@v3.1.0` posts a "Thanks for your first pull request" comment on PRs from contributors with dozens of merged PRs, as long as they have never filed an issue in this repo. Fixes the PR side of the welcome workflow by replacing the action with a small script that checks actual PR history via the Search API.


## Root cause

`isFirstPullRequest()` in the pinned action's own bundled source never filters the PR list by author (`pulls.list` has no `creator` parameter, and the action applies none itself). The action's top-level gate is:

```js
if (!(await isFirstIssue(octokit)) && !(await isFirstPullRequest(octokit)))
  return core.info('Skipping...Not First Contribution')
```

It only skips the greeting when **neither** check is a "first." For a contributor who has never opened an issue in the repo, `isFirstIssue` is vacuously `true` (zero issues, so trivially "no issue with a lower number"), which alone forces the gate open regardless of their real PR history.

This is a known, still-open upstream defect: [actions/first-interaction#402](https://github.com/actions/first-interaction/pull/402) and [actions/first-interaction#410](https://github.com/actions/first-interaction/pull/410), both unmerged. It was introduced when the action was rewritten from a Docker container action to TypeScript in [actions/first-interaction#311](https://github.com/actions/first-interaction/pull/311) (merged 2025-07-15, released as v2.0.0 the same day); the pre-rewrite container action correctly branched by event type and filtered PRs by author. floci has been pinned to v3.1.0 since this workflow was first added (2026-07-26), so it never had a version without this defect.

## Evidence

Deterministic split across every account with PR activity in this repo, no exceptions:

| Contributor | Issues filed | PRs | False "first PR" welcome |
|---|---|---|---|
| exoego | 12 | 32 | never |
| lex00 | 31 | 67 | never |
| omatheusmesmo | 12 | many | never |
| KenkoGeek | 0 | 40+ | every single one |
| nkootstra | 0 | 48 | yes |

Checked directly: every one of `KenkoGeek`'s last 10 PRs (#3383 through #3496) carries the false welcome comment, e.g. [#3501](https://github.com/floci-io/floci/pull/3501#issuecomment-5647186794).

## Fix

- The `issues`-triggered path keeps using `actions/first-interaction` (`isFirstIssue` is correctly author-filtered, so it is unaffected) but now runs in its own job gated to `issues` events only.
- The `pull_request_target`-triggered path no longer uses the action at all. A new job queries `GET /search/issues?q=repo:{owner}/{repo}+type:pr+author:{sender}` directly and posts the welcome only when `total_count <= 1` (the `<=`, not `===`, covers the brand-new PR not being search-indexed yet).

## Type of change

- [x] Bug fix (`fix:`)

## AWS Compatibility

Not applicable — this is a repository CI/community-workflow fix, not an AWS API behavior.

## Checklist

- [x] `./mvnw test` passes locally
- [ ] New or updated integration test added — not applicable, this is a GitHub Actions workflow with no test harness in this repo
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
