### PR TITLE
fix(codepipeline): resolve effective source revisions

### DIFF
--- a/docs/services/codepipeline.md
+++ b/docs/services/codepipeline.md
@@ -25,6 +25,11 @@ Stages execute in declaration order. Actions with the same `runOrder` execute in
 A `QUEUED` or `PARALLEL` pipeline holds at most 50 active executions, as on AWS;
 `StartPipelineExecution` beyond that returns `ConcurrentPipelineExecutionsLimitExceededException`.
 
+S3 source actions resolve `sourceRevisions` from the object actually consumed by the execution.
+Unversioned objects report their ETag as the revision ID; versioned objects report the version ID.
+`StartPipelineExecution.sourceRevisions` is treated as an override, including supported S3 object-key
+and version-ID overrides, rather than being copied directly into execution history.
+
 The following providers execute against local Floci services:
 
 | Category | Provider | Behavior |

--- a/src/main/java/io/github/hectorvent/floci/services/codepipeline/CodePipelineService.java
+++ b/src/main/java/io/github/hectorvent/floci/services/codepipeline/CodePipelineService.java
@@ -279,7 +279,8 @@ public class CodePipelineService {
         execution.setStatusSummary("Pipeline execution started.");
         execution.setStartTime(now());
         execution.setLastUpdateTime(execution.getStartTime());
-        execution.setSourceRevisions(objectList(request.path("sourceRevisions")));
+        execution.setSourceRevisions(new ArrayList<>());
+        execution.setSourceRevisionOverrides(sourceRevisionOverrides(request, pipeline));
         execution.setVariables(variableList(request.path("variables")));
         Map<String, String> trigger = new LinkedHashMap<>();
         trigger.put("triggerType", "StartPipelineExecution");
@@ -562,7 +563,7 @@ public class CodePipelineService {
                 account, region, pipelineName, text(request, "pipelineExecutionId"));
         ObjectNode start = mapper.createObjectNode();
         start.put("name", pipelineName);
-        start.set("sourceRevisions", mapper.valueToTree(source.getSourceRevisions()));
+        start.set("sourceRevisions", mapper.valueToTree(source.getSourceRevisionOverrides()));
         ArrayNode vars = start.putArray("variables");
         source.getVariables().forEach(v -> vars.addObject()
                 .put("name", v.get("name"))
@@ -927,20 +928,27 @@ public class CodePipelineService {
         JsonNode config = action.path("configuration");
         if ("Source".equals(state.getCategory())) {
             String bucket = config.path("S3Bucket").asText(config.path("BucketName").asText(null));
-            String key = config.path("S3ObjectKey").asText(config.path("ObjectKey").asText(null));
-            S3Object object = s3Service.getObject(bucket, key);
+            String key = effectiveS3SourceKey(execution, state.getActionName(), config);
+            String versionId = sourceRevisionOverride(
+                    execution, state.getActionName(), "S3_OBJECT_VERSION_ID");
+            S3Object object = s3Service.getObject(bucket, key, versionId);
             for (JsonNode artifact : action.path("outputArtifacts")) {
                 runtimeArtifacts.put(artifactKey(execution, artifact.path("name").asText()), object.getData());
             }
-            Map<String, Object> revision = new LinkedHashMap<>();
-            revision.put("name", state.getActionName());
-            revision.put("revisionId", object.getVersionId() != null ? object.getVersionId() : object.getETag());
-            revision.put("revisionChangeIdentifier", object.getETag());
-            revision.put("revisionSummary", bucket + "/" + key);
-            revision.put("revisionUrl", "s3://" + bucket + "/" + key);
-            revision.put("created", object.getLastModified().toEpochMilli() / 1000.0);
-            execution.getArtifactRevisions().add(revision);
-            state.setExternalExecutionId(revision.get("revisionId").toString());
+            String revisionId = object.getVersionId() != null
+                    ? object.getVersionId() : unquoteETag(object.getETag());
+            synchronized (execution) {
+                Map<String, Object> revision = new LinkedHashMap<>();
+                revision.put("name", state.getActionName());
+                revision.put("revisionId", revisionId);
+                revision.put("revisionChangeIdentifier", unquoteETag(object.getETag()));
+                revision.put("revisionSummary", bucket + "/" + key);
+                revision.put("revisionUrl", "s3://" + bucket + "/" + key);
+                revision.put("created", object.getLastModified().toEpochMilli() / 1000.0);
+                execution.getArtifactRevisions().add(revision);
+                upsertSourceRevision(execution, state.getActionName(), revisionId, bucket, key, object);
+            }
+            state.setExternalExecutionId(revisionId);
             return;
         }
         String bucket = config.path("BucketName").asText(config.path("S3Bucket").asText(null));
@@ -1297,7 +1305,7 @@ public class CodePipelineService {
     private ObjectNode executionNode(CodePipelineExecution execution) {
         ObjectNode node = mapper.valueToTree(execution);
         node.remove(List.of("accountId", "region", "startTime", "lastUpdateTime",
-                "sourceRevisions", "actionExecutions", "currentStage", "stopRequested", "abandon",
+                "sourceRevisionOverrides", "actionExecutions", "currentStage", "stopRequested", "abandon",
                 "rollbackTargetPipelineExecutionId"));
         if (execution.getRollbackTargetPipelineExecutionId() != null) {
             node.putObject("rollbackMetadata").put(
@@ -1406,6 +1414,107 @@ public class CodePipelineService {
             return "Succeeded";
         }
         return "Failed";
+    }
+
+    private List<Map<String, Object>> sourceRevisionOverrides(JsonNode request, CodePipelinePipeline pipeline) {
+        JsonNode overridesNode = request.get("sourceRevisions");
+        if (overridesNode == null || overridesNode.isNull()) {
+            return new ArrayList<>();
+        }
+        if (!overridesNode.isArray()) {
+            throw new AwsException("ValidationException", "sourceRevisions must be an array", 400);
+        }
+        List<Map<String, Object>> overrides = new ArrayList<>();
+        Set<String> seenOverrides = new java.util.HashSet<>();
+        for (JsonNode override : overridesNode) {
+            if (!override.isObject()) {
+                throw new AwsException("ValidationException", "sourceRevisions entries must be objects", 400);
+            }
+            requireOnlyMembers(override, "sourceRevisions entry",
+                    Set.of("actionName", "revisionType", "revisionValue"));
+            String actionName = text(override, "actionName");
+            String revisionType = text(override, "revisionType");
+            String revisionValue = text(override, "revisionValue");
+            if (!seenOverrides.add(actionName + "\0" + revisionType)) {
+                throw new AwsException("ValidationException",
+                        "Duplicate " + revisionType + " override for source action " + actionName, 400);
+            }
+            JsonNode action = sourceActionByName(pipeline, actionName);
+            String provider = action.path("actionTypeId").path("provider").asText();
+            if (!"S3".equals(provider)) {
+                throw new AwsException("ValidationException",
+                        "Source revision overrides are not supported for provider " + provider, 400);
+            }
+            if (!List.of("S3_OBJECT_KEY", "S3_OBJECT_VERSION_ID").contains(revisionType)) {
+                throw new AwsException("ValidationException",
+                        "Invalid S3 source revision type: " + revisionType, 400);
+            }
+            if (revisionValue.isBlank()) {
+                throw new AwsException("ValidationException", "revisionValue must not be empty", 400);
+            }
+            if ("S3_OBJECT_KEY".equals(revisionType)
+                    && !Boolean.parseBoolean(action.path("configuration")
+                            .path("AllowOverrideForS3ObjectKey").asText("false"))) {
+                throw new AwsException("ValidationException",
+                        "S3_OBJECT_KEY override requires AllowOverrideForS3ObjectKey=true", 400);
+            }
+            Map<String, Object> value = new LinkedHashMap<>();
+            value.put("actionName", actionName);
+            value.put("revisionType", revisionType);
+            value.put("revisionValue", revisionValue);
+            overrides.add(value);
+        }
+        return overrides;
+    }
+
+    private JsonNode sourceActionByName(CodePipelinePipeline pipeline, String actionName) {
+        for (JsonNode stage : pipeline.getDeclaration().path("stages")) {
+            for (JsonNode action : stage.path("actions")) {
+                if ("Source".equals(action.path("actionTypeId").path("category").asText())
+                        && actionName.equals(action.path("name").asText())) {
+                    return action;
+                }
+            }
+        }
+        throw new AwsException("ValidationException", "Source action not found: " + actionName, 400);
+    }
+
+    private String effectiveS3SourceKey(CodePipelineExecution execution, String actionName, JsonNode config) {
+        String override = sourceRevisionOverride(execution, actionName, "S3_OBJECT_KEY");
+        return override != null
+                ? override : config.path("S3ObjectKey").asText(config.path("ObjectKey").asText(null));
+    }
+
+    private String sourceRevisionOverride(CodePipelineExecution execution, String actionName, String revisionType) {
+        String value = null;
+        for (Map<String, Object> override : execution.getSourceRevisionOverrides()) {
+            if (actionName.equals(override.get("actionName")) && revisionType.equals(override.get("revisionType"))) {
+                if (value != null) {
+                    throw new AwsException("ValidationException",
+                            "Duplicate " + revisionType + " override for source action " + actionName, 400);
+                }
+                value = Objects.toString(override.get("revisionValue"), null);
+            }
+        }
+        return value;
+    }
+
+    private void upsertSourceRevision(CodePipelineExecution execution, String actionName, String revisionId,
+                                      String bucket, String key, S3Object object) {
+        Map<String, Object> sourceRevision = new LinkedHashMap<>();
+        sourceRevision.put("actionName", actionName);
+        sourceRevision.put("revisionId", revisionId);
+        String summary = object.getMetadata().get("codepipeline-artifact-revision-summary");
+        if (summary != null && !summary.isBlank()) {
+            sourceRevision.put("revisionSummary", summary);
+        }
+        sourceRevision.put("revisionUrl", "s3://" + bucket + "/" + key);
+        execution.getSourceRevisions().removeIf(existing -> actionName.equals(existing.get("actionName")));
+        execution.getSourceRevisions().add(sourceRevision);
+    }
+
+    private static String unquoteETag(String eTag) {
+        return eTag == null ? null : eTag.replace("\"", "");
     }
 
     private List<Map<String, Object>> objectList(JsonNode node) {

--- a/src/main/java/io/github/hectorvent/floci/services/codepipeline/model/CodePipelineExecution.java
+++ b/src/main/java/io/github/hectorvent/floci/services/codepipeline/model/CodePipelineExecution.java
@@ -27,6 +27,7 @@ public class CodePipelineExecution {
     private Double lastUpdateTime;
     private List<Map<String, Object>> artifactRevisions = new ArrayList<>();
     private List<Map<String, Object>> sourceRevisions = new ArrayList<>();
+    private List<Map<String, Object>> sourceRevisionOverrides = new ArrayList<>();
     private List<Map<String, String>> variables = new ArrayList<>();
     private Map<String, String> trigger = new LinkedHashMap<>();
     private List<ActionExecution> actionExecutions = new ArrayList<>();
@@ -138,6 +139,14 @@ public class CodePipelineExecution {
 
     public void setSourceRevisions(List<Map<String, Object>> sourceRevisions) {
         this.sourceRevisions = sourceRevisions;
+    }
+
+    public List<Map<String, Object>> getSourceRevisionOverrides() {
+        return sourceRevisionOverrides;
+    }
+
+    public void setSourceRevisionOverrides(List<Map<String, Object>> sourceRevisionOverrides) {
+        this.sourceRevisionOverrides = sourceRevisionOverrides == null ? new ArrayList<>() : sourceRevisionOverrides;
     }
 
     public List<Map<String, String>> getVariables() {

--- a/src/test/java/io/github/hectorvent/floci/services/codepipeline/CodePipelineIntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/codepipeline/CodePipelineIntegrationTest.java
@@ -167,7 +167,8 @@ class CodePipelineIntegrationTest {
     void pipelineLifecycleExecutesS3SourceAndDeployActions() throws Exception {
         createBucket("codepipeline-source");
         createBucket("codepipeline-destination");
-        putObject("codepipeline-source", "source.zip", "pipeline artifact");
+        String sourceETag = putObject(
+                "codepipeline-source", "source.zip", "pipeline artifact", "release candidate");
 
         String pipelineName = "s3-copy-pipeline";
         post("CreatePipeline", pipeline(pipelineName, """
@@ -238,7 +239,14 @@ class CodePipelineIntegrationTest {
                 .body("pipelineExecution.pipelineName", equalTo(pipelineName))
                 .body("pipelineExecution.status", equalTo("Succeeded"))
                 .body("pipelineExecution.artifactRevisions", hasSize(1))
-                .body("pipelineExecution.artifactRevisions[0].name", equalTo("SourceObject"));
+                .body("pipelineExecution.artifactRevisions[0].name", equalTo("SourceObject"))
+                .body("pipelineExecution.sourceRevisions", hasSize(1))
+                .body("pipelineExecution.sourceRevisions[0].actionName", equalTo("SourceObject"))
+                .body("pipelineExecution.sourceRevisions[0].revisionId", equalTo(unquote(sourceETag)))
+                .body("pipelineExecution.sourceRevisions[0].revisionSummary", equalTo("release candidate"))
+                .body("pipelineExecution.sourceRevisions[0].revisionUrl",
+                        equalTo("s3://codepipeline-source/source.zip"))
+                .body("pipelineExecution.sourceRevisionOverrides", nullValue());
 
         post("ListPipelineExecutions", """
                 {"pipelineName": "%s"}
@@ -247,7 +255,10 @@ class CodePipelineIntegrationTest {
                 .statusCode(200)
                 .body("pipelineExecutionSummaries", hasSize(1))
                 .body("pipelineExecutionSummaries[0].pipelineExecutionId", equalTo(executionId))
-                .body("pipelineExecutionSummaries[0].status", equalTo("Succeeded"));
+                .body("pipelineExecutionSummaries[0].status", equalTo("Succeeded"))
+                .body("pipelineExecutionSummaries[0].sourceRevisions", hasSize(1))
+                .body("pipelineExecutionSummaries[0].sourceRevisions[0].revisionId",
+                        equalTo(unquote(sourceETag)));
 
         post("ListPipelineExecutions", """
                 {
@@ -322,6 +333,198 @@ class CodePipelineIntegrationTest {
                 .then()
                 .statusCode(200)
                 .body("pipelines.name", hasItem(pipelineName));
+
+        post("DeletePipeline", """
+                {"name": "%s"}
+                """.formatted(pipelineName)).then().statusCode(200);
+    }
+
+    @Test
+    void startPipelineExecutionS3OverridesSelectEffectiveKeyAndVersion() throws Exception {
+        createBucket("codepipeline-source-override");
+        createBucket("codepipeline-override-destination");
+        given()
+                .body("<VersioningConfiguration><Status>Enabled</Status></VersioningConfiguration>")
+        .when()
+                .put("/codepipeline-source-override?versioning")
+        .then()
+                .statusCode(200);
+
+        putObject("codepipeline-source-override", "source.zip", "default artifact");
+        String oldVersion = given()
+                .contentType("application/octet-stream")
+                .body("selected old version".getBytes(java.nio.charset.StandardCharsets.UTF_8))
+        .when()
+                .put("/codepipeline-source-override/alternate.zip")
+        .then()
+                .statusCode(200)
+                .header("x-amz-version-id", notNullValue())
+                .extract().header("x-amz-version-id");
+        putObject("codepipeline-source-override", "alternate.zip", "newer version");
+
+        String pipelineName = "source-revision-override-pipeline";
+        post("CreatePipeline", pipeline(pipelineName, """
+                {
+                    "name": "Source",
+                    "actions": [{
+                        "name": "SourceObject",
+                        "actionTypeId": {
+                            "category": "Source",
+                            "owner": "AWS",
+                            "provider": "S3",
+                            "version": "1"
+                        },
+                        "configuration": {
+                            "S3Bucket": "codepipeline-source-override",
+                            "S3ObjectKey": "source.zip",
+                            "AllowOverrideForS3ObjectKey": "true"
+                        },
+                        "outputArtifacts": [{"name": "SourceOutput"}]
+                    }]
+                },
+                {
+                    "name": "Deploy",
+                    "actions": [{
+                        "name": "DeployObject",
+                        "actionTypeId": {
+                            "category": "Deploy",
+                            "owner": "AWS",
+                            "provider": "S3",
+                            "version": "1"
+                        },
+                        "configuration": {
+                            "BucketName": "codepipeline-override-destination",
+                            "ObjectKey": "deployed.zip"
+                        },
+                        "inputArtifacts": [{"name": "SourceOutput"}]
+                    }]
+                }
+                """))
+                .then().statusCode(200);
+
+        String executionId = post("StartPipelineExecution", """
+                {
+                    "name": "%s",
+                    "sourceRevisions": [
+                        {
+                            "actionName": "SourceObject",
+                            "revisionType": "S3_OBJECT_KEY",
+                            "revisionValue": "alternate.zip"
+                        },
+                        {
+                            "actionName": "SourceObject",
+                            "revisionType": "S3_OBJECT_VERSION_ID",
+                            "revisionValue": "%s"
+                        }
+                    ]
+                }
+                """.formatted(pipelineName, oldVersion))
+                .then()
+                .statusCode(200)
+                .extract().path("pipelineExecutionId");
+
+        waitForExecution(pipelineName, executionId, "Succeeded");
+
+        given()
+                .get("/codepipeline-override-destination/deployed.zip")
+        .then()
+                .statusCode(200)
+                .body(equalTo("selected old version"));
+
+        post("GetPipelineExecution", """
+                {"pipelineName": "%s", "pipelineExecutionId": "%s"}
+                """.formatted(pipelineName, executionId))
+                .then()
+                .statusCode(200)
+                .body("pipelineExecution.sourceRevisions", hasSize(1))
+                .body("pipelineExecution.sourceRevisions[0].actionName", equalTo("SourceObject"))
+                .body("pipelineExecution.sourceRevisions[0].revisionId", equalTo(oldVersion))
+                .body("pipelineExecution.sourceRevisions[0].revisionUrl",
+                        equalTo("s3://codepipeline-source-override/alternate.zip"))
+                .body("pipelineExecution.sourceRevisionOverrides", nullValue());
+
+        post("DeletePipeline", """
+                {"name": "%s"}
+                """.formatted(pipelineName)).then().statusCode(200);
+    }
+
+    @Test
+    void startPipelineExecutionRejectsS3KeyOverrideUnlessActionAllowsIt() {
+        String pipelineName = "source-revision-key-override-validation";
+        post("CreatePipeline", pipeline(pipelineName, """
+                {
+                    "name": "Source",
+                    "actions": [{
+                        "name": "SourceObject",
+                        "actionTypeId": {
+                            "category": "Source",
+                            "owner": "AWS",
+                            "provider": "S3",
+                            "version": "1"
+                        },
+                        "configuration": {
+                            "S3Bucket": "codepipeline-source",
+                            "S3ObjectKey": "source.zip"
+                        },
+                        "outputArtifacts": [{"name": "SourceOutput"}]
+                    }]
+                },
+                {
+                    "name": "Deploy",
+                    "actions": [{
+                        "name": "DeployObject",
+                        "actionTypeId": {
+                            "category": "Deploy",
+                            "owner": "AWS",
+                            "provider": "S3",
+                            "version": "1"
+                        },
+                        "configuration": {
+                            "BucketName": "codepipeline-destination",
+                            "ObjectKey": "deployed.zip"
+                        },
+                        "inputArtifacts": [{"name": "SourceOutput"}]
+                    }]
+                }
+                """))
+                .then().statusCode(200);
+
+        post("StartPipelineExecution", """
+                {
+                    "name": "%s",
+                    "sourceRevisions": [{
+                        "actionName": "SourceObject",
+                        "revisionType": "S3_OBJECT_KEY",
+                        "revisionValue": "alternate.zip"
+                    }]
+                }
+                """.formatted(pipelineName))
+                .then()
+                .statusCode(400)
+                .body("__type", containsString("ValidationException"))
+                .body("message", containsString("AllowOverrideForS3ObjectKey"));
+
+        post("StartPipelineExecution", """
+                {
+                    "name": "%s",
+                    "sourceRevisions": [
+                        {
+                            "actionName": "SourceObject",
+                            "revisionType": "S3_OBJECT_VERSION_ID",
+                            "revisionValue": "v1"
+                        },
+                        {
+                            "actionName": "SourceObject",
+                            "revisionType": "S3_OBJECT_VERSION_ID",
+                            "revisionValue": "v2"
+                        }
+                    ]
+                }
+                """.formatted(pipelineName))
+                .then()
+                .statusCode(400)
+                .body("__type", containsString("ValidationException"))
+                .body("message", containsString("Duplicate S3_OBJECT_VERSION_ID"));
 
         post("DeletePipeline", """
                 {"name": "%s"}
@@ -1388,13 +1591,27 @@ class CodePipelineIntegrationTest {
         given().when().put("/" + bucket).then().statusCode(200);
     }
 
-    private static void putObject(String bucket, String key, String body) {
-        given()
+    private static String putObject(String bucket, String key, String body) {
+        return putObject(bucket, key, body, null);
+    }
+
+    private static String putObject(String bucket, String key, String body, String revisionSummary) {
+        var request = given()
                 .contentType("application/octet-stream")
-                .body(body.getBytes(java.nio.charset.StandardCharsets.UTF_8))
+                .body(body.getBytes(java.nio.charset.StandardCharsets.UTF_8));
+        if (revisionSummary != null) {
+            request.header("x-amz-meta-codepipeline-artifact-revision-summary", revisionSummary);
+        }
+        return request
         .when()
                 .put("/" + bucket + "/" + key)
         .then()
-                .statusCode(200);
+                .statusCode(200)
+                .header("ETag", notNullValue())
+                .extract().header("ETag");
+    }
+
+    private static String unquote(String value) {
+        return value == null ? null : value.replace("\"", "");
     }
 }


### PR DESCRIPTION
## Summary

Make CodePipeline report the effective S3 source revision that an execution actually consumed instead of echoing request-side source revision overrides or omitting the field.

- Separates `StartPipelineExecution.sourceRevisions` overrides from the execution's resolved `sourceRevisions` response state.
- Records the effective S3 revision from the same object read that produces the source artifact.
- Reports S3 ETag for unversioned objects and version ID for versioned objects.
- Carries source revision metadata into `GetPipelineExecution` and `ListPipelineExecutions`.
- Supports S3 object-key/version overrides while keeping the bytes consumed and revision reported in sync.
- Rejects invalid/duplicate source revision overrides synchronously.

Closes #2222

## Type of change

- [x] Bug fix (`fix:`)
- [ ] New feature (`feat:`)
- [ ] Breaking change (`feat!:` or `fix!:`)
- [ ] Docs / chore

## AWS Compatibility

AWS CodePipeline reports the source revision an execution actually consumed. For S3 sources, the effective revision is derived from the selected object metadata, while `StartPipelineExecution.sourceRevisions` is an override input rather than a response field to echo blindly.

References:
- https://docs.aws.amazon.com/codepipeline/latest/APIReference/API_SourceRevision.html
- https://docs.aws.amazon.com/codepipeline/latest/APIReference/API_CurrentRevision.html
- https://docs.aws.amazon.com/codepipeline/latest/APIReference/API_StartPipelineExecution.html

Validation after rebasing onto current `main`:

```text
./mvnw -q -Dtest=CodePipelineIntegrationTest test
./mvnw -q -DskipTests package
make docs-check
git diff --check origin/main...HEAD
```

Integration coverage verifies ETag-based revisions, S3 metadata summaries, versioned-object overrides, byte-for-byte artifact selection, and invalid/duplicate override validation.

## Checklist

- [x] `./mvnw test` passes locally
- [x] New or updated integration test added
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
