### PR TITLE
fix(cloudformation): expose the RDS resource-id GetAtt attributes

### DIFF
--- a/src/main/java/io/github/hectorvent/floci/services/cloudformation/provisioners/RdsCfnProvisioner.java
+++ b/src/main/java/io/github/hectorvent/floci/services/cloudformation/provisioners/RdsCfnProvisioner.java
@@ -250,6 +250,9 @@ public class RdsCfnProvisioner implements CfnResourceProvisioner {
         if (instance.getDbInstanceArn() != null) {
             r.getAttributes().put("DBInstanceArn", instance.getDbInstanceArn());
         }
+        if (instance.getDbiResourceId() != null) {
+            r.getAttributes().put("DbiResourceId", instance.getDbiResourceId());
+        }
     }
 
     private void provisionDbCluster(StackResource r, JsonNode props, CloudFormationTemplateEngine engine,
@@ -321,6 +324,9 @@ public class RdsCfnProvisioner implements CfnResourceProvisioner {
         }
         if (cluster.getDbClusterArn() != null) {
             r.getAttributes().put("DBClusterArn", cluster.getDbClusterArn());
+        }
+        if (cluster.getDbClusterResourceId() != null) {
+            r.getAttributes().put("DBClusterResourceId", cluster.getDbClusterResourceId());
         }
     }
 

