### PR TITLE
fix(codepipeline): poll S3 source changes

### DIFF
--- a/docs/services/codepipeline.md
+++ b/docs/services/codepipeline.md
@@ -25,6 +25,11 @@ Stages execute in declaration order. Actions with the same `runOrder` execute in
 A `QUEUED` or `PARALLEL` pipeline holds at most 50 active executions, as on AWS;
 `StartPipelineExecution` beyond that returns `ConcurrentPipelineExecutionsLimitExceededException`.
 
+S3 source actions poll for source changes by default, matching AWS when `PollForSourceChanges` is
+omitted or set to `true`. Floci establishes a baseline for the configured object and starts one new
+execution when its version ID or ETag changes, recording `PollForSourceChanges` as the execution
+trigger. Set `PollForSourceChanges` to `false` to disable this polling path.
+
 The following providers execute against local Floci services:
 
 | Category | Provider | Behavior |

--- a/src/main/java/io/github/hectorvent/floci/services/codepipeline/CodePipelineService.java
+++ b/src/main/java/io/github/hectorvent/floci/services/codepipeline/CodePipelineService.java
@@ -46,6 +46,7 @@ import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.RejectedExecutionException;
+import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
 
 @ApplicationScoped
@@ -55,6 +56,9 @@ public class CodePipelineService {
     private static final String DEFAULT_PIPELINE_TYPE = "V1";
     private static final int MAX_ACTIVE_EXECUTIONS = 50;
     private static final long POLL_INTERVAL_MS = 100L;
+    private static final long SOURCE_POLL_INTERVAL_MS = 500L;
+    private static final String SOURCE_POLL_TYPE = "source-poll";
+    private static final String MISSING_SOURCE_REVISION = "missing";
 
     private final AccountAwareStorageBackend<CodePipelinePipeline> pipelineStore;
     private final AccountAwareStorageBackend<CodePipelineExecution> executionStore;
@@ -65,6 +69,7 @@ public class CodePipelineService {
     private final LambdaService lambdaService;
     private final S3Service s3Service;
     private final ExecutorService executor = Executors.newVirtualThreadPerTaskExecutor();
+    private final ScheduledExecutorService sourcePoller = Executors.newSingleThreadScheduledExecutor();
     private final Map<String, Object> pipelineLocks = new ConcurrentHashMap<>();
     // Admission is serialized per pipeline on its own lock. A QUEUED worker holds the pipelineLocks
     // monitor for its whole run, so counting under that monitor would block StartPipelineExecution
@@ -162,6 +167,152 @@ public class CodePipelineService {
                         putExecution(execution);
                     });
         }
