### PR TITLE
chore(release): document the ordering invariant behind the baseline native/ wipe

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -223,6 +223,12 @@ jobs:
           cache-from: type=gha
           cache-to: type=gha,mode=max
 
+      # Ordering matters: this step wipes native/ and replaces it with the arm64-only
+      # baseline binary. It is safe only because it runs AFTER the multi-arch image
+      # above has been pushed, and nothing that follows reads native/ from the build
+      # context: the Cedar sidecar builds from sidecars/cedar/ only, and the compat
+      # image pulls its base (BASE_IMAGE) from the registry. Moving this step above
+      # the multi-arch push would silently publish `latest` from the baseline binary.
       - name: Stage ARMv8.0 baseline artifact under the native package path
         run: |
           rm -rf native/amd64 native/arm64


### PR DESCRIPTION

## Summary

Adds a comment above the `rm -rf native/amd64 native/arm64` step in the `push-native` job of `.github/workflows/release.yml` explaining why it is safe at its current position.

The step wipes `native/` and replaces it with the arm64-only ARMv8.0 baseline binary. That is only safe because:

- the multi-arch image (`floci/floci:latest`) is pushed **before** this step runs;
- the Cedar sidecar image builds from `sidecars/cedar/` only and never reads `native/`;
- the compat image pulls its base from the registry via `BASE_IMAGE`, not from the local build context.

None of this was written next to the `rm -rf`, so a future reorder of the job's steps could publish `latest` from the baseline binary with no error or warning. Follow-up requested by the reviewer of #3461.

Comment-only change, no behavioral difference.

Closes #3517

## Type of change

- [ ] Bug fix (`fix:`)
- [ ] New feature (`feat:`)
- [ ] Breaking change (`feat!:` or `fix!:`)
- [X] Docs / chore

## AWS Compatibility

N/A. CI / release tooling only, no AWS API involved.

## Checklist

- [X] `./mvnw test` passes locally
- [ ] New or updated integration test added
- [X] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)

<!-- First PR here? Your CI checks wait for a maintainer to approve them before they run — that's GitHub's gate on first-time contributors, not a problem with your PR. -->
<!-- Questions, or want feedback on an approach before going further? Join us on Slack: https://join.slack.com/t/floci/shared_invite/zt-3tjn02s3q-A00kEjJ1cZxsg_imTfy6Cw -->