--- a/src/test/java/io/github/hectorvent/floci/services/cloudformation/RdsCfnProvisionerTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/cloudformation/RdsCfnProvisionerTest.java
@@ -122,6 +122,7 @@ class RdsCfnProvisionerTest {
         when(instance.getDbInstanceIdentifier()).thenReturn("mydb");
         when(instance.getEndpoint()).thenReturn(new DbEndpoint("mydb.local", 5432));
         when(instance.getDbInstanceArn()).thenReturn("arn:aws:rds:us-east-1:000000000000:db:mydb");
+        when(instance.getDbiResourceId()).thenReturn("db-ABCDEFGHIJKLMNOP");
         when(rdsService.createDbInstance(any(), any(), any(), any(), any(), any(), any(),
                 anyInt(), anyBoolean(), any(), any(), any(), any(), anyBoolean(), anyBoolean(),
                 any(), anyMap(), nullable(String.class))).thenReturn(instance);
@@ -137,6 +138,9 @@ class RdsCfnProvisionerTest {
         assertEquals("mydb.local", r.getAttributes().get("Endpoint.Address"));
         assertEquals("5432", r.getAttributes().get("Endpoint.Port"));
         assertEquals("arn:aws:rds:us-east-1:000000000000:db:mydb", r.getAttributes().get("DBInstanceArn"));
+        // The schema declares DbiResourceId readOnly and RdsService already assigns one, so it is
+        // a real GetAtt key rather than a recorded gap.
+        assertEquals("db-ABCDEFGHIJKLMNOP", r.getAttributes().get("DbiResourceId"));
         // CFN properties mapped to the create-method arguments; absent optionals are null.
         verify(rdsService).createDbInstance("mydb", "postgres", "16", "admin", "secret",
                 "appdb", "db.t3.small", 50, false, null, null, null,
@@ -168,6 +172,7 @@ class RdsCfnProvisionerTest {
         when(cluster.getEndpoint()).thenReturn(new DbEndpoint("mycluster.local", 5432));
         when(cluster.getReaderEndpoint()).thenReturn(new DbEndpoint("mycluster-ro.local", 5432));
         when(cluster.getDbClusterArn()).thenReturn("arn:aws:rds:us-east-1:000000000000:cluster:mycluster");
+        when(cluster.getDbClusterResourceId()).thenReturn("cluster-ABCDEFGHIJKLMNOP");
         when(rdsService.createDbCluster(any(), any(), any(), any(), any(), any(), anyBoolean(), any(),
                 any(), any(), anyBoolean(), any()))
                 .thenReturn(cluster);
@@ -181,6 +186,11 @@ class RdsCfnProvisionerTest {
         assertEquals("mycluster.local", r.getAttributes().get("Endpoint.Address"));
         assertEquals("mycluster-ro.local", r.getAttributes().get("ReadEndpoint.Address"));
         assertEquals("5432", r.getAttributes().get("Endpoint.Port"));
+        assertEquals("arn:aws:rds:us-east-1:000000000000:cluster:mycluster",
+                r.getAttributes().get("DBClusterArn"));
+        // Same as DbiResourceId on the instance: declared readOnly and already assigned by the
+        // service, so it belongs in the attributes rather than in the gaps file.
+        assertEquals("cluster-ABCDEFGHIJKLMNOP", r.getAttributes().get("DBClusterResourceId"));
         verify(rdsService).createDbCluster("mycluster", "aurora-postgresql", "16.3",
                 "admin", "secret", "appdb", false, null, null, null, false, "us-east-1");
     }

--- a/src/test/resources/cloudformation/getatt-attribute-gaps.tsv
+++ b/src/test/resources/cloudformation/getatt-attribute-gaps.tsv
@@ -26,7 +26,6 @@ AWS::Pipes::Pipe	CreationTime	pipe lifecycle timestamps are not tracked
 AWS::Pipes::Pipe	CurrentState	pipe state transitions are not modelled
 AWS::Pipes::Pipe	LastModifiedTime	pipe lifecycle timestamps are not tracked
 AWS::Pipes::Pipe	StateReason	pipe state transitions are not modelled
-AWS::RDS::DBCluster	DBClusterResourceId	not set by the legacy switch; closable, deferred to a follow-up PR to keep this one a pure move
 AWS::RDS::DBCluster	Endpoint	the dotted Endpoint.Address and Endpoint.Port are set instead, which is the form AWS's GetAtt actually exposes
 AWS::RDS::DBCluster	ReadEndpoint	ReadEndpoint.Address is set instead, the form AWS's GetAtt exposes
 AWS::RDS::DBCluster	StorageEncryptionType	cluster storage encryption is not emulated
@@ -34,7 +33,6 @@ AWS::RDS::DBCluster	StorageThroughput	provisioned storage throughput is not emul
 AWS::RDS::DBInstance	AutomaticRestartTime	instance restart scheduling is not emulated
 AWS::RDS::DBInstance	CertificateDetails	per-instance CA certificate metadata is not emulated
 AWS::RDS::DBInstance	DBInstanceStatus	the model carries no lifecycle status; instances reach available synchronously
-AWS::RDS::DBInstance	DbiResourceId	not set by the legacy switch; closable, deferred to a follow-up PR to keep this one a pure move
 AWS::RDS::DBInstance	InstanceCreateTime	creation timestamps are not recorded on the instance
 AWS::RDS::DBInstance	IsStorageConfigUpgradeAvailable	storage configuration upgrades are not emulated
 AWS::RDS::DBInstance	LatestRestorableTime	point-in-time restore windows are not emulated


### PR DESCRIPTION
## Summary

Follow-up to #3459, which moved the RDS types into `RdsCfnProvisioner` as a pure behaviour-preserving move and deliberately left these two attributes alone.

`AWS::RDS::DBCluster` declares `DBClusterResourceId` readOnly and `AWS::RDS::DBInstance` declares `DbiResourceId`, and `RdsService` already assigns both. Neither reached the stack resource, so `Fn::GetAtt` on either resolved to the literal `"LogicalId.DbiResourceId"` rather than the id. That is the silent failure mode `Fn::GetAtt` has when an attribute is never mapped: nothing errors, the template just gets a string that looks like a logical reference.

It was invisible until now because both types were `LEGACY_SWITCH`, and `CfnSchemaCoverageTest` skips those. Moving them to a provisioner is what surfaced it, which is why the two rows were recorded as gaps in #3459 and are removed here.

## Type of change

- [x] Bug fix (`fix:`)
- [ ] New feature (`feat:`)
- [ ] Breaking change (`feat!:` or `fix!:`)
- [ ] Docs / chore

## AWS Compatibility

Both attributes are declared in the registry schemas under `readOnlyProperties`, and both are already populated on the model by `RdsService`, so this maps existing values rather than inventing them. No wire shape changes: the only difference is that `Fn::GetAtt` now resolves to the resource id instead of to the literal `"LogicalId.Attr"` string.

## Tests

Two assertions added to the existing `RdsCfnProvisionerTest` cases, verified non-vacuous: with the six lines of production code reverted, both fail with `expected: <db-ABCDEFGHIJKLMNOP> but was: <null>`.

```
2110 tests, 0 failures
```
across the CloudFormation and RDS packages. `make docs-check` passes.

## Checklist

- [x] `./mvnw test` passes locally
- [ ] New or updated integration test added
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)

## Refs

Follow-up to #3459.