+        initializePersistedSourcePollingBaselines();
+        sourcePoller.scheduleWithFixedDelay(
+                this::pollS3SourcesSafely, SOURCE_POLL_INTERVAL_MS, SOURCE_POLL_INTERVAL_MS, TimeUnit.MILLISECONDS);
+    }
+
+    private void initializePersistedSourcePollingBaselines() {
+        for (CodePipelinePipeline pipeline : pipelineStore.scanAllAccounts()) {
+            ensureSourcePollingBaselines(pipeline);
+        }
+    }
+
+    private void resetSourcePollingBaselines(CodePipelinePipeline pipeline) {
+        deleteSourcePollingBaselines(pipeline.getAccountId(), pipeline.getRegion(), pipeline.getName());
+        ensureSourcePollingBaselines(pipeline);
+    }
+
+    private void ensureSourcePollingBaselines(CodePipelinePipeline pipeline) {
+        forEachPolledS3Source(pipeline, (stageName, action) -> {
+            String cursorId = sourcePollCursorId(pipeline.getName(), stageName, action.path("name").asText());
+            String key = itemKey(pipeline.getRegion(), SOURCE_POLL_TYPE, cursorId);
+            if (itemStore.getForAccount(pipeline.getAccountId(), key).isPresent()) {
+                return;
+            }
+            String revision = observeS3SourceRevision(action);
+            storeSourcePollCursor(pipeline, cursorId, revision);
+        });
+    }
+
+    private void deleteSourcePollingBaselines(String account, String region, String pipelineName) {
+        String prefix = itemKey(region, SOURCE_POLL_TYPE, pipelineName + "::");
+        for (String key : itemStore.keysForAccount(account)) {
+            if (key.startsWith(prefix)) {
+                itemStore.deleteForAccount(account, key);
+            }
+        }
+    }
+
+    private void pollS3SourcesSafely() {
+        try {
+            for (CodePipelinePipeline pipeline : pipelineStore.scanAllAccounts()) {
+                pollS3Sources(pipeline);
+            }
+        } catch (RuntimeException e) {
+            LOG.warn("CodePipeline S3 source polling cycle failed", e);
+        }
+    }
+
+    private void pollS3Sources(CodePipelinePipeline pipeline) {
+        forEachPolledS3Source(pipeline, (stageName, action) -> {
+            String actionName = action.path("name").asText();
+            String cursorId = sourcePollCursorId(pipeline.getName(), stageName, actionName);
+            String key = itemKey(pipeline.getRegion(), SOURCE_POLL_TYPE, cursorId);
+            Optional<CodePipelineStoredItem> existing = itemStore.getForAccount(pipeline.getAccountId(), key);
+            if (existing.isEmpty()) {
+                storeSourcePollCursor(pipeline, cursorId, observeS3SourceRevision(action));
+                return;
+            }
+
+            String previous = existing.get().getData().path("revision").asText(MISSING_SOURCE_REVISION);
+            String current;
+            try {
+                current = observeS3SourceRevision(action);
+            } catch (RuntimeException e) {
+                LOG.debugf(e, "Unable to poll CodePipeline S3 source %s/%s", pipeline.getName(), actionName);
+                return;
+            }
+            if (Objects.equals(previous, current)) {
+                return;
+            }
+
+            if (MISSING_SOURCE_REVISION.equals(current)) {
+                updateSourcePollCursor(existing.get(), current);
+                return;
+            }
+            JsonNode config = action.path("configuration");
+            String bucket = config.path("S3Bucket").asText(config.path("BucketName").asText(null));
+            String objectKey = config.path("S3ObjectKey").asText(config.path("ObjectKey").asText(null));
+            ObjectNode request = mapper.createObjectNode().put("name", pipeline.getName());
+            startPipelineExecution(request, pipeline.getRegion(), pipeline.getAccountId(),
+                    "PollForSourceChanges", "s3://" + bucket + "/" + objectKey);
+            updateSourcePollCursor(existing.get(), current);
+        });
+    }
+
+    private void forEachPolledS3Source(CodePipelinePipeline pipeline, S3SourceConsumer consumer) {
+        for (JsonNode stage : pipeline.getDeclaration().path("stages")) {
+            String stageName = stage.path("name").asText();
+            for (JsonNode action : stage.path("actions")) {
+                JsonNode type = action.path("actionTypeId");
+                if (!"Source".equals(type.path("category").asText())
+                        || !"AWS".equals(type.path("owner").asText())
+                        || !"S3".equals(type.path("provider").asText())) {
+                    continue;
+                }
+                JsonNode config = action.path("configuration");
+                String bucket = config.path("S3Bucket").asText(config.path("BucketName").asText(null));
+                String objectKey = config.path("S3ObjectKey").asText(config.path("ObjectKey").asText(null));
+                if (bucket == null || bucket.isBlank() || objectKey == null || objectKey.isBlank()) {
+                    continue;
+                }
+                if (!Boolean.parseBoolean(config.path("PollForSourceChanges").asText("true"))) {
+                    continue;
+                }
+                consumer.accept(stageName, action);
+            }
+        }
+    }
+
+    private String observeS3SourceRevision(JsonNode action) {
+        JsonNode config = action.path("configuration");
+        String bucket = config.path("S3Bucket").asText(config.path("BucketName").asText(null));
+        String key = config.path("S3ObjectKey").asText(config.path("ObjectKey").asText(null));
+        try {
+            S3Object object = s3Service.headObject(bucket, key);
+            return object.getVersionId() != null
+                    ? "version:" + object.getVersionId() : "etag:" + unquoteETag(object.getETag());
+        } catch (AwsException e) {
+            if ("NoSuchBucket".equals(e.getErrorCode()) || "NoSuchKey".equals(e.getErrorCode())) {
+                return MISSING_SOURCE_REVISION;
+            }
+            throw e;
+        }
+    }
+
+    private void storeSourcePollCursor(CodePipelinePipeline pipeline, String cursorId, String revision) {
+        ObjectNode data = mapper.createObjectNode().put("revision", revision);
+        storeItem(pipeline.getAccountId(), pipeline.getRegion(), SOURCE_POLL_TYPE, cursorId, "ACTIVE", data);
+    }
+
+    private void updateSourcePollCursor(CodePipelineStoredItem item, String revision) {
+        item.setData(mapper.createObjectNode().put("revision", revision));
+        item.setUpdated(now());
+        putItem(item);
+    }
+
+    private static String sourcePollCursorId(String pipelineName, String stageName, String actionName) {
+        return pipelineName + "::" + stageName + "::" + actionName;
+    }
+
+    private static String unquoteETag(String eTag) {
+        return eTag == null ? null : eTag.replace("\"", "");
+    }
+
+    @FunctionalInterface
+    private interface S3SourceConsumer {
+        void accept(String stageName, JsonNode action);
     }
 
     private ObjectNode createPipeline(JsonNode request, String region, String account) {
@@ -183,6 +334,7 @@ public class CodePipelineService {
         pipeline.setTags(parseTags(request.path("tags")));
         initializeTransitions(pipeline);
         putPipeline(pipeline);
+        resetSourcePollingBaselines(pipeline);
         ObjectNode response = mapper.createObjectNode();
         response.set("pipeline", pipeline.getDeclaration());
         if (!pipeline.getTags().isEmpty()) {
@@ -201,6 +353,7 @@ public class CodePipelineService {
         pipeline.setDeclaration(normalizeDeclaration(declaration, version));
         initializeTransitions(pipeline);
         putPipeline(pipeline);
+        resetSourcePollingBaselines(pipeline);
         ObjectNode response = mapper.createObjectNode();
         response.set("pipeline", pipeline.getDeclaration());
         return response;
@@ -231,6 +384,7 @@ public class CodePipelineService {
                 executionStore.deleteForAccount(account, key);
             }
         }
+        deleteSourcePollingBaselines(account, region, name);
         return mapper.createObjectNode();
     }
 
@@ -256,6 +410,11 @@ public class CodePipelineService {
     }
 
     private ObjectNode startPipelineExecution(JsonNode request, String region, String account) {
+        return startPipelineExecution(request, region, account, "StartPipelineExecution", "manual");
+    }
+
+    private ObjectNode startPipelineExecution(JsonNode request, String region, String account,
+                                              String triggerType, String triggerDetail) {
         CodePipelinePipeline pipeline = requirePipeline(account, region, text(request, "name"));
         String clientToken = request.path("clientRequestToken").asText(null);
         if (clientToken != null) {
@@ -282,8 +441,8 @@ public class CodePipelineService {
         execution.setSourceRevisions(objectList(request.path("sourceRevisions")));
         execution.setVariables(variableList(request.path("variables")));
         Map<String, String> trigger = new LinkedHashMap<>();
-        trigger.put("triggerType", "StartPipelineExecution");
-        trigger.put("triggerDetail", "manual");
+        trigger.put("triggerType", triggerType);
+        trigger.put("triggerDetail", triggerDetail);
         if (clientToken != null) {
             trigger.put("clientRequestToken", clientToken);
         }
@@ -1546,6 +1705,7 @@ public class CodePipelineService {
 
     @PreDestroy
     void shutdown() {
+        sourcePoller.shutdownNow();
         executor.shutdownNow();
         try {
             if (!executor.awaitTermination(5, TimeUnit.SECONDS)) {

--- a/src/test/java/io/github/hectorvent/floci/services/codepipeline/CodePipelineIntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/codepipeline/CodePipelineIntegrationTest.java
@@ -329,6 +329,222 @@ class CodePipelineIntegrationTest {
     }
 
     @Test
+    void s3SourcePollingStartsExactlyOneExecutionForARevisionChange() throws Exception {
+        createBucket("codepipeline-poll-source");
+        createBucket("codepipeline-poll-destination");
+        putObject("codepipeline-poll-source", "source.zip", "baseline artifact");
+
+        String pipelineName = "s3-source-polling-pipeline";
+        post("CreatePipeline", pipeline(pipelineName, """
+                {
+                    "name": "Source",
+                    "actions": [{
+                        "name": "SourceObject",
+                        "actionTypeId": {
+                            "category": "Source",
+                            "owner": "AWS",
+                            "provider": "S3",
+                            "version": "1"
+                        },
+                        "configuration": {
+                            "S3Bucket": "codepipeline-poll-source",
+                            "S3ObjectKey": "source.zip"
+                        },
+                        "outputArtifacts": [{"name": "SourceOutput"}]
+                    }]
+                },
+                {
+                    "name": "Deploy",
+                    "actions": [{
+                        "name": "DeployObject",
+                        "actionTypeId": {
+                            "category": "Deploy",
+                            "owner": "AWS",
+                            "provider": "S3",
+                            "version": "1"
+                        },
+                        "configuration": {
+                            "BucketName": "codepipeline-poll-destination",
+                            "ObjectKey": "deployed.zip"
+                        },
+                        "inputArtifacts": [{"name": "SourceOutput"}]
+                    }]
+                }
+                """))
+                .then().statusCode(200);
+
+        Thread.sleep(1200);
+        post("ListPipelineExecutions", """
+                {"pipelineName": "%s"}
+                """.formatted(pipelineName))
+                .then()
+                .statusCode(200)
+                .body("pipelineExecutionSummaries", hasSize(0));
+
+        putObject("codepipeline-poll-source", "source.zip", "changed artifact");
+
+        Response executions = waitForPipelineExecutionCount(pipelineName, 1);
+        String executionId = executions.jsonPath().getString("pipelineExecutionSummaries[0].pipelineExecutionId");
+        waitForExecution(pipelineName, executionId, "Succeeded");
+
+        post("GetPipelineExecution", """
+                {"pipelineName": "%s", "pipelineExecutionId": "%s"}
+                """.formatted(pipelineName, executionId))
+                .then()
+                .statusCode(200)
+                .body("pipelineExecution.trigger.triggerType", equalTo("PollForSourceChanges"))
+                .body("pipelineExecution.trigger.triggerDetail",
+                        equalTo("s3://codepipeline-poll-source/source.zip"));
+
+        given()
+                .get("/codepipeline-poll-destination/deployed.zip")
+        .then()
+                .statusCode(200)
+                .body(equalTo("changed artifact"));
+
+        Thread.sleep(1200);
+        post("ListPipelineExecutions", """
+                {"pipelineName": "%s"}
+                """.formatted(pipelineName))
+                .then()
+                .statusCode(200)
+                .body("pipelineExecutionSummaries", hasSize(1));
+
+        post("DeletePipeline", """
+                {"name": "%s"}
+                """.formatted(pipelineName)).then().statusCode(200);
+    }
+
+    @Test
+    void s3SourcePollingStartsWhenPreviouslyMissingObjectAppears() throws Exception {
+        createBucket("codepipeline-poll-missing-source");
+        createBucket("codepipeline-poll-missing-destination");
+
+        String pipelineName = "s3-source-polling-missing-object";
+        post("CreatePipeline", pipeline(pipelineName, """
+                {
+                    "name": "Source",
+                    "actions": [{
+                        "name": "SourceObject",
+                        "actionTypeId": {
+                            "category": "Source",
+                            "owner": "AWS",
+                            "provider": "S3",
+                            "version": "1"
+                        },
+                        "configuration": {
+                            "S3Bucket": "codepipeline-poll-missing-source",
+                            "S3ObjectKey": "source.zip"
+                        },
+                        "outputArtifacts": [{"name": "SourceOutput"}]
+                    }]
+                },
+                {
+                    "name": "Deploy",
+                    "actions": [{
+                        "name": "DeployObject",
+                        "actionTypeId": {
+                            "category": "Deploy",
+                            "owner": "AWS",
+                            "provider": "S3",
+                            "version": "1"
+                        },
+                        "configuration": {
+                            "BucketName": "codepipeline-poll-missing-destination",
+                            "ObjectKey": "deployed.zip"
+                        },
+                        "inputArtifacts": [{"name": "SourceOutput"}]
+                    }]
+                }
+                """))
+                .then().statusCode(200);
+
+        Thread.sleep(700);
+        post("ListPipelineExecutions", """
+                {"pipelineName": "%s"}
+                """.formatted(pipelineName))
+                .then()
+                .statusCode(200)
+                .body("pipelineExecutionSummaries", hasSize(0));
+
+        putObject("codepipeline-poll-missing-source", "source.zip", "first available artifact");
+
+        Response executions = waitForPipelineExecutionCount(pipelineName, 1);
+        String executionId = executions.jsonPath().getString("pipelineExecutionSummaries[0].pipelineExecutionId");
+        waitForExecution(pipelineName, executionId, "Succeeded");
+        post("GetPipelineExecution", """
+                {"pipelineName": "%s", "pipelineExecutionId": "%s"}
+                """.formatted(pipelineName, executionId))
+                .then()
+                .statusCode(200)
+                .body("pipelineExecution.trigger.triggerType", equalTo("PollForSourceChanges"));
+
+        post("DeletePipeline", """
+                {"name": "%s"}
+                """.formatted(pipelineName)).then().statusCode(200);
+    }
+
+    @Test
+    void s3SourcePollingDisabledDoesNotStartExecution() throws Exception {
+        createBucket("codepipeline-poll-disabled-source");
+        putObject("codepipeline-poll-disabled-source", "source.zip", "baseline artifact");
+
+        String pipelineName = "s3-source-polling-disabled";
+        post("CreatePipeline", pipeline(pipelineName, """
+                {
+                    "name": "Source",
+                    "actions": [{
+                        "name": "SourceObject",
+                        "actionTypeId": {
+                            "category": "Source",
+                            "owner": "AWS",
+                            "provider": "S3",
+                            "version": "1"
+                        },
+                        "configuration": {
+                            "S3Bucket": "codepipeline-poll-disabled-source",
+                            "S3ObjectKey": "source.zip",
+                            "PollForSourceChanges": "false"
+                        },
+                        "outputArtifacts": [{"name": "SourceOutput"}]
+                    }]
+                },
+                {
+                    "name": "Deploy",
+                    "actions": [{
+                        "name": "PlaceholderAction",
+                        "actionTypeId": {
+                            "category": "Deploy",
+                            "owner": "AWS",
+                            "provider": "S3",
+                            "version": "1"
+                        },
+                        "configuration": {
+                            "BucketName": "unused-codepipeline-destination",
+                            "ObjectKey": "deployed.zip"
+                        },
+                        "inputArtifacts": [{"name": "SourceOutput"}]
+                    }]
+                }
+                """))
+                .then().statusCode(200);
+
+        putObject("codepipeline-poll-disabled-source", "source.zip", "changed artifact");
+        Thread.sleep(1200);
+
+        post("ListPipelineExecutions", """
+                {"pipelineName": "%s"}
+                """.formatted(pipelineName))
+                .then()
+                .statusCode(200)
+                .body("pipelineExecutionSummaries", hasSize(0));
+
+        post("DeletePipeline", """
+                {"name": "%s"}
+                """.formatted(pipelineName)).then().statusCode(200);
+    }
+
+    @Test
     void listPipelineExecutionsValidatesFilterAndMaxResults() {
         String pipelineName = "list-executions-validation-pipeline";
         post("CreatePipeline", pipeline(pipelineName, """
@@ -1232,6 +1448,21 @@ class CodePipelineIntegrationTest {
             Thread.sleep(50);
         } while (Instant.now().isBefore(deadline));
         throw new AssertionError("Custom action job was not created");
+    }
+
+    private Response waitForPipelineExecutionCount(String pipelineName, int expectedCount) throws Exception {
+        Instant deadline = Instant.now().plus(Duration.ofSeconds(5));
+        Response response;
+        do {
+            response = post("ListPipelineExecutions", """
+                    {"pipelineName": "%s"}
+                    """.formatted(pipelineName));
+            if (response.jsonPath().getList("pipelineExecutionSummaries").size() == expectedCount) {
+                return response;
+            }
+            Thread.sleep(50);
+        } while (Instant.now().isBefore(deadline));
+        throw new AssertionError("Pipeline execution count did not reach " + expectedCount);
     }
 
     private void waitForExecution(String pipelineName, String executionId, String expected) throws Exception {


### PR DESCRIPTION
## Summary

Adds S3 source change detection for CodePipeline when `PollForSourceChanges` is enabled or omitted.

- `PollForSourceChanges` defaults to `true`, matching AWS.
- Existing source objects are baselined when a pipeline is created or updated, so Floci does not trigger a spurious execution immediately.
- Changes to the configured S3 object start a pipeline execution with trigger type `PollForSourceChanges`.
- Versioned sources track the S3 version ID; unversioned sources track the object ETag.
- Missing sources are tracked without starting an execution, and the first later upload triggers exactly one execution.
- `PollForSourceChanges=false` disables polling and does not emulate EventBridge notifications.
- Poll cursors are persisted per pipeline/stage/action and removed when the pipeline is deleted.

Closes #2223

## Type of change

- [x] Bug fix (`fix:`)
- [ ] New feature (`feat:`)
- [ ] Breaking change (`feat!:` or `fix!:`)
- [ ] Docs / chore

## AWS Compatibility

AWS documents the S3 source action's `PollForSourceChanges` setting as optional and enabled by default. When enabled, CodePipeline periodically checks the configured S3 object for changes. AWS also exposes S3 source revisions using the object version ID for versioned buckets or ETag for unversioned objects, and reports `PollForSourceChanges` as the execution trigger type for polling-started runs.

References:
- https://docs.aws.amazon.com/codepipeline/latest/userguide/action-reference-S3.html
- https://docs.aws.amazon.com/codepipeline/latest/userguide/detect-changes-cloudformation.html
- https://docs.aws.amazon.com/codepipeline/latest/APIReference/API_ExecutionTrigger.html

Validation after rebasing onto current `main`:

```text
./mvnw -q -Dtest=CodePipelineIntegrationTest test
make docs-check
git diff --check origin/main...HEAD
```

The integration coverage verifies the existing-object baseline, a single execution after an object change, no duplicate polling execution, first upload after a missing source, and `PollForSourceChanges=false` disabling automatic starts.

## Checklist

- [x] `./mvnw test` passes locally
- [x] New or updated integration test added
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
