### PR TITLE
feat(stepfunctions): implement s3:listObjectsV2 ItemReader

### DIFF
--- a/src/main/java/io/github/hectorvent/floci/services/stepfunctions/AslExecutor.java
+++ b/src/main/java/io/github/hectorvent/floci/services/stepfunctions/AslExecutor.java
@@ -2817,8 +2817,7 @@ public class AslExecutor {
                                                     ObjectNode variables) throws Exception {
         String resource = itemReader.path("Resource").asText(null);
         if ("arn:aws:states:::s3:listObjectsV2".equals(resource)) {
-            throw new FailStateException("States.ItemReaderFailed",
-                    "ItemReader resource arn:aws:states:::s3:listObjectsV2 is not yet implemented by the emulator");
+            return resolveS3ListObjectsV2Items(itemReader, input, context, jsonata, variables);
         }
         if (!"arn:aws:states:::s3:getObject".equals(resource)) {
             throw new FailStateException("States.Runtime", "Unsupported ItemReader resource: " + resource);
@@ -2866,6 +2865,70 @@ public class AslExecutor {
             throw new FailStateException("States.ItemReaderFailed",
                     e.getMessage() != null ? e.getMessage() : "Failed to parse ItemReader input");
         }
+    }
+
+    /**
+     * Resolves ItemReader items for the {@code arn:aws:states:::s3:listObjectsV2} resource.
+     * Pages through S3's ListObjectsV2 continuation token so a Distributed Map sees every object
+     * under the prefix rather than just the first page, and emits one item per object shaped the
+     * way AWS documents it: {@code Etag}, {@code Key}, {@code LastModified}, {@code Size} and
+     * {@code StorageClass}.
+     */
+    private ResolvedMapItems resolveS3ListObjectsV2Items(JsonNode itemReader, JsonNode input,
+                                                         JsonNode context, boolean jsonata,
+                                                         ObjectNode variables) throws Exception {
+        String transformation = itemReader.path("ReaderConfig").path("Transformation").asText("NONE");
+        if (!"NONE".equals(transformation)) {
+            throw new FailStateException("States.ItemReaderFailed",
+                    "ItemReader ReaderConfig.Transformation " + transformation
+                            + " is not yet implemented by the emulator");
+        }
+
+        JsonNode resolvedParameters;
+        if (jsonata && itemReader.has("Arguments")) {
+            JsonNode statesVar = buildStatesVar(input, null, context);
+            resolvedParameters = jsonataEvaluator.resolveTemplate(
+                    itemReader.get("Arguments"), "ItemReader/Arguments", statesVar, variables);
+        } else {
+            JsonNode parameters = itemReader.path("Parameters");
+            resolvedParameters = resolveParameters(parameters, input, context);
+        }
+        String bucket = resolvedParameters.path("Bucket").asText(null);
+        if (bucket == null) {
+            throw new FailStateException("States.Runtime", "ItemReader Parameters must include Bucket");
+        }
+        String prefix = resolvedParameters.path("Prefix").asText(null);
+
+        try {
+            ArrayNode items = objectMapper.createArrayNode();
+            String continuationToken = null;
+            do {
+                S3Service.ListObjectsResult page = s3Service.listObjectsWithPrefixes(
+                        bucket, prefix, null, 1000, continuationToken, null);
+                for (S3Object object : page.objects()) {
+                    items.add(toS3ListObjectsV2Item(object));
+                }
+                continuationToken = page.isTruncated() ? page.nextContinuationToken() : null;
+            } while (continuationToken != null);
+            return new ResolvedMapItems(applyMaxItems(itemReader, items), MapItemsSource.ITEM_READER_ARRAY);
+        } catch (AwsException e) {
+            throw new FailStateException("States.ItemReaderFailed", e.getMessage());
+        } catch (FailStateException e) {
+            throw e;
+        } catch (Exception e) {
+            throw new FailStateException("States.ItemReaderFailed",
+                    e.getMessage() != null ? e.getMessage() : "Failed to list ItemReader objects");
+        }
+    }
+
+    private ObjectNode toS3ListObjectsV2Item(S3Object object) {
+        ObjectNode item = objectMapper.createObjectNode();
+        item.put("Etag", object.getETag());
+        item.put("Key", object.getKey());
+        item.put("LastModified", object.getLastModified().getEpochSecond());
+        item.put("Size", object.getSize());
+        item.put("StorageClass", object.getStorageClass());
+        return item;
     }
 
     private ArrayNode normalizeObjectItems(JsonNode items) {

--- a/src/test/java/io/github/hectorvent/floci/services/stepfunctions/AslExecutorS3ListObjectsV2ItemReaderTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/stepfunctions/AslExecutorS3ListObjectsV2ItemReaderTest.java
@@ -1,0 +1,190 @@
+package io.github.hectorvent.floci.services.stepfunctions;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.github.hectorvent.floci.config.EmulatorConfig;
+import io.github.hectorvent.floci.services.dynamodb.DynamoDbJsonHandler;
+import io.github.hectorvent.floci.services.dynamodb.DynamoDbService;
+import io.github.hectorvent.floci.services.lambda.LambdaExecutorService;
+import io.github.hectorvent.floci.services.lambda.LambdaFunctionStore;
+import io.github.hectorvent.floci.services.s3.S3Service;
+import io.github.hectorvent.floci.services.s3.model.S3Object;
+import io.github.hectorvent.floci.services.sns.SnsJsonHandler;
+import io.github.hectorvent.floci.services.sqs.SqsJsonHandler;
+import io.github.hectorvent.floci.services.stepfunctions.model.Execution;
+import io.github.hectorvent.floci.services.stepfunctions.model.HistoryEvent;
+import io.github.hectorvent.floci.services.stepfunctions.model.StateMachine;
+import jakarta.enterprise.inject.Instance;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentMatchers.isNull;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+/**
+ * Unit coverage for the Distributed Map {@code ItemReader} with the
+ * {@code arn:aws:states:::s3:listObjectsV2} resource: the emitted item shape (per the AWS
+ * ListObjectsV2 ItemReader specification) and the pagination loop that follows S3's
+ * continuation token so every object under a prefix is seen, not just the first page.
+ */
+class AslExecutorS3ListObjectsV2ItemReaderTest {
+
+    private final ObjectMapper mapper = new ObjectMapper();
+    private S3Service s3Service;
+    private AslExecutor executor;
+
+    @BeforeEach
+    @SuppressWarnings("unchecked")
+    void setUp() {
+        s3Service = mock(S3Service.class);
+        Instance<StepFunctionsService> sfnService = mock(Instance.class);
+        when(sfnService.get()).thenReturn(mock(StepFunctionsService.class));
+        executor = new AslExecutor(
+                mock(LambdaExecutorService.class),
+                mock(LambdaFunctionStore.class),
+                mock(DynamoDbService.class),
+                mock(DynamoDbJsonHandler.class),
+                mock(SqsJsonHandler.class), mock(SnsJsonHandler.class),
+                mock(io.github.hectorvent.floci.services.cloudformation.CloudFormationQueryHandler.class),
+                mock(io.github.hectorvent.floci.services.ec2.Ec2Service.class),
+                s3Service,
+                mock(io.github.hectorvent.floci.services.ecs.EcsService.class),
+                mock(io.github.hectorvent.floci.services.ecs.EcsJsonHandler.class),
+                mock(io.github.hectorvent.floci.services.eventbridge.EventBridgeHandler.class),
+                mock(io.github.hectorvent.floci.services.scheduler.SchedulerService.class),
+                mock(io.github.hectorvent.floci.services.scheduler.SchedulerController.class),
+                mapper,
+                new JsonataEvaluator(mapper),
+                sfnService,
+                mock(EmulatorConfig.class),
+                null,
+                null);
+    }
+
+    private S3Object object(String key) {
+        S3Object object = new S3Object();
+        object.setKey(key);
+        object.setSize(key.length());
+        object.setETag("\"" + key.hashCode() + "\"");
+        object.setLastModified(Instant.ofEpochSecond(1700000000L));
+        return object;
+    }
+
+    private StateMachine machine(String definition) {
+        StateMachine sm = new StateMachine();
+        sm.setName("listObjectsV2");
+        sm.setStateMachineArn("arn:aws:states:us-east-1:000000000000:stateMachine:listObjectsV2");
+        sm.setRoleArn("arn:aws:iam::000000000000:role/test-role");
+        sm.setDefinition(definition);
+        return sm;
+    }
+
+    private Execution execution(StateMachine sm, String name) {
+        Execution execution = new Execution();
+        execution.setName(name);
+        execution.setExecutionArn(
+                "arn:aws:states:us-east-1:000000000000:execution:" + sm.getName() + ":" + name);
+        execution.setStateMachineArn(sm.getStateMachineArn());
+        execution.setInput("{}");
+        return execution;
+    }
+
+    @Test
+    void emitsOneItemPerObjectShapedPerAwsListObjectsV2ItemReaderSpec() throws Exception {
+        S3Service.ListObjectsResult page = new S3Service.ListObjectsResult(
+                List.of(object("prefix/a.json"), object("prefix/b.json")), List.of(), false, null);
+        when(s3Service.listObjectsWithPrefixes(eq("my-bucket"), eq("prefix/"), isNull(), anyInt(), isNull(), isNull()))
+                .thenReturn(page);
+
+        StateMachine sm = machine("""
+                {
+                  "StartAt":"Process",
+                  "States":{
+                    "Process":{
+                      "Type":"Map",
+                      "ItemReader":{
+                        "Resource":"arn:aws:states:::s3:listObjectsV2",
+                        "Parameters":{"Bucket":"my-bucket","Prefix":"prefix/"}
+                      },
+                      "ItemProcessor":{
+                        "ProcessorConfig":{"Mode":"DISTRIBUTED","ExecutionType":"STANDARD"},
+                        "StartAt":"PassItem",
+                        "States":{"PassItem":{"Type":"Pass","End":true}}
+                      },
+                      "End":true
+                    }
+                  }
+                }
+                """);
+        Execution execution = execution(sm, "shape");
+
+        executor.executeSync(sm, execution, new ArrayList<HistoryEvent>(), (u, h) -> { });
+
+        assertEquals("SUCCEEDED", execution.getStatus(), execution.getCause());
+        JsonNode output = mapper.readTree(execution.getOutput());
+        assertEquals(2, output.size());
+        JsonNode first = output.get(0);
+        assertEquals("prefix/a.json", first.path("Key").asText());
+        assertEquals("STANDARD", first.path("StorageClass").asText());
+        assertTrue(first.path("Etag").isTextual());
+        assertTrue(first.path("LastModified").isIntegralNumber());
+        assertTrue(first.path("Size").isIntegralNumber());
+    }
+
+    @Test
+    void pagesThroughS3ContinuationTokenUntilNotTruncated() throws Exception {
+        S3Service.ListObjectsResult firstPage = new S3Service.ListObjectsResult(
+                List.of(object("prefix/1"), object("prefix/2"), object("prefix/3")),
+                List.of(), true, "prefix/3");
+        S3Service.ListObjectsResult secondPage = new S3Service.ListObjectsResult(
+                List.of(object("prefix/4"), object("prefix/5")), List.of(), false, null);
+        when(s3Service.listObjectsWithPrefixes(
+                eq("pagination-bucket"), eq("prefix/"), isNull(), anyInt(), any(), isNull()))
+                .thenReturn(firstPage, secondPage);
+
+        StateMachine sm = machine("""
+                {
+                  "StartAt":"Process",
+                  "States":{
+                    "Process":{
+                      "Type":"Map",
+                      "ItemReader":{
+                        "Resource":"arn:aws:states:::s3:listObjectsV2",
+                        "Parameters":{"Bucket":"pagination-bucket","Prefix":"prefix/"}
+                      },
+                      "ItemProcessor":{
+                        "ProcessorConfig":{"Mode":"DISTRIBUTED","ExecutionType":"STANDARD"},
+                        "StartAt":"PassItem",
+                        "States":{"PassItem":{"Type":"Pass","End":true}}
+                      },
+                      "End":true
+                    }
+                  }
+                }
+                """);
+        Execution execution = execution(sm, "pagination");
+
+        executor.executeSync(sm, execution, new ArrayList<HistoryEvent>(), (u, h) -> { });
+
+        assertEquals("SUCCEEDED", execution.getStatus(), execution.getCause());
+        JsonNode output = mapper.readTree(execution.getOutput());
+        assertEquals(5, output.size());
+        for (int i = 0; i < 5; i++) {
+            assertEquals("prefix/" + (i + 1), output.get(i).path("Key").asText());
+        }
+        verify(s3Service, times(2)).listObjectsWithPrefixes(
+                eq("pagination-bucket"), eq("prefix/"), isNull(), anyInt(), any(), isNull());
+    }
+}

--- a/src/test/java/io/github/hectorvent/floci/services/stepfunctions/StepFunctionsJsonataIntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/stepfunctions/StepFunctionsJsonataIntegrationTest.java
@@ -2235,9 +2235,11 @@ class StepFunctionsJsonataIntegrationTest {
     }
 
     @Test
-    void distributedMapWithListObjectsV2ItemReader_failsWithNotImplementedItemReaderError() throws Exception {
+    void distributedMapWithListObjectsV2ItemReader_fansOutOneIterationPerObjectUnderPrefix() throws Exception {
         createBucket("map-inputs-list-objects");
-        putObject("map-inputs-list-objects", "workers/a.json", "[]");
+        putObject("map-inputs-list-objects", "workers/a.json", "{\"workerId\":\"w1\"}");
+        putObject("map-inputs-list-objects", "workers/b.json", "{\"workerId\":\"w2\"}");
+        putObject("map-inputs-list-objects", "other/c.json", "{\"workerId\":\"w3\"}");
 
         String definition = """
                 {
@@ -2247,9 +2249,6 @@ class StepFunctionsJsonataIntegrationTest {
                             "Type": "Map",
                             "ItemReader": {
                                 "Resource": "arn:aws:states:::s3:listObjectsV2",
-                                "ReaderConfig": {
-                                    "InputType": "JSON"
-                                },
                                 "Parameters": {
                                     "Bucket": "map-inputs-list-objects",
                                     "Prefix": "workers/"
@@ -2276,11 +2275,102 @@ class StepFunctionsJsonataIntegrationTest {
 
         String smArn = createStateMachine("map-itemreader-s3-list-objects-v2-test", definition);
         String execArn = startExecution(smArn, "{}");
+        JsonNode output = objectMapper.readTree(waitForExecution(execArn));
+
+        assertTrue(output.isArray());
+        assertEquals(2, output.size());
+        for (JsonNode item : output) {
+            assertTrue(item.path("Key").asText().startsWith("workers/"));
+            assertTrue(item.has("Etag"));
+            assertTrue(item.has("LastModified"));
+            assertTrue(item.has("Size"));
+            assertEquals("STANDARD", item.path("StorageClass").asText());
+        }
+    }
+
+    @Test
+    void distributedMapWithListObjectsV2ItemReader_emptyPrefixProducesNoIterations() throws Exception {
+        createBucket("map-inputs-list-objects-empty");
+
+        String definition = """
+                {
+                    "StartAt": "ProcessWorkers",
+                    "States": {
+                        "ProcessWorkers": {
+                            "Type": "Map",
+                            "ItemReader": {
+                                "Resource": "arn:aws:states:::s3:listObjectsV2",
+                                "Parameters": {
+                                    "Bucket": "map-inputs-list-objects-empty",
+                                    "Prefix": "nothing-here/"
+                                }
+                            },
+                            "ItemProcessor": {
+                                "ProcessorConfig": {
+                                    "Mode": "DISTRIBUTED",
+                                    "ExecutionType": "STANDARD"
+                                },
+                                "StartAt": "PassItem",
+                                "States": {
+                                    "PassItem": {
+                                        "Type": "Pass",
+                                        "End": true
+                                    }
+                                }
+                            },
+                            "End": true
+                        }
+                    }
+                }
+                """;
+
+        String smArn = createStateMachine("map-itemreader-s3-list-objects-v2-empty-test", definition);
+        String execArn = startExecution(smArn, "{}");
+        String output = waitForExecution(execArn);
+
+        assertEquals("[]", output);
+    }
+
+    @Test
+    void distributedMapWithListObjectsV2ItemReader_missingBucketFailsWithItemReaderError() throws Exception {
+        String definition = """
+                {
+                    "StartAt": "ProcessWorkers",
+                    "States": {
+                        "ProcessWorkers": {
+                            "Type": "Map",
+                            "ItemReader": {
+                                "Resource": "arn:aws:states:::s3:listObjectsV2",
+                                "Parameters": {
+                                    "Bucket": "map-inputs-list-objects-missing-bucket",
+                                    "Prefix": "workers/"
+                                }
+                            },
+                            "ItemProcessor": {
+                                "ProcessorConfig": {
+                                    "Mode": "DISTRIBUTED",
+                                    "ExecutionType": "STANDARD"
+                                },
+                                "StartAt": "PassItem",
+                                "States": {
+                                    "PassItem": {
+                                        "Type": "Pass",
+                                        "End": true
+                                    }
+                                }
+                            },
+                            "End": true
+                        }
+                    }
+                }
+                """;
+
+        String smArn = createStateMachine("map-itemreader-s3-list-objects-v2-missing-bucket-test", definition);
+        String execArn = startExecution(smArn, "{}");
         Response failure = waitForExecutionFailure(execArn);
 
         assertEquals("FAILED", failure.jsonPath().getString("status"));
         assertEquals("States.ItemReaderFailed", failure.jsonPath().getString("error"));
-        assertTrue(failure.jsonPath().getString("cause").contains("not yet implemented by the emulator"));
     }
 
     @Test


### PR DESCRIPTION
## Summary

Implements the `arn:aws:states:::s3:listObjectsV2` ItemReader for Distributed Map states. Previously every execution using this resource failed with `States.ItemReaderFailed: ... is not yet implemented by the emulator`. Closes #3409

## Type of change

- [ ] Bug fix (`fix:`)
- [x] New feature (`feat:`)
- [ ] Breaking change (`feat!:` or `fix!:`)
- [ ] Docs / chore

## AWS Compatibility

Implemented against the AWS Step Functions ItemReader docs ("A list of Amazon S3 objects" example): `Parameters`/`Arguments` take `Bucket` and `Prefix`; each emitted item mirrors the documented S3 ListObjectsV2 metadata shape (`Etag`, `Key`, `LastModified`, `Size`, `StorageClass`). The reader pages through S3's ListObjectsV2 continuation token internally so a Distributed Map sees every object under the prefix, not just the first page. An empty prefix yields zero items (zero iterations), not a failure. `ReaderConfig.Transformation: LOAD_AND_FLATTEN` is not yet supported and fails with an explicit "not yet implemented" error rather than being silently ignored.

## Checklist

- [x] `./mvnw test` passes locally
- [x] New or updated integration test added
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)