### PR TITLE
fix(codepipeline): cap QUEUED and PARALLEL pipelines at 50 active executions

### DIFF
--- a/docs/services/codepipeline.md
+++ b/docs/services/codepipeline.md
@@ -22,6 +22,8 @@ state use Floci's configured storage backend.
 Stages execute in declaration order. Actions with the same `runOrder` execute in parallel.
 `SUPERSEDED`, `QUEUED`, and `PARALLEL` execution modes are recognized, with `QUEUED` and
 `PARALLEL` restricted to V2 pipelines.
+A `QUEUED` or `PARALLEL` pipeline holds at most 50 active executions, as on AWS;
+`StartPipelineExecution` beyond that returns `ConcurrentPipelineExecutionsLimitExceededException`.
 
 The following providers execute against local Floci services:
 

--- a/src/main/java/io/github/hectorvent/floci/services/codepipeline/CodePipelineService.java
+++ b/src/main/java/io/github/hectorvent/floci/services/codepipeline/CodePipelineService.java
@@ -45,6 +45,7 @@ import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
+import java.util.concurrent.RejectedExecutionException;
 import java.util.concurrent.TimeUnit;
 
 @ApplicationScoped
@@ -52,6 +53,7 @@ public class CodePipelineService {
     private static final Logger LOG = Logger.getLogger(CodePipelineService.class);
     private static final String DEFAULT_EXECUTION_MODE = "SUPERSEDED";
     private static final String DEFAULT_PIPELINE_TYPE = "V1";
+    private static final int MAX_ACTIVE_EXECUTIONS = 50;
     private static final long POLL_INTERVAL_MS = 100L;
 
     private final AccountAwareStorageBackend<CodePipelinePipeline> pipelineStore;
@@ -64,6 +66,10 @@ public class CodePipelineService {
     private final S3Service s3Service;
     private final ExecutorService executor = Executors.newVirtualThreadPerTaskExecutor();
     private final Map<String, Object> pipelineLocks = new ConcurrentHashMap<>();
+    // Admission is serialized per pipeline on its own lock. A QUEUED worker holds the pipelineLocks
+    // monitor for its whole run, so counting under that monitor would block StartPipelineExecution
+    // until the running execution finished.
+    private final Map<String, Object> startLocks = new ConcurrentHashMap<>();
     private final Map<String, byte[]> runtimeArtifacts = new ConcurrentHashMap<>();
 
     @Inject
@@ -281,10 +287,42 @@ public class CodePipelineService {
             trigger.put("clientRequestToken", clientToken);
         }
         execution.setTrigger(trigger);
-        putExecution(execution);
+        if (!persistExecutionIfSlotAvailable(execution)) {
+            throw new AwsException("ConcurrentPipelineExecutionsLimitExceededException",
+                    "The pipeline has reached the limit for concurrent pipeline executions", 400);
+        }
         applyExecutionMode(execution);
-        executor.submit(() -> runExecution(pipeline, execution));
+        try {
+            executor.submit(() -> runExecution(pipeline, execution));
+        } catch (RejectedExecutionException exception) {
+            execution.setStatus("Failed");
+            execution.setStatusSummary("Pipeline execution could not be scheduled.");
+            execution.setLastUpdateTime(now());
+            putExecution(execution);
+            throw new AwsException("ConflictException",
+                    "Your request cannot be handled because the pipeline is busy handling ongoing activities. "
+                            + "Try again later.", 400);
+        }
         return mapper.createObjectNode().put("pipelineExecutionId", execution.getPipelineExecutionId());
+    }
+
+    private boolean persistExecutionIfSlotAvailable(CodePipelineExecution execution) {
+        if (!List.of("QUEUED", "PARALLEL").contains(execution.getExecutionMode())) {
+            putExecution(execution);
+            return true;
+        }
+        synchronized (startLocks.computeIfAbsent(lockKey(execution), ignored -> new Object())) {
+            long active = executions(execution.getAccountId(), execution.getRegion(), execution.getPipelineName())
+                    .stream()
+                    .filter(candidate -> "InProgress".equals(candidate.getStatus())
+                            || "Stopping".equals(candidate.getStatus()))
+                    .count();
+            if (active >= MAX_ACTIVE_EXECUTIONS) {
+                return false;
+            }
+            putExecution(execution);
+            return true;
+        }
     }
 
     private ObjectNode stopPipelineExecution(JsonNode request, String region, String account) {
@@ -1451,6 +1489,14 @@ public class CodePipelineService {
     @PreDestroy
     void shutdown() {
         executor.shutdownNow();
+        try {
+            if (!executor.awaitTermination(5, TimeUnit.SECONDS)) {
+                LOG.warn("CodePipeline execution workers did not stop within the shutdown timeout");
+            }
+        } catch (InterruptedException exception) {
+            Thread.currentThread().interrupt();
+            LOG.warn("Interrupted while stopping CodePipeline execution workers", exception);
+        }
     }
 
     private record Page(int start, int end) {

--- a/src/test/java/io/github/hectorvent/floci/services/codepipeline/CodePipelineIntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/codepipeline/CodePipelineIntegrationTest.java
@@ -8,8 +8,11 @@ import org.junit.jupiter.api.Test;
 
 import java.time.Duration;
 import java.time.Instant;
+import java.util.ArrayList;
+import java.util.List;
 
 import static io.restassured.RestAssured.given;
+import static org.junit.jupiter.api.Assertions.assertTimeoutPreemptively;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.hasItem;
@@ -1035,6 +1038,50 @@ class CodePipelineIntegrationTest {
                 .body("__type", containsString("InvalidStructureException"));
     }
 
+    @Test
+    void parallelPipelineRejectsExecutionAfterAwsActiveLimit() throws Exception {
+        String pipelineName = "parallel-limit-pipeline";
+        post("CreatePipeline", approvalPipeline(pipelineName, "PARALLEL")).then().statusCode(200);
+        List<String> executionIds = new ArrayList<>();
+        try {
+            while (executionIds.size() < 50) {
+                executionIds.add(startExecution(pipelineName));
+            }
+            waitForActiveExecutions(pipelineName, 50);
+
+            post("StartPipelineExecution", "{\"name\": \"%s\"}".formatted(pipelineName))
+                    .then()
+                    .statusCode(400)
+                    .body("__type", containsString("ConcurrentPipelineExecutionsLimitExceededException"));
+        } finally {
+            stopExecutions(pipelineName, executionIds);
+        }
+    }
+
+    @Test
+    void queuedPipelineAcceptsStartsWhileAnExecutionRunsAndRejectsTheFiftyFirst() throws Exception {
+        String pipelineName = "queued-limit-pipeline";
+        post("CreatePipeline", approvalPipeline(pipelineName, "QUEUED")).then().statusCode(200);
+        List<String> executionIds = new ArrayList<>();
+        try {
+            executionIds.add(startExecution(pipelineName));
+            waitForApprovalToken(pipelineName);
+
+            assertTimeoutPreemptively(Duration.ofSeconds(10), () -> {
+                while (executionIds.size() < 50) {
+                    executionIds.add(startExecution(pipelineName));
+                }
+            }, "StartPipelineExecution waited for the running execution to finish");
+
+            post("StartPipelineExecution", "{\"name\": \"%s\"}".formatted(pipelineName))
+                    .then()
+                    .statusCode(400)
+                    .body("__type", containsString("ConcurrentPipelineExecutionsLimitExceededException"));
+        } finally {
+            stopExecutions(pipelineName, executionIds);
+        }
+    }
+
     private Response waitForJob() throws Exception {
         Instant deadline = Instant.now().plus(Duration.ofSeconds(5));
         Response response;
@@ -1107,6 +1154,74 @@ class CodePipelineIntegrationTest {
             Thread.sleep(50);
         } while (Instant.now().isBefore(deadline));
         throw new AssertionError("Approval token was not issued for pipeline " + pipelineName);
+    }
+
+    private void waitForActiveExecutions(String pipelineName, int expected) throws Exception {
+        Instant deadline = Instant.now().plus(Duration.ofSeconds(5));
+        do {
+            int active = post("ListPipelineExecutions", "{\"pipelineName\": \"%s\"}".formatted(pipelineName))
+                    .jsonPath().getList("pipelineExecutionSummaries.status", String.class).stream()
+                    .filter("InProgress"::equals)
+                    .toList()
+                    .size();
+            if (active >= expected) {
+                return;
+            }
+            Thread.sleep(50);
+        } while (Instant.now().isBefore(deadline));
+        throw new AssertionError("Pipeline did not reach " + expected + " active executions");
+    }
+
+    private static String approvalPipeline(String name, String executionMode) {
+        return """
+                {
+                    "pipeline": {
+                        "name": "%s",
+                        "roleArn": "arn:aws:iam::000000000000:role/codepipeline-role",
+                        "pipelineType": "V2",
+                        "executionMode": "%s",
+                        "artifactStore": {"type": "S3", "location": "codepipeline-artifacts"},
+                        "stages": [{
+                            "name": "Approve",
+                            "actions": [{
+                                "name": "ManualApproval",
+                                "actionTypeId": {
+                                    "category": "Approval",
+                                    "owner": "AWS",
+                                    "provider": "Manual",
+                                    "version": "1"
+                                }
+                            }]
+                        }, {
+                            "name": "Complete",
+                            "actions": [{
+                                "name": "ManualApprovalComplete",
+                                "actionTypeId": {
+                                    "category": "Approval",
+                                    "owner": "AWS",
+                                    "provider": "Manual",
+                                    "version": "1"
+                                }
+                            }]
+                        }]
+                    }
+                }
+                """.formatted(name, executionMode);
+    }
+
+    private static String startExecution(String pipelineName) {
+        return post("StartPipelineExecution", "{\"name\": \"%s\"}".formatted(pipelineName))
+                .then()
+                .statusCode(200)
+                .extract().jsonPath().getString("pipelineExecutionId");
+    }
+
+    private static void stopExecutions(String pipelineName, List<String> executionIds) {
+        for (String executionId : executionIds) {
+            post("StopPipelineExecution", """
+                    {"pipelineName": "%s", "pipelineExecutionId": "%s", "abandon": true}
+                    """.formatted(pipelineName, executionId)).then().statusCode(200);
+        }
     }
 
     private static Response post(String action, String body) {

--- a/src/test/java/io/github/hectorvent/floci/services/codepipeline/CodePipelineServiceTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/codepipeline/CodePipelineServiceTest.java
@@ -1,0 +1,97 @@
+package io.github.hectorvent.floci.services.codepipeline;
+
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.github.hectorvent.floci.core.common.AwsException;
+import io.github.hectorvent.floci.core.storage.AccountAwareStorageBackend;
+import io.github.hectorvent.floci.core.storage.StorageFactory;
+import io.github.hectorvent.floci.services.codebuild.CodeBuildService;
+import io.github.hectorvent.floci.services.codedeploy.CodeDeployService;
+import io.github.hectorvent.floci.services.lambda.LambdaService;
+import io.github.hectorvent.floci.services.s3.S3Service;
+import org.junit.jupiter.api.Test;
+
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.mock;
+
+class CodePipelineServiceTest {
+
+    private static final String REGION = "us-east-1";
+    private static final String ACCOUNT = "000000000000";
+
+    private final ObjectMapper mapper = new ObjectMapper();
+    private final CodePipelineService service = new CodePipelineService(
+            new InMemoryStorageFactory(),
+            mapper,
+            mock(CodeBuildService.class),
+            mock(CodeDeployService.class),
+            mock(LambdaService.class),
+            mock(S3Service.class));
+
+    @Test
+    void aStartAfterShutdownIsRefusedAndTheExecutionIsPersistedAsFailed() throws Exception {
+        handle("CreatePipeline", """
+                {
+                    "pipeline": {
+                        "name": "pipeline",
+                        "roleArn": "arn:aws:iam::000000000000:role/codepipeline-role",
+                        "artifactStore": {"type": "S3", "location": "codepipeline-artifacts"},
+                        "stages": [{
+                            "name": "Approve",
+                            "actions": [{
+                                "name": "ManualApproval",
+                                "actionTypeId": {
+                                    "category": "Approval",
+                                    "owner": "AWS",
+                                    "provider": "Manual",
+                                    "version": "1"
+                                }
+                            }]
+                        }, {
+                            "name": "Complete",
+                            "actions": [{
+                                "name": "ManualApprovalComplete",
+                                "actionTypeId": {
+                                    "category": "Approval",
+                                    "owner": "AWS",
+                                    "provider": "Manual",
+                                    "version": "1"
+                                }
+                            }]
+                        }]
+                    }
+                }
+                """);
+        service.shutdown();
+
+        AwsException refused = assertThrows(AwsException.class,
+                () -> handle("StartPipelineExecution", "{\"name\": \"pipeline\"}"));
+
+        assertEquals("ConflictException", refused.getErrorCode());
+        assertEquals(400, refused.getHttpStatus());
+        JsonNode summaries = handle("ListPipelineExecutions", "{\"pipelineName\": \"pipeline\"}")
+                .path("pipelineExecutionSummaries");
+        assertEquals(1, summaries.size());
+        assertEquals("Failed", summaries.get(0).path("status").asText());
+    }
+
+    private JsonNode handle(String action, String body) throws Exception {
+        return service.handle(action, mapper.readTree(body), REGION, ACCOUNT);
+    }
+
+    private static final class InMemoryStorageFactory extends StorageFactory {
+        private InMemoryStorageFactory() {
+            super(null, null);
+        }
+
+        @Override
+        public <V> AccountAwareStorageBackend<V> create(String serviceName, String fileName,
+                                                    TypeReference<Map<String, V>> typeReference) {
+            return AccountAwareStorageBackend.inMemory(ACCOUNT);
+        }
+    }
+}


### PR DESCRIPTION
## Summary

AWS caps a `QUEUED` or `PARALLEL` pipeline at 50 concurrent executions. Floci accepted any number, so every `StartPipelineExecution` succeeded and each one took a virtual thread with nothing bounding the count. This addresses the audit item for `CodePipelineService`:

> Virtual-thread execution is unbounded at the service boundary. Add explicit operation concurrency limits and shutdown accounting.

- `StartPipelineExecution` on a `QUEUED` or `PARALLEL` pipeline counts the pipeline's `InProgress` and `Stopping` executions under a per-pipeline admission lock and returns `ConcurrentPipelineExecutionsLimitExceededException` (400) at 50. Retry and rollback reuse the same path, so they are covered. `SUPERSEDED` pipelines are unchanged.
- The admission lock is its own map, separate from the monitor a `QUEUED` worker holds for its whole run. Counting under that monitor would block the start until the running execution finished.
- A start that reaches the executor after shutdown is persisted as `Failed` and returns `ConflictException` with the AWS message instead of leaking `RejectedExecutionException`.
- `shutdown()` waits up to five seconds for execution workers to stop so their final status writes complete before the process exits.
- Executions found in storage at startup are resumed as before. The limit applies only when a new execution is started.
- `docs/services/codepipeline.md` gains one sentence on the limit.

Tests:

- `parallelPipelineRejectsExecutionAfterAwsActiveLimit`: 50 executions parked at manual approval, the 51st start is rejected.
- `queuedPipelineAcceptsStartsWhileAnExecutionRunsAndRejectsTheFiftyFirst`: with one execution inside a stage, 49 more starts return within a bounded time and the 51st is rejected. This guards the admission lock choice above.
- `CodePipelineServiceTest.aStartAfterShutdownIsRefusedAndTheExecutionIsPersistedAsFailed`: unit test for the shutdown path, no Quarkus boot.

Both integration tests stop their executions with `abandon` when they finish, so no workers linger for the rest of the JVM.

Out of scope, both pre-existing:

- `SUPERSEDED` mode gates nothing at stage entry, so its execution count stays unbounded. For that mode the audit item is narrowed, not closed.
- A clean shutdown interrupts in-flight workers, whose error path marks their executions `Failed`, so a restart never resumes them even though `resumePersistedExecutions` exists for that. The termination wait added here makes that write land reliably; it does not change the outcome.

## Type of change

- [x] Bug fix (`fix:`)
- [ ] New feature (`feat:`)
- [ ] Breaking change (`feat!:` or `fix!:`)
- [ ] Docs / chore

## AWS Compatibility

Any number of executions was accepted per pipeline. AWS documents "Maximum number of concurrent pipeline executions per pipeline (QUEUED|PARALLEL mode): 50" in the [CodePipeline quotas](https://docs.aws.amazon.com/codepipeline/latest/userguide/limits.html), and `StartPipelineExecution` returns `ConcurrentPipelineExecutionsLimitExceededException` ("The pipeline has reached the limit for concurrent pipeline executions.", HTTP 400) beyond it. The `ConflictException` message matches the [StartPipelineExecution API reference](https://docs.aws.amazon.com/codepipeline/latest/APIReference/API_StartPipelineExecution.html).

## Checklist

- [ ] `./mvnw test` passes locally
- [x] New or updated integration test added
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
