### PR TITLE
docs(marketplace): add known deviations and behavior notes for change sets

### DIFF
--- a/docs/services/marketplace.md
+++ b/docs/services/marketplace.md
@@ -69,6 +69,12 @@ Floci emulates AWS Marketplace APIs under the shared `aws-marketplace` SigV4 sig
 
 Catalog change sets use AWS states (`PREPARING`, `APPLYING`, `SUCCEEDED`, and `CANCELLED`). Floci applies supported entity mutations locally when a change set is observed and persists entities, change sets, tags, resource policies, and assessments through `StorageFactory`, isolated by AWS account.
 
+### Known deviations
+
+- `ListEntities` rejects the `EntityTypeFilters` and `EntityTypeSort` request members with a `ValidationException`. AWS accepts these entity-type-specific filter and sort documents; Floci only supports the generic `FilterList` and `Sort` members.
+- Change sets do not progress asynchronously. A change set stays in `PREPARING` until it is next observed through `DescribeChangeSet` or `ListChangeSets`, at which point Floci applies it and moves it straight to `SUCCEEDED` in the same call. The `APPLYING` state is never returned, and change sets never reach `FAILED`; `CancelChangeSet` only succeeds while a change set is still unobserved.
+- The Marketplace Catalog API is served only in `us-east-1`, matching the single AWS endpoint. Requests signed for any other region are rejected with a `ValidationException` instead of being routed to a regional endpoint.
+
 ## Marketplace Agreement
 
 Agreement request acceptance persists the resulting agreement and exposes it through subsequent read and search operations. State is isolated by AWS account through `StorageFactory`.


### PR DESCRIPTION

## Summary

Closes: #3518 

Adds a "Known deviations" subsection to the Marketplace Catalog section of `docs/services/marketplace.md`, matching the convention already used by the Marketplace Agreement and Marketplace Reporting sections on the same page.

The three deviations documented were confirmed against the current `MarketplaceService` implementation:

- `ListEntities` rejects the `EntityTypeFilters` and `EntityTypeSort` request members with a `ValidationException`; only the generic `FilterList` and `Sort` members are supported.
- Change sets do not progress asynchronously. They stay in `PREPARING` until observed via `DescribeChangeSet` or `ListChangeSets`, then move straight to `SUCCEEDED` in the same call. `APPLYING` is never returned, `FAILED` never occurs, and `CancelChangeSet` only succeeds while the change set is still unobserved.
- The API is served only in `us-east-1` (matching the single AWS endpoint); requests for any other region are rejected with a `ValidationException`.

## Type of change

- [ ] Bug fix (`fix:`)
- [ ] New feature (`feat:`)
- [ ] Breaking change (`feat!:` or `fix!:`)
- [X] Docs / chore

## AWS Compatibility

Documentation only. No behavior change; this discloses existing gaps between the local emulation and AWS behavior.

## Checklist

- [ ] `./mvnw test` passes locally
- [ ] New or updated integration test added
- [X] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)

<!-- First PR here? Your CI checks wait for a maintainer to approve them before they run — that's GitHub's gate on first-time contributors, not a problem with your PR. -->
<!-- Questions, or want feedback on an approach before going further? Join us on Slack: https://join.slack.com/t/floci/shared_invite/zt-3tjn02s3q-A00kEjJ1cZxsg_imTfy6Cw -->

