### PR TITLE
fix(core): accept only JSON objects as JSON protocol request bodies

### DIFF
--- a/src/main/java/io/github/hectorvent/floci/core/common/AwsJson11Controller.java
+++ b/src/main/java/io/github/hectorvent/floci/core/common/AwsJson11Controller.java
@@ -276,8 +276,16 @@ public class AwsJson11Controller {
 
         JsonNode request;
         try {
-            request = strictBodyReader.readTree(body);
+            // No payload is how an operation without input goes over the wire, so it reads as {}.
+            request = body == null || body.isBlank()
+                    ? objectMapper.createObjectNode()
+                    : strictBodyReader.readTree(body);
         } catch (JsonProcessingException e) {
+            return JsonErrorResponseUtils.createSerializationErrorResponse();
+        }
+        // Input is always a structure: a bare null, array or scalar parses but is still a
+        // client serialization error rather than something every handler must guard against.
+        if (!request.isObject()) {
             return JsonErrorResponseUtils.createSerializationErrorResponse();
         }
 

--- a/src/main/java/io/github/hectorvent/floci/core/common/AwsJsonController.java
+++ b/src/main/java/io/github/hectorvent/floci/core/common/AwsJsonController.java
@@ -111,8 +111,16 @@ public class AwsJsonController {
 
         JsonNode request;
         try {
-            request = strictBodyReader.readTree(body);
+            // No payload is how an operation without input goes over the wire, so it reads as {}.
+            request = body == null || body.isBlank()
+                    ? objectMapper.createObjectNode()
+                    : strictBodyReader.readTree(body);
         } catch (JsonProcessingException e) {
+            return JsonErrorResponseUtils.createSerializationErrorResponse();
+        }
+        // Input is always a structure: a bare null, array or scalar parses but is still a
+        // client serialization error rather than something every handler must guard against.
+        if (!request.isObject()) {
             return JsonErrorResponseUtils.createSerializationErrorResponse();
         }
 

--- a/src/test/java/io/github/hectorvent/floci/core/common/JsonMalformedInputIntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/core/common/JsonMalformedInputIntegrationTest.java
@@ -97,6 +97,92 @@ class JsonMalformedInputIntegrationTest {
             .statusCode(200);
     }
 
+    // ── Dispatcher: the body must be a JSON object; no body at all is the wire form of "no input" ──
+
+    @Test
+    void emptyBodyOnJson11IsReadAsEmptyInput() {
+        req(JSON_1_1, "TrentService.ListKeys", "")
+        .when().post("/")
+        .then()
+            .statusCode(200);
+    }
+
+    @Test
+    void whitespaceOnlyBodyOnJson11IsReadAsEmptyInput() {
+        req(JSON_1_1, "TrentService.ListKeys", " \n ")
+        .when().post("/")
+        .then()
+            .statusCode(200);
+    }
+
+    @Test
+    void emptyBodyOnJson11NoInputOperationBehavesLikeEmptyObject() {
+        // The awsJson1_1 protocol requires services to accept no payload for operations that
+        // define no input, so an empty body must be answered exactly like {}.
+        int statusWithEmptyObject = req(JSON_1_1, "AWSOrganizationsV20161128.DescribeOrganization", "{}")
+                .when().post("/")
+                .then().extract().statusCode();
+
+        req(JSON_1_1, "AWSOrganizationsV20161128.DescribeOrganization", "")
+        .when().post("/")
+        .then()
+            .statusCode(statusWithEmptyObject)
+            .body("__type", not(equalTo("SerializationException")));
+    }
+
+    @Test
+    void emptyBodyOnJson10IsReadAsEmptyInput() {
+        req(JSON_1_0, "DynamoDB_20120810.ListTables", "")
+        .when().post("/")
+        .then()
+            .statusCode(200);
+    }
+
+    @Test
+    void jsonNullBodyOnJson11IsSerializationException() {
+        req(JSON_1_1, "TrentService.ListKeys", "null")
+        .when().post("/")
+        .then()
+            .statusCode(400)
+            .body("__type", equalTo("SerializationException"));
+    }
+
+    @Test
+    void arrayBodyOnJson11IsSerializationException() {
+        req(JSON_1_1, "TrentService.ListKeys", "[]")
+        .when().post("/")
+        .then()
+            .statusCode(400)
+            .body("__type", equalTo("SerializationException"));
+    }
+
+    @Test
+    void scalarBodyOnJson11IsSerializationException() {
+        req(JSON_1_1, "TrentService.ListKeys", "\"ListKeys\"")
+        .when().post("/")
+        .then()
+            .statusCode(400)
+            .body("__type", equalTo("SerializationException"));
+    }
+
+    @Test
+    void jsonNullBodyOnJson10IsSerializationException() {
+        req(JSON_1_0, "DynamoDB_20120810.ListTables", "null")
+        .when().post("/")
+        .then()
+            .statusCode(400)
+            .body("__type", equalTo("SerializationException"));
+    }
+
+    @Test
+    void arrayBodyOnJson10IsSerializationException() {
+        req(JSON_1_0, "DynamoDB_20120810.ListTables", "[]")
+        .when().post("/")
+        .then()
+            .statusCode(400)
+            .body("__type", equalTo("SerializationException"));
+    }
+
     // ── KMS: base64 blob fields ──
 
     @Test


### PR DESCRIPTION
## Summary

The JSON 1.0 and JSON 1.1 dispatchers handed whatever Jackson parsed straight to the service handlers. A body of `null`, `[]` or a bare scalar therefore reached code that expects an object and failed with an unhelpful 500. Both dispatchers now return the standard 400 `SerializationException` for any body that is not a JSON object.

An empty or whitespace only body is still read as `{}`.

## Type of change

- [x] Bug fix (`fix:`)
- [ ] New feature (`feat:`)
- [ ] Breaking change (`feat!:` or `fix!:`)
- [ ] Docs / chore

## AWS Compatibility

The Smithy `awsJson1_1` protocol tests state that services must accept no payload, or an empty object payload, for operations that define no input. Floci serves such operations, for example Organizations `DescribeOrganization`, so an empty body has to behave exactly like `{}` rather than being rejected. Anything that parses but is not an object is a client serialization error, which AWS reports as a 400 `SerializationException`.

The JSON 1.0 dispatcher had the same gap, so the guard is applied to both.

New cases in `JsonMalformedInputIntegrationTest` cover empty and whitespace bodies (200), an empty body on a no input operation behaving like `{}`, and `null`, `[]` and scalar bodies (400 `SerializationException`) on both protocols.

## Checklist

- [ ] `./mvnw test` passes locally
- [x] New or updated integration test added
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)

Test note: `JsonMalformedInputIntegrationTest` (20 tests) passes. The full suite was not run.
