### PR TITLE
fix(glue): bound DeleteSchemaVersions ranges before expanding them

### DIFF
--- a/src/main/java/io/github/hectorvent/floci/services/glue/schemaregistry/GlueSchemaRegistryService.java
+++ b/src/main/java/io/github/hectorvent/floci/services/glue/schemaregistry/GlueSchemaRegistryService.java
@@ -725,8 +725,16 @@ public class GlueSchemaRegistryService {
                         throw new AwsException("InvalidInputException",
                                 "Invalid version range: " + token, 400);
                     }
-                    for (long v = start; v <= end; v++) {
-                        versions.add(v);
+                    // Bound the range before expanding it so a request such as 1-9223372036854775807
+                    // is rejected outright instead of materialising every version number.
+                    long rangeSize = end - start;
+                    if (rangeSize >= MAX_DELETE_SCHEMA_VERSIONS) {
+                        throw new AwsException("InvalidInputException",
+                                "Versions expression cannot expand to more than "
+                                        + MAX_DELETE_SCHEMA_VERSIONS + " versions", 400);
+                    }
+                    for (long offset = 0; offset <= rangeSize; offset++) {
+                        versions.add(start + offset);
                     }
                 } else {
                     versions.add(Long.parseLong(token));

--- a/src/test/java/io/github/hectorvent/floci/services/glue/schemaregistry/GlueSchemaRegistryServiceTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/glue/schemaregistry/GlueSchemaRegistryServiceTest.java
@@ -694,6 +694,27 @@ class GlueSchemaRegistryServiceTest {
     }
 
     @Test
+    void deleteSchemaVersionsRejectsHugeRangeBeforeExpansion() {
+        preCreateRegistry();
+        service.createSchema(new RegistryId("reg", null), "a", "AVRO", "BACKWARD", null, AVRO_V1, null, REGION);
+
+        AwsException ex = assertThrows(AwsException.class, () ->
+                service.deleteSchemaVersions(new SchemaId("reg", "a", null), "1-9223372036854775807", REGION));
+
+        assertEquals("InvalidInputException", ex.getErrorCode());
+    }
+
+    @Test
+    void deleteSchemaVersionsAcceptsRangeOfExactlyTwentyFiveVersions() {
+        preCreateRegistry();
+        service.createSchema(new RegistryId("reg", null), "a", "AVRO", "BACKWARD", null, AVRO_V1, null, REGION);
+
+        var results = service.deleteSchemaVersions(new SchemaId("reg", "a", null), "1-25", REGION);
+
+        assertEquals(25, results.size());
+    }
+
+    @Test
     void deleteSchemaVersionsReportsErrorsForMissingVersions() {
         preCreateRegistry();
         service.createSchema(new RegistryId("reg", null), "a", "AVRO", "BACKWARD", null, AVRO_V1, null, REGION);


### PR DESCRIPTION
## Summary

`DeleteSchemaVersions` expanded a `Versions` range such as `1-9223372036854775807` into a full list before applying the 25 version limit, so a single request could exhaust memory. The range size is now checked before expansion, and any range that would expand to more than 25 versions is rejected with `InvalidInputException`.

## Type of change

- [x] Bug fix (`fix:`)
- [ ] New feature (`feat:`)
- [ ] Breaking change (`feat!:` or `fix!:`)
- [ ] Docs / chore

## AWS Compatibility

AWS documents the `Versions` expression as a comma separated list of version numbers or ranges (`[1-9][0-9]*|[1-9][0-9]*-[1-9][0-9]*`) and limits each call to 25 versions, which is the existing `MAX_DELETE_SCHEMA_VERSIONS` constant in Floci. Before this fix the limit was only enforced after the range had been materialised, so an oversized range consumed memory proportional to its size instead of returning the validation error.

Tests cover a huge range, a range of 26 versions, and the boundary of exactly 25 versions.

## Checklist

- [ ] `./mvnw test` passes locally
- [ ] New or updated integration test added
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)

Test note: coverage is in `GlueSchemaRegistryServiceTest` (service level, 79 tests pass). The full suite was not run.
