### PR TITLE
fix(kms): protect ciphertext blobs with an AES-GCM envelope

### DIFF
--- a/docs/services/kms.md
+++ b/docs/services/kms.md
@@ -55,7 +55,55 @@
 
 `Encrypt`, `Decrypt`, and `ReEncrypt` apply real RSAES-OAEP for RSA keys (`RSA_2048`, `RSA_3072`, `RSA_4096`) when `EncryptionAlgorithm` is `RSAES_OAEP_SHA_1` or `RSAES_OAEP_SHA_256`. The ciphertext is raw RSA output of the modulus length, for example exactly 256 bytes for `RSA_2048`. A ciphertext produced locally with the public key from `GetPublicKey` decrypts the same way it does on real AWS, which makes the usual envelope pattern work. Only the encrypting side needs the public key. As on real AWS, asymmetric `Decrypt` requires `KeyId`, an `EncryptionContext` is rejected for asymmetric keys, and plaintext larger than the OAEP capacity of the key fails validation.
 
-Symmetric keys keep the emulator's internal ciphertext format, which is not compatible with ciphertexts from real AWS KMS.
+Symmetric keys keep the emulator's internal ciphertext format, described below, which is not compatible with ciphertexts from real AWS KMS.
+
+## Symmetric Ciphertext Envelope
+
+`Encrypt`, `Decrypt`, `ReEncrypt` and `GenerateDataKey` protect `SYMMETRIC_DEFAULT` plaintext with
+real AES-256-GCM, using a per-key data-encryption key ("backing key") generated when the key is
+created and never exposed by any API. The blob is opaque bytes, base64-encoded in JSON exactly
+like real AWS KMS, but internally it is a versioned envelope:
+
+```
+offset      size  field
+0           4     magic "KMS3" (0x4B 0x4D 0x53 0x33)
+4           1     format version (currently 1)
+5           2     key id length (big-endian unsigned short)
+7           N     key id (UTF-8)
+7+N         2     backing key id length (big-endian unsigned short)
+9+N         M     backing key id (UTF-8)
+9+N+M       12    AES-GCM IV (random, generated per call)
+21+N+M      ...   AES-256-GCM ciphertext, followed by the 16-byte GCM tag
+```
+
+The key id lets `Decrypt` identify the key from the blob alone, matching AWS KMS, which does not
+require `KeyId` on `Decrypt` for symmetric keys. The GCM additional authenticated data (AAD) is
+every header byte up to and including the IV, plus the SHA-256 fingerprint of the canonicalized
+`EncryptionContext`. Binding the header into the AAD means decrypting with the wrong key, the
+wrong backing key version, or the wrong `EncryptionContext`, and any bit flip anywhere in the
+blob (header, IV, ciphertext or tag), all fail GCM tag verification the same way and surface as
+`InvalidCiphertextException`, never a plaintext.
+
+`RotateKeyOnDemand` mints a new backing key and switches future encryptions to it, but keeps prior
+backing keys in the key's state, so ciphertext encrypted before a rotation keeps decrypting after
+it, matching real AWS KMS, which also retains prior backing keys.
+
+### Legacy blob formats (read-only)
+
+Two older, unauthenticated formats are still accepted by `Decrypt` for backward compatibility with
+ciphertext produced by earlier versions of this emulator, but are never produced by `Encrypt`
+anymore:
+
+- `kms:v2:<keyId>:<nonceHex>:<contextFingerprintHex>:<base64(plaintext)>`
+- `kms:<keyId>:<base64(plaintext)>`
+
+Neither format used real key material: the payload was the plaintext itself, base64-encoded, so
+anyone holding a v1 or v2 blob could read the plaintext directly, and a tampered blob still
+"decrypted" to the original value. Any ciphertext already persisted in this shape (for example,
+stored in a database from before this fix) keeps decrypting so existing data is not orphaned, but
+new calls to `Encrypt` always produce the AES-GCM envelope described above. Keys created before
+backing keys existed generate their backing key material lazily the first time they are used for
+a cryptographic operation, and persist it from then on.
 
 ## Imported Key Material
 

--- a/docs/services/kms.md
+++ b/docs/services/kms.md
@@ -60,9 +60,10 @@ Symmetric keys keep the emulator's internal ciphertext format, described below, 
 ## Symmetric Ciphertext Envelope
 
 `Encrypt`, `Decrypt`, `ReEncrypt` and `GenerateDataKey` protect `SYMMETRIC_DEFAULT` plaintext with
-real AES-256-GCM, using a per-key data-encryption key ("backing key") generated when the key is
-created and never exposed by any API. The blob is opaque bytes, base64-encoded in JSON exactly
-like real AWS KMS, but internally it is a versioned envelope:
+real AES-256-GCM, using a per-key data-encryption key ("backing key") that is generated when the
+key is created, or is the material imported into an `Origin=EXTERNAL` key, and is never exposed by
+any API. The blob is opaque bytes, base64-encoded in JSON exactly like real AWS KMS, but
+internally it is a versioned envelope:
 
 ```
 offset      size  field
@@ -129,6 +130,11 @@ future and no more than 365 days out. Once `ValidTo` passes, the material is dro
 returns to `PendingImport`, as does `DeleteImportedKeyMaterial`. Expiry is evaluated when the key
 is next read rather than on a timer, which is not observable through the API. Deleting the
 material of a key that is already in `PendingDeletion` leaves that state in place.
+
+A `SYMMETRIC_DEFAULT` key with `Origin=EXTERNAL` encrypts under the imported material itself: it
+is the backing key named in the ciphertext envelope described above, and no other material is
+ever generated for the key. Deleting or expiring the material removes that backing key, so
+ciphertext produced under it decrypts again only once the same material has been re-imported.
 
 A key in `PendingImport` rejects cryptographic operations, `EnableKey` and `DisableKey` with
 `KMSInvalidStateException`. `CancelKeyDeletion` on a key whose material was never imported, or was

--- a/src/main/java/io/github/hectorvent/floci/services/kms/KmsService.java
+++ b/src/main/java/io/github/hectorvent/floci/services/kms/KmsService.java
@@ -102,6 +102,9 @@ public class KmsService implements ResourceProvider {
     private final StorageBackend<String, KmsGrant> grantStore;
     private final RegionResolver regionResolver;
     private final SecureRandom secureRandom;
+    // Guards the check-generate-put sequence in ensureBackingKeyMaterial so two concurrent
+    // first uses of the same legacy key cannot each mint a different backing key.
+    private final Object backingKeyMaterialLock = new Object();
 
     @Inject
     public KmsService(StorageFactory storageFactory, RegionResolver regionResolver) {
@@ -305,18 +308,42 @@ public class KmsService implements ResourceProvider {
      * load (existing {@code @JsonIgnoreProperties(ignoreUnknown = true)} already tolerates the
      * missing field). Material is generated lazily on first use and persisted immediately,
      * mirroring how {@link #expireImportedKeyMaterialIfDue} self-heals imported-key state.
+     *
+     * <p>Double-checked: the cheap unsynchronized check below lets an already-healed key (the
+     * overwhelming majority of calls, once a key has been used once) return without taking the
+     * lock. Only a key that still needs healing pays for entering the {@code synchronized}
+     * block, where the key is re-read from {@code keyStore} and re-checked before generating,
+     * so that if two callers race to heal the same legacy key concurrently, only one backing key
+     * is ever minted and every caller ends up with (and returns) the same persisted instance.
+     * Without this, two concurrent first uses could each generate a different backing key and
+     * each {@code put} their own copy, leaving one of the two backing keys, and any ciphertext
+     * encrypted under it, unreachable from the persisted key.
+     *
+     * @return the key instance to use for this call: either {@code key} unchanged, or the
+     *     re-read, healed instance that was just persisted.
      */
-    private void ensureBackingKeyMaterial(KmsKey key, String region) {
+    private KmsKey ensureBackingKeyMaterial(KmsKey key, String region) {
         if (KmsKeySpec.SYMMETRIC_DEFAULT != key.getKeySpec() || KmsKeyUsage.ENCRYPT_DECRYPT != key.getKeyUsage()) {
-            return;
+            return key;
         }
-        if (key.getCurrentBackingKeyId() != null && key.getBackingKeys() != null
-                && key.getBackingKeys().containsKey(key.getCurrentBackingKeyId())) {
-            return;
+        if (hasBackingKeyMaterial(key)) {
+            return key;
         }
-        generateBackingKey(key);
-        keyStore.put(region + "::" + key.getKeyId(), key);
-        LOG.infov("Generated backing key material for legacy KMS key: {0} in {1}", key.getKeyId(), region);
+        synchronized (backingKeyMaterialLock) {
+            KmsKey current = keyStore.get(region + "::" + key.getKeyId()).orElse(key);
+            if (hasBackingKeyMaterial(current)) {
+                return current;
+            }
+            generateBackingKey(current);
+            keyStore.put(region + "::" + current.getKeyId(), current);
+            LOG.infov("Generated backing key material for legacy KMS key: {0} in {1}", current.getKeyId(), region);
+            return current;
+        }
+    }
+
+    private static boolean hasBackingKeyMaterial(KmsKey key) {
+        return key.getCurrentBackingKeyId() != null && key.getBackingKeys() != null
+                && key.getBackingKeys().containsKey(key.getCurrentBackingKeyId());
     }
 
     public KmsKey getPublicKey(String keyId, String region) {
@@ -2230,7 +2257,7 @@ public class KmsService implements ResourceProvider {
         KmsKey key = keyStore.get(region + "::" + id)
                 .orElseThrow(() -> new AwsException("NotFoundException", "Key not found: " + keyIdOrArn, 404));
         key = expireImportedKeyMaterialIfDue(key, region);
-        ensureBackingKeyMaterial(key, region);
+        key = ensureBackingKeyMaterial(key, region);
         return key;
     }
 

--- a/src/main/java/io/github/hectorvent/floci/services/kms/KmsService.java
+++ b/src/main/java/io/github/hectorvent/floci/services/kms/KmsService.java
@@ -326,6 +326,12 @@ public class KmsService implements ResourceProvider {
         if (KmsKeySpec.SYMMETRIC_DEFAULT != key.getKeySpec() || KmsKeyUsage.ENCRYPT_DECRYPT != key.getKeyUsage()) {
             return key;
         }
+        // An EXTERNAL key is backed only by what its owner imports (see importKeyMaterial).
+        // Minting random material here would let it encrypt under a key that was never imported
+        // and would keep that key usable after the imported material is deleted or expires.
+        if (EXTERNAL_ORIGIN.equals(key.getOrigin())) {
+            return key;
+        }
         if (hasBackingKeyMaterial(key)) {
             return key;
         }
@@ -901,6 +907,9 @@ public class KmsService implements ResourceProvider {
         requireSameMaterialAsFirstImport(key, keyMaterialId);
 
         key.setPrivateKeyEncoded(Base64.getEncoder().encodeToString(material));
+        if (KmsKeySpec.SYMMETRIC_DEFAULT == key.getKeySpec()) {
+            installImportedBackingKey(key, keyMaterialId, material);
+        }
         key.setKeyMaterialId(keyMaterialId);
         key.setExpirationModel(effectiveExpirationModel);
         key.setValidTo(KEY_MATERIAL_EXPIRES.equals(effectiveExpirationModel) ? validTo : 0L);
@@ -912,6 +921,18 @@ public class KmsService implements ResourceProvider {
         LOG.infov("Imported key material into KMS key {0} in {1} ({2})",
                 key.getKeyId(), region, effectiveExpirationModel);
         return key;
+    }
+
+    /**
+     * Makes the imported material the backing key of the ciphertext envelope. Its id is the
+     * {@code keyMaterialId}, which is derived from the material itself, so re-importing the same
+     * material after a delete or expiry reinstates the id that earlier ciphertext names.
+     */
+    private static void installImportedBackingKey(KmsKey key, String keyMaterialId, byte[] material) {
+        Map<String, String> backingKeys = new HashMap<>();
+        backingKeys.put(keyMaterialId, Base64.getEncoder().encodeToString(material));
+        key.setBackingKeys(backingKeys);
+        key.setCurrentBackingKeyId(keyMaterialId);
     }
 
     /**
@@ -954,6 +975,8 @@ public class KmsService implements ResourceProvider {
      */
     private static void clearImportedKeyMaterial(KmsKey key) {
         key.setPrivateKeyEncoded(null);
+        key.setBackingKeys(new HashMap<>());
+        key.setCurrentBackingKeyId(null);
         key.setExpirationModel(null);
         key.setValidTo(0);
         key.setImportParameters(null);
@@ -1329,6 +1352,9 @@ public class KmsService implements ResourceProvider {
         if (isEnvelopeV3(ciphertext)) {
             EnvelopeV3 envelope = parseEnvelopeV3(ciphertext);
             KmsKey key = resolveEnvelopeKey(envelope.keyId(), region);
+            // A key whose imported material was deleted or expired no longer holds the backing
+            // key this blob names; answer with the key's state, as AWS does, not "invalid ciphertext".
+            requireImportedKeyMaterial(key, "Decrypt");
             byte[] plaintext = decryptEnvelopeV3(envelope, key, encryptionContext);
 
             if (requestKeyId != null && !requestKeyId.isBlank()) {

--- a/src/main/java/io/github/hectorvent/floci/services/kms/KmsService.java
+++ b/src/main/java/io/github/hectorvent/floci/services/kms/KmsService.java
@@ -58,6 +58,7 @@ import org.jboss.logging.Logger;
 
 import javax.crypto.Cipher;
 import javax.crypto.Mac;
+import javax.crypto.spec.GCMParameterSpec;
 import javax.crypto.spec.OAEPParameterSpec;
 import javax.crypto.spec.PSource;
 import javax.crypto.spec.SecretKeySpec;
@@ -228,7 +229,7 @@ public class KmsService implements ResourceProvider {
                     new SecureRandom().nextBytes(material);
                     key.setPrivateKeyEncoded(Base64.getEncoder().encodeToString(material));
                 }
-                case SYMMETRIC -> {/* // Use existing mock behavior for symmetric keys */}
+                case SYMMETRIC -> generateBackingKey(key);
                 case RSA -> {
                     KeyPairGenerator generator = KeyPairGenerator.getInstance("RSA");
                     int size = Integer.parseInt(spec.name().substring(4));
@@ -280,6 +281,42 @@ public class KmsService implements ResourceProvider {
         } catch (NoSuchAlgorithmException | InvalidAlgorithmParameterException e) {
             throw new AwsException("InternalFailure", "Failed to generate key material: " + e.getMessage(), 500);
         }
+    }
+
+    /**
+     * Mints a new AES-256 backing key for the AES-GCM ciphertext envelope and makes it the
+     * current one, keeping any earlier backing keys in the map so ciphertext produced under
+     * them keeps decrypting (AWS KMS never discards prior backing keys either).
+     */
+    private void generateBackingKey(KmsKey key) {
+        byte[] material = new byte[AES_KEY_BYTES];
+        SECURE_RANDOM.nextBytes(material);
+        String backingKeyId = UUID.randomUUID().toString();
+        if (key.getBackingKeys() == null) {
+            key.setBackingKeys(new HashMap<>());
+        }
+        key.getBackingKeys().put(backingKeyId, Base64.getEncoder().encodeToString(material));
+        key.setCurrentBackingKeyId(backingKeyId);
+    }
+
+    /**
+     * Self-healing for keys persisted before the AES-GCM envelope existed: their JSON has no
+     * {@code backingKeys}/{@code currentBackingKeyId}, so the field defaults to an empty map on
+     * load (existing {@code @JsonIgnoreProperties(ignoreUnknown = true)} already tolerates the
+     * missing field). Material is generated lazily on first use and persisted immediately,
+     * mirroring how {@link #expireImportedKeyMaterialIfDue} self-heals imported-key state.
+     */
+    private void ensureBackingKeyMaterial(KmsKey key, String region) {
+        if (KmsKeySpec.SYMMETRIC_DEFAULT != key.getKeySpec() || KmsKeyUsage.ENCRYPT_DECRYPT != key.getKeyUsage()) {
+            return;
+        }
+        if (key.getCurrentBackingKeyId() != null && key.getBackingKeys() != null
+                && key.getBackingKeys().containsKey(key.getCurrentBackingKeyId())) {
+            return;
+        }
+        generateBackingKey(key);
+        keyStore.put(region + "::" + key.getKeyId(), key);
+        LOG.infov("Generated backing key material for legacy KMS key: {0} in {1}", key.getKeyId(), region);
     }
 
     public KmsKey getPublicKey(String keyId, String region) {
@@ -760,6 +797,11 @@ public class KmsService implements ResourceProvider {
                     "On-demand rotation quota for KMS key " + key.getKeyId() + " is exceeded.", 400);
         }
         key.setOnDemandRotationCount(key.getOnDemandRotationCount() + 1);
+        // validateRotationSupported already restricts this to ENCRYPT_DECRYPT/SYMMETRIC_DEFAULT
+        // keys, i.e. exactly the keys that carry AES-GCM backing key material. AWS keeps prior
+        // backing keys after rotation so ciphertext encrypted under them keeps decrypting;
+        // generateBackingKey adds a new entry rather than replacing the map.
+        generateBackingKey(key);
         keyStore.put(region + "::" + key.getKeyId(), key);
         return key.getKeyId();
     }
@@ -1132,13 +1174,29 @@ public class KmsService implements ResourceProvider {
 
     // ──────────────────────────── Crypto Ops (Mocks) ────────────────────────────
 
-    // v2 blob: kms:v2:<keyId>:<nonceHex>:<contextFingerprintHex>:<base64(plaintext)>
-    // Nonce makes Encrypt non-deterministic; contextFingerprint binds EncryptionContext as AAD.
-    // Legacy v1 (kms:<keyId>:<base64>) still accepted on Decrypt for persistent-store back-compat.
+    // v3 envelope (current): magic "KMS3" + version byte + length-prefixed keyId +
+    // length-prefixed backingKeyId + 12-byte GCM IV + AES-256-GCM(ciphertext || 16-byte tag).
+    // AAD = every byte up to and including the IV, plus the EncryptionContext fingerprint, so
+    // decrypting with the wrong key, the wrong backing key version, or the wrong context, and
+    // any bit flip anywhere in the blob, all fail the GCM tag check the same way.
+    //
+    // v2 blob (legacy, decrypt-only): kms:v2:<keyId>:<nonceHex>:<contextFingerprintHex>:
+    // <base64(plaintext)>. This never provided real encryption: the "nonce" and context
+    // fingerprint were not bound to anything, so the payload was recoverable plaintext and any
+    // ciphertext with a syntactically valid shape "decrypted". Kept read-only so blobs persisted
+    // before this fix keep decrypting; Encrypt never produces this format again.
+    //
+    // v1 blob (legacy, decrypt-only): kms:<keyId>:<base64(plaintext)>. No nonce, no context
+    // binding at all. Decrypts only when the caller supplies an empty/null context.
+    private static final byte[] ENVELOPE_MAGIC_V3 = {0x4B, 0x4D, 0x53, 0x33}; // "KMS3"
+    private static final byte ENVELOPE_VERSION_V3 = 1;
+    private static final String AES_GCM_TRANSFORMATION = "AES/GCM/NoPadding";
+    private static final int GCM_IV_BYTES = 12;
+    private static final int GCM_TAG_BITS = 128;
+    private static final int AES_KEY_BYTES = 32;
     private static final String BLOB_PREFIX_V2 = "kms:v2:";
     private static final String BLOB_PREFIX_V1 = "kms:";
     private static final int SHA_512_DIGEST_BYTES = 64;
-    private static final int NONCE_BYTES = 8;
     private static final int MIN_MAC_MESSAGE_BYTES = 1;
     private static final int MAX_MAC_MESSAGE_BYTES = 4096;
     private static final int MIN_ENCRYPT_PLAINTEXT_BYTES = 1;
@@ -1176,16 +1234,8 @@ public class KmsService implements ResourceProvider {
             return new EncryptResult(ciphertext, kmsKey.getArn(), algorithm.getAlgName());
         }
 
-        byte[] nonceBytes = new byte[NONCE_BYTES];
-        SECURE_RANDOM.nextBytes(nonceBytes);
-        String nonceHex = HexFormat.of().formatHex(nonceBytes);
-
-        String blob = BLOB_PREFIX_V2
-                + kmsKey.getKeyId() + ":"
-                + nonceHex + ":"
-                + contextFingerprint(encryptionContext) + ":"
-                + Base64.getEncoder().encodeToString(plaintext);
-        return new EncryptResult(blob.getBytes(StandardCharsets.UTF_8), kmsKey.getArn(), algorithm.getAlgName());
+        byte[] envelope = encryptEnvelope(kmsKey, plaintext, encryptionContext);
+        return new EncryptResult(envelope, kmsKey.getArn(), algorithm.getAlgName());
     }
 
     public byte[] decrypt(byte[] ciphertext, String region) {
@@ -1193,6 +1243,11 @@ public class KmsService implements ResourceProvider {
     }
 
     public byte[] decrypt(byte[] ciphertext, Map<String, String> encryptionContext, String region) {
+        if (isEnvelopeV3(ciphertext)) {
+            EnvelopeV3 envelope = parseEnvelopeV3(ciphertext);
+            KmsKey key = resolveEnvelopeKey(envelope.keyId(), region);
+            return decryptEnvelopeV3(envelope, key, encryptionContext);
+        }
         ParsedBlob parsed = parseBlob(ciphertext);
         if (!parsed.contextFingerprint.equals(contextFingerprint(encryptionContext))) {
             throw new AwsException("InvalidCiphertextException", "The ciphertext is invalid.", 400);
@@ -1202,7 +1257,8 @@ public class KmsService implements ResourceProvider {
 
     public String decryptToKeyArn(byte[] ciphertext, String region) {
         try {
-            return resolveKey(parseBlob(ciphertext).keyId, region).getArn();
+            String keyId = isEnvelopeV3(ciphertext) ? parseEnvelopeV3(ciphertext).keyId() : parseBlob(ciphertext).keyId;
+            return resolveKey(keyId, region).getArn();
         } catch (AwsException e) {
             return null;
         }
@@ -1241,6 +1297,28 @@ public class KmsService implements ResourceProvider {
             rejectEncryptionContextForAsymmetricKey(encryptionContext);
             byte[] plaintext = rsaOaep(Cipher.DECRYPT_MODE, requestKey, algorithm, ciphertext);
             return new DecryptResult(plaintext, requestKey.getArn(), algorithm.getAlgName());
+        }
+
+        if (isEnvelopeV3(ciphertext)) {
+            EnvelopeV3 envelope = parseEnvelopeV3(ciphertext);
+            KmsKey key = resolveEnvelopeKey(envelope.keyId(), region);
+            byte[] plaintext = decryptEnvelopeV3(envelope, key, encryptionContext);
+
+            if (requestKeyId != null && !requestKeyId.isBlank()) {
+                KmsKey requestKey = resolveKey(requestKeyId, region);
+                if (!requestKey.getKeyId().equals(key.getKeyId())) {
+                    throw new AwsException(
+                            "IncorrectKeyException",
+                            "The request was rejected because the specified KMS key cannot decrypt the data.",
+                            400
+                    );
+                }
+                validateKeyIsUsableForCryptoOperations(requestKey);
+                return new DecryptResult(plaintext, requestKey.getArn(), algorithm.getAlgName());
+            }
+
+            validateKeyIsUsableForCryptoOperations(key);
+            return new DecryptResult(plaintext, key.getArn(), algorithm.getAlgName());
         }
 
         // With the defaulted SYMMETRIC_DEFAULT algorithm, real KMS parses the ciphertext
@@ -1287,6 +1365,135 @@ public class KmsService implements ResourceProvider {
     public record GenerateMacResult(byte[] mac, String keyArn) {}
 
     public record VerifyMacResult(String keyArn) {}
+
+    /**
+     * A parsed v3 envelope. {@code aadHeader} is every byte of the blob up to and including the
+     * IV (magic, version, keyId, backingKeyId, IV): the whole header is authenticated, not just
+     * checked for equality, so a tampered key id or backing key id fails the GCM tag check
+     * instead of silently decrypting under the wrong material.
+     */
+    private record EnvelopeV3(String keyId, String backingKeyId, byte[] aadHeader, byte[] iv, byte[] ciphertextAndTag) {}
+
+    private static boolean isEnvelopeV3(byte[] ciphertext) {
+        if (ciphertext == null || ciphertext.length < ENVELOPE_MAGIC_V3.length) {
+            return false;
+        }
+        for (int i = 0; i < ENVELOPE_MAGIC_V3.length; i++) {
+            if (ciphertext[i] != ENVELOPE_MAGIC_V3[i]) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    /** Any malformed header (bad length prefixes, truncation, unknown version) is a bad ciphertext, never a server fault. */
+    private static EnvelopeV3 parseEnvelopeV3(byte[] blob) {
+        try {
+            ByteBuffer buffer = ByteBuffer.wrap(blob);
+            byte[] magic = new byte[ENVELOPE_MAGIC_V3.length];
+            buffer.get(magic);
+            byte version = buffer.get();
+            if (version != ENVELOPE_VERSION_V3) {
+                throw new AwsException("InvalidCiphertextException", "The ciphertext is invalid.", 400);
+            }
+            byte[] keyIdBytes = new byte[buffer.getShort() & 0xFFFF];
+            buffer.get(keyIdBytes);
+            byte[] backingKeyIdBytes = new byte[buffer.getShort() & 0xFFFF];
+            buffer.get(backingKeyIdBytes);
+            int headerLength = buffer.position();
+            byte[] iv = new byte[GCM_IV_BYTES];
+            buffer.get(iv);
+            byte[] ciphertextAndTag = new byte[buffer.remaining()];
+            buffer.get(ciphertextAndTag);
+            if (ciphertextAndTag.length == 0) {
+                throw new AwsException("InvalidCiphertextException", "The ciphertext is invalid.", 400);
+            }
+            byte[] aadHeader = Arrays.copyOfRange(blob, 0, headerLength + GCM_IV_BYTES);
+            return new EnvelopeV3(new String(keyIdBytes, StandardCharsets.UTF_8),
+                    new String(backingKeyIdBytes, StandardCharsets.UTF_8), aadHeader, iv, ciphertextAndTag);
+        } catch (AwsException e) {
+            throw e;
+        } catch (RuntimeException e) {
+            throw new AwsException("InvalidCiphertextException", "The ciphertext is invalid.", 400);
+        }
+    }
+
+    private static byte[] buildEnvelopeHeaderAndIv(String keyId, String backingKeyId, byte[] iv) {
+        byte[] keyIdBytes = keyId.getBytes(StandardCharsets.UTF_8);
+        byte[] backingKeyIdBytes = backingKeyId.getBytes(StandardCharsets.UTF_8);
+        ByteBuffer buffer = ByteBuffer.allocate(ENVELOPE_MAGIC_V3.length + 1
+                + 2 + keyIdBytes.length + 2 + backingKeyIdBytes.length + iv.length);
+        buffer.put(ENVELOPE_MAGIC_V3);
+        buffer.put(ENVELOPE_VERSION_V3);
+        buffer.putShort((short) keyIdBytes.length);
+        buffer.put(keyIdBytes);
+        buffer.putShort((short) backingKeyIdBytes.length);
+        buffer.put(backingKeyIdBytes);
+        buffer.put(iv);
+        return buffer.array();
+    }
+
+    /**
+     * Builds a v3 envelope: AES-256-GCM under the key's current backing key, with the header
+     * (key id + backing key id + IV) and the EncryptionContext fingerprint as AAD.
+     */
+    private byte[] encryptEnvelope(KmsKey key, byte[] plaintext, Map<String, String> encryptionContext) {
+        String backingKeyId = key.getCurrentBackingKeyId();
+        byte[] dek = Base64.getDecoder().decode(key.getBackingKeys().get(backingKeyId));
+        byte[] iv = new byte[GCM_IV_BYTES];
+        SECURE_RANDOM.nextBytes(iv);
+        byte[] headerAndIv = buildEnvelopeHeaderAndIv(key.getKeyId(), backingKeyId, iv);
+        try {
+            Cipher cipher = Cipher.getInstance(AES_GCM_TRANSFORMATION);
+            cipher.init(Cipher.ENCRYPT_MODE, new SecretKeySpec(dek, "AES"), new GCMParameterSpec(GCM_TAG_BITS, iv));
+            cipher.updateAAD(headerAndIv);
+            cipher.updateAAD(contextFingerprint(encryptionContext).getBytes(StandardCharsets.UTF_8));
+            byte[] ciphertextAndTag = cipher.doFinal(plaintext);
+            byte[] blob = new byte[headerAndIv.length + ciphertextAndTag.length];
+            System.arraycopy(headerAndIv, 0, blob, 0, headerAndIv.length);
+            System.arraycopy(ciphertextAndTag, 0, blob, headerAndIv.length, ciphertextAndTag.length);
+            return blob;
+        } catch (GeneralSecurityException e) {
+            throw new AwsException("InternalFailure", "Failed to encrypt: " + e.getMessage(), 500);
+        }
+    }
+
+    /**
+     * Resolves the key named in a v3 envelope header. A lookup failure here can only mean the
+     * header was tampered with (this codebase never deletes keys from the store), so it is
+     * reported the same way as any other broken envelope: InvalidCiphertextException, never a
+     * NotFoundException that would tell an attacker their tampering hit a real key id or not.
+     */
+    private KmsKey resolveEnvelopeKey(String keyId, String region) {
+        try {
+            return resolveKey(keyId, region);
+        } catch (AwsException e) {
+            throw new AwsException("InvalidCiphertextException", "The ciphertext is invalid.", 400);
+        }
+    }
+
+    /**
+     * Decrypts a v3 envelope's ciphertext under the given key's backing key material. Does not
+     * check the key's enabled/pending-deletion state: callers decide whether and when to run
+     * {@link #validateKeyIsUsableForCryptoOperations}, matching the legacy behavior where
+     * {@link #decrypt} never checked key state but {@link #decryptAndResolveKey} always did.
+     */
+    private byte[] decryptEnvelopeV3(EnvelopeV3 envelope, KmsKey key, Map<String, String> encryptionContext) {
+        String materialB64 = key.getBackingKeys() == null ? null : key.getBackingKeys().get(envelope.backingKeyId());
+        if (materialB64 == null) {
+            throw new AwsException("InvalidCiphertextException", "The ciphertext is invalid.", 400);
+        }
+        byte[] dek = Base64.getDecoder().decode(materialB64);
+        try {
+            Cipher cipher = Cipher.getInstance(AES_GCM_TRANSFORMATION);
+            cipher.init(Cipher.DECRYPT_MODE, new SecretKeySpec(dek, "AES"), new GCMParameterSpec(GCM_TAG_BITS, envelope.iv()));
+            cipher.updateAAD(envelope.aadHeader());
+            cipher.updateAAD(contextFingerprint(encryptionContext).getBytes(StandardCharsets.UTF_8));
+            return cipher.doFinal(envelope.ciphertextAndTag());
+        } catch (GeneralSecurityException e) {
+            throw new AwsException("InvalidCiphertextException", "The ciphertext is invalid.", 400);
+        }
+    }
 
     private record ParsedBlob(String keyId, String nonce, String contextFingerprint, String payload) {}
 
@@ -2022,7 +2229,9 @@ public class KmsService implements ResourceProvider {
         // Key id
         KmsKey key = keyStore.get(region + "::" + id)
                 .orElseThrow(() -> new AwsException("NotFoundException", "Key not found: " + keyIdOrArn, 404));
-        return expireImportedKeyMaterialIfDue(key, region);
+        key = expireImportedKeyMaterialIfDue(key, region);
+        ensureBackingKeyMaterial(key, region);
+        return key;
     }
 
     private static void validateKeyIsUsableForCryptoOperations(KmsKey key) {

--- a/src/main/java/io/github/hectorvent/floci/services/kms/model/KmsKey.java
+++ b/src/main/java/io/github/hectorvent/floci/services/kms/model/KmsKey.java
@@ -30,6 +30,14 @@ public class KmsKey {
     private String privateKeyEncoded;
     private String publicKeyEncoded;
     private int onDemandRotationCount;
+    // Backing keys for the AES-GCM ciphertext envelope (symmetric CMKs only): backing key id
+    // -> Base64(32 random bytes). Rotation adds a new entry and switches currentBackingKeyId
+    // rather than replacing the map, so blobs encrypted under a prior backing key keep
+    // decrypting, matching AWS KMS's own behavior of retaining prior backing keys. Keys
+    // persisted before this field existed load with an empty map (Jackson leaves the default),
+    // and KmsService lazily generates material for them on first use.
+    private Map<String, String> backingKeys = new HashMap<>();
+    private String currentBackingKeyId;
 
     public KmsKey() {
         this.creationDate = Instant.now().getEpochSecond();
@@ -96,4 +104,10 @@ public class KmsKey {
 
     public int getOnDemandRotationCount() { return onDemandRotationCount; }
     public void setOnDemandRotationCount(int onDemandRotationCount) { this.onDemandRotationCount = onDemandRotationCount; }
+
+    public Map<String, String> getBackingKeys() { return backingKeys; }
+    public void setBackingKeys(Map<String, String> backingKeys) { this.backingKeys = backingKeys; }
+
+    public String getCurrentBackingKeyId() { return currentBackingKeyId; }
+    public void setCurrentBackingKeyId(String currentBackingKeyId) { this.currentBackingKeyId = currentBackingKeyId; }
 }

--- a/src/test/java/io/github/hectorvent/floci/services/kms/KmsServiceTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/kms/KmsServiceTest.java
@@ -32,12 +32,18 @@ import java.security.spec.PSSParameterSpec;
 import java.security.spec.X509EncodedKeySpec;
 import java.time.Duration;
 import java.time.Instant;
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Base64;
 import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
 
@@ -2747,6 +2753,51 @@ class KmsServiceTest {
             KmsKey healed = keyStore.get(REGION + "::" + key.getKeyId()).orElseThrow();
             assertNotNull(healed.getCurrentBackingKeyId());
             assertFalse(healed.getBackingKeys().isEmpty());
+        }
+
+        @Test
+        void concurrentFirstUsesOfALegacyKeyMintExactlyOneBackingKey() throws Exception {
+            KmsKey key = kmsService.createKey(null, REGION);
+            KmsKey stored = keyStore.get(REGION + "::" + key.getKeyId()).orElseThrow();
+            // Simulate a key persisted before this fix: no backing key material on disk.
+            stored.setBackingKeys(new HashMap<>());
+            stored.setCurrentBackingKeyId(null);
+            keyStore.put(REGION + "::" + key.getKeyId(), stored);
+
+            int threadCount = 12;
+            byte[] plaintext = "concurrent-legacy-plaintext".getBytes(StandardCharsets.UTF_8);
+            CountDownLatch startGate = new CountDownLatch(1);
+            List<Future<byte[]>> futures = new ArrayList<>();
+
+            try (ExecutorService executor = Executors.newFixedThreadPool(threadCount)) {
+                for (int i = 0; i < threadCount; i++) {
+                    futures.add(executor.submit(() -> {
+                        startGate.await();
+                        return kmsService.encrypt(key.getKeyId(), plaintext, REGION);
+                    }));
+                }
+                startGate.countDown();
+
+                List<byte[]> ciphertexts = new ArrayList<>();
+                for (Future<byte[]> future : futures) {
+                    ciphertexts.add(future.get(10, TimeUnit.SECONDS));
+                }
+
+                // Every thread must have healed onto the same backing key: exactly one backing key
+                // was minted for the whole race, never one per racing thread.
+                KmsKey healed = keyStore.get(REGION + "::" + key.getKeyId()).orElseThrow();
+                assertNotNull(healed.getCurrentBackingKeyId());
+                assertEquals(1, healed.getBackingKeys().size(),
+                        "concurrent first uses of a legacy key must mint exactly one backing key");
+                assertTrue(healed.getBackingKeys().containsKey(healed.getCurrentBackingKeyId()));
+
+                // Every ciphertext produced under the race, regardless of which thread produced it,
+                // must still decrypt: none of them can have been encrypted under a backing key that
+                // a losing keyStore.put then discarded.
+                for (byte[] ciphertext : ciphertexts) {
+                    assertArrayEquals(plaintext, kmsService.decrypt(ciphertext, REGION));
+                }
+            }
         }
 
         private static int indexOf(byte[] haystack, byte[] needle) {

--- a/src/test/java/io/github/hectorvent/floci/services/kms/KmsServiceTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/kms/KmsServiceTest.java
@@ -18,6 +18,7 @@ import org.junit.jupiter.api.Test;
 
 import javax.crypto.Cipher;
 import javax.crypto.Mac;
+import javax.crypto.spec.GCMParameterSpec;
 import javax.crypto.spec.OAEPParameterSpec;
 import javax.crypto.spec.PSource;
 import javax.crypto.spec.SecretKeySpec;
@@ -2628,6 +2629,66 @@ class KmsServiceTest {
             AwsException ex = assertThrows(AwsException.class, () ->
                     kmsService.getParametersForImport(keyId, "RSA_AES_KEY_WRAP_SHA_256", "RSA_2048", REGION));
             assertEquals("UnsupportedOperationException", ex.getErrorCode());
+        }
+
+        @Test
+        void aSymmetricKeyEncryptsWithTheMaterialThatWasImported() throws Exception {
+            KmsKey key = externalSymmetricKey();
+            byte[] rawMaterial = material(32, (byte) 42);
+            byte[] plaintext = "bring-your-own-key".getBytes(StandardCharsets.UTF_8);
+            importInto(key, rawMaterial, OAEP_SHA_256);
+
+            byte[] envelope = kmsService.encrypt(key.getKeyId(), plaintext, REGION);
+
+            // Open the documented KMS3 envelope with nothing but the imported material: the header
+            // up to and including the 12-byte IV is the AAD (an empty EncryptionContext adds none)
+            // and the 16-byte GCM tag trails the ciphertext.
+            int ivEnd = envelope.length - plaintext.length - 16;
+            byte[] headerAndIv = Arrays.copyOfRange(envelope, 0, ivEnd);
+            byte[] iv = Arrays.copyOfRange(envelope, ivEnd - 12, ivEnd);
+            Cipher aesGcm = Cipher.getInstance("AES/GCM/NoPadding");
+            aesGcm.init(Cipher.DECRYPT_MODE, new SecretKeySpec(rawMaterial, "AES"), new GCMParameterSpec(128, iv));
+            aesGcm.updateAAD(headerAndIv);
+            assertArrayEquals(plaintext, aesGcm.doFinal(Arrays.copyOfRange(envelope, ivEnd, envelope.length)));
+        }
+
+        @Test
+        void deletingImportedMaterialLeavesNothingThatCanOpenItsCiphertext() throws Exception {
+            KmsKey key = externalSymmetricKey();
+            importInto(key, material(32, (byte) 42), OAEP_SHA_256);
+            byte[] ciphertext = kmsService.encrypt(key.getKeyId(), "bring-your-own-key".getBytes(StandardCharsets.UTF_8), REGION);
+
+            kmsService.deleteImportedKeyMaterial(key.getKeyId(), REGION);
+
+            AwsException ex = assertThrows(AwsException.class, () -> kmsService.decrypt(ciphertext, REGION));
+            assertEquals("InvalidCiphertextException", ex.getErrorCode());
+        }
+
+        @Test
+        void decryptingUnderAKeyWhoseMaterialWasDeletedReportsPendingImport() throws Exception {
+            KmsKey key = externalSymmetricKey();
+            importInto(key, material(32, (byte) 42), OAEP_SHA_256);
+            byte[] ciphertext = kmsService.encrypt(key.getKeyId(), "bring-your-own-key".getBytes(StandardCharsets.UTF_8), REGION);
+
+            kmsService.deleteImportedKeyMaterial(key.getKeyId(), REGION);
+
+            AwsException ex = assertThrows(AwsException.class, () ->
+                    kmsService.decryptAndResolveKey(ciphertext, Map.of(), REGION, null));
+            assertEquals("KMSInvalidStateException", ex.getErrorCode());
+        }
+
+        @Test
+        void reimportingTheSameMaterialOpensCiphertextMadeBeforeTheDeletion() throws Exception {
+            KmsKey key = externalSymmetricKey();
+            byte[] rawMaterial = material(32, (byte) 42);
+            byte[] plaintext = "bring-your-own-key".getBytes(StandardCharsets.UTF_8);
+            importInto(key, rawMaterial, OAEP_SHA_256);
+            byte[] ciphertext = kmsService.encrypt(key.getKeyId(), plaintext, REGION);
+            kmsService.deleteImportedKeyMaterial(key.getKeyId(), REGION);
+
+            importInto(key, rawMaterial, OAEP_SHA_256);
+
+            assertArrayEquals(plaintext, kmsService.decrypt(ciphertext, REGION));
         }
     }
 

--- a/src/test/java/io/github/hectorvent/floci/services/kms/KmsServiceTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/kms/KmsServiceTest.java
@@ -34,6 +34,7 @@ import java.time.Duration;
 import java.time.Instant;
 import java.util.Arrays;
 import java.util.Base64;
+import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
@@ -2621,6 +2622,144 @@ class KmsServiceTest {
             AwsException ex = assertThrows(AwsException.class, () ->
                     kmsService.getParametersForImport(keyId, "RSA_AES_KEY_WRAP_SHA_256", "RSA_2048", REGION));
             assertEquals("UnsupportedOperationException", ex.getErrorCode());
+        }
+    }
+
+    /**
+     * The v2 blob ("kms:v2:&lt;keyId&gt;:&lt;nonce&gt;:&lt;contextFingerprint&gt;:&lt;base64(plaintext)&gt;")
+     * carried no real encryption: the payload was plain base64 with no key material involved, so
+     * anyone holding a CiphertextBlob could read the plaintext and a tampered blob still "decrypted".
+     * These tests pin the AES-GCM envelope that replaces it: real per-CMK key material, AEAD binding
+     * of key id / backing key id / EncryptionContext, and rejection of any tampering.
+     */
+    @Nested
+    class EnvelopeEncryptionTests {
+
+        @Test
+        void encryptDoesNotProduceLegacyBase64Blob() {
+            KmsKey key = kmsService.createKey(null, REGION);
+            byte[] plaintext = "super-secret-value".getBytes(StandardCharsets.UTF_8);
+
+            byte[] ciphertext = kmsService.encrypt(key.getKeyId(), plaintext, REGION);
+
+            String asText = new String(ciphertext, StandardCharsets.UTF_8);
+            assertFalse(asText.startsWith("kms:"),
+                    "encrypt must not produce the legacy plaintext-revealing blob format");
+            byte[] plaintextBase64 = Base64.getEncoder().encodeToString(plaintext).getBytes(StandardCharsets.UTF_8);
+            assertEquals(-1, indexOf(ciphertext, plaintextBase64),
+                    "ciphertext must not contain the base64 plaintext as a substring");
+        }
+
+        @Test
+        void decryptRoundTripsTheNewEnvelope() {
+            KmsKey key = kmsService.createKey(null, REGION);
+            byte[] plaintext = "hello envelope".getBytes(StandardCharsets.UTF_8);
+
+            byte[] ciphertext = kmsService.encrypt(key.getKeyId(), plaintext, Map.of("tenant", "1"), REGION);
+
+            assertArrayEquals(plaintext, kmsService.decrypt(ciphertext, Map.of("tenant", "1"), REGION));
+        }
+
+        @Test
+        void decryptWithFlippedTagByteThrowsInvalidCiphertext() {
+            KmsKey key = kmsService.createKey(null, REGION);
+            byte[] ciphertext = kmsService.encrypt(key.getKeyId(), "hello world".getBytes(StandardCharsets.UTF_8), REGION);
+
+            byte[] tampered = ciphertext.clone();
+            tampered[tampered.length - 1] ^= 0x01;
+
+            AwsException ex = assertThrows(AwsException.class, () -> kmsService.decrypt(tampered, REGION));
+            assertEquals("InvalidCiphertextException", ex.getErrorCode());
+        }
+
+        @Test
+        void decryptWithFlippedIvByteThrowsInvalidCiphertext() {
+            KmsKey key = kmsService.createKey(null, REGION);
+            byte[] plaintext = "hello world".getBytes(StandardCharsets.UTF_8);
+            byte[] ciphertext = kmsService.encrypt(key.getKeyId(), plaintext, REGION);
+
+            int gcmTagBytes = 16;
+            int gcmIvBytes = 12;
+            int ivStart = ciphertext.length - gcmIvBytes - (plaintext.length + gcmTagBytes);
+            byte[] tampered = ciphertext.clone();
+            tampered[ivStart] ^= 0x01;
+
+            AwsException ex = assertThrows(AwsException.class, () -> kmsService.decrypt(tampered, REGION));
+            assertEquals("InvalidCiphertextException", ex.getErrorCode());
+        }
+
+        @Test
+        void decryptWithCorruptedKeyIdInHeaderThrowsInvalidCiphertextNeverAPlaintext() {
+            KmsKey key = kmsService.createKey(null, REGION);
+            byte[] plaintext = "hello world".getBytes(StandardCharsets.UTF_8);
+            byte[] ciphertext = kmsService.encrypt(key.getKeyId(), plaintext, REGION);
+
+            // magic(4) + version(1) + keyId length prefix(2) = keyId bytes start at index 7.
+            int keyIdStart = 7;
+            byte[] tampered = ciphertext.clone();
+            tampered[keyIdStart] ^= 0x01;
+
+            AwsException ex = assertThrows(AwsException.class, () -> kmsService.decrypt(tampered, REGION));
+            assertEquals("InvalidCiphertextException", ex.getErrorCode());
+        }
+
+        @Test
+        void decryptOfTruncatedEnvelopeThrowsInvalidCiphertext() {
+            KmsKey key = kmsService.createKey(null, REGION);
+            byte[] ciphertext = kmsService.encrypt(key.getKeyId(), "hello world".getBytes(StandardCharsets.UTF_8), REGION);
+
+            byte[] truncated = Arrays.copyOf(ciphertext, ciphertext.length - 20);
+
+            AwsException ex = assertThrows(AwsException.class, () -> kmsService.decrypt(truncated, REGION));
+            assertEquals("InvalidCiphertextException", ex.getErrorCode());
+        }
+
+        @Test
+        void rotateKeyOnDemandKeepsOldCiphertextDecryptableAndMintsANewBackingKey() {
+            KmsKey key = kmsService.createKey(null, REGION);
+            byte[] plaintext = "before-rotation".getBytes(StandardCharsets.UTF_8);
+            byte[] beforeRotation = kmsService.encrypt(key.getKeyId(), plaintext, REGION);
+
+            kmsService.rotateKeyOnDemand(key.getKeyId(), REGION);
+            byte[] afterRotation = kmsService.encrypt(key.getKeyId(), plaintext, REGION);
+
+            assertArrayEquals(plaintext, kmsService.decrypt(beforeRotation, REGION));
+            assertArrayEquals(plaintext, kmsService.decrypt(afterRotation, REGION));
+            assertFalse(Arrays.equals(beforeRotation, afterRotation));
+
+            KmsKey stored = keyStore.get(REGION + "::" + key.getKeyId()).orElseThrow();
+            assertEquals(2, stored.getBackingKeys().size());
+        }
+
+        @Test
+        void legacyKeyWithoutBackingMaterialLazilyGeneratesItOnUse() {
+            KmsKey key = kmsService.createKey(null, REGION);
+            KmsKey stored = keyStore.get(REGION + "::" + key.getKeyId()).orElseThrow();
+            // Simulate a key persisted before this fix: no backing key material on disk.
+            stored.setBackingKeys(new HashMap<>());
+            stored.setCurrentBackingKeyId(null);
+            keyStore.put(REGION + "::" + key.getKeyId(), stored);
+
+            byte[] plaintext = "legacy-key-plaintext".getBytes(StandardCharsets.UTF_8);
+            byte[] ciphertext = kmsService.encrypt(key.getKeyId(), plaintext, REGION);
+            assertArrayEquals(plaintext, kmsService.decrypt(ciphertext, REGION));
+
+            KmsKey healed = keyStore.get(REGION + "::" + key.getKeyId()).orElseThrow();
+            assertNotNull(healed.getCurrentBackingKeyId());
+            assertFalse(healed.getBackingKeys().isEmpty());
+        }
+
+        private static int indexOf(byte[] haystack, byte[] needle) {
+            outer:
+            for (int i = 0; i <= haystack.length - needle.length; i++) {
+                for (int j = 0; j < needle.length; j++) {
+                    if (haystack[i + j] != needle[j]) {
+                        continue outer;
+                    }
+                }
+                return i;
+            }
+            return -1;
         }
     }
 }


### PR DESCRIPTION
## Summary


A symmetric `Encrypt` produced base64 of the plaintext with a cosmetic nonce and a context fingerprint. Anyone holding a `CiphertextBlob` could read the plaintext, and a blob with flipped bits still "decrypted" to the same value, so application code that relied on KMS to detect tampering or a wrong `EncryptionContext` was never exercised.

Ciphertext is now a versioned AES-256-GCM envelope under real per-CMK key material, with the key id, the backing key id and the canonicalized encryption context bound as additional authenticated data. Decrypting with the wrong key, the wrong context, or any modified byte fails with `InvalidCiphertextException`.

Decisions a reviewer should weigh:

- `RotateKeyOnDemand` mints a new backing key and keeps the old ones, so ciphertext from before a rotation still decrypts.
- Legacy blobs already on disk keep decrypting read-only; `Encrypt` never produces the old format again.
- Keys persisted before this change generate their backing key lazily on first use. The second commit puts that step under a lock after a review found that two concurrent first uses could each mint a different backing key and strand the loser's ciphertext.
- RSA keys keep their existing RSAES-OAEP path untouched.

Validation: `KmsServiceTest` covers the envelope format, tamper detection, context mismatch, rotation, legacy decryption and a twelve-thread concurrent first use converging on one backing key. A whole-repo `test-compile` passes. The full suite was not run locally and is left to CI.

## Type of change

- [x] Bug fix (`fix:`)
- [ ] New feature (`feat:`)
- [ ] Breaking change (`feat!:` or `fix!:`)
- [ ] Docs / chore

## AWS Compatibility

Incorrect behaviour: ciphertext leaked its plaintext and accepted tampering and a mismatched `EncryptionContext`. AWS KMS returns `InvalidCiphertextException` in those cases and keeps decrypting older ciphertext after rotation; both now hold in Floci.

## Checklist

- [ ] `./mvnw test` passes locally (focused classes only; full suite in CI)
- [ ] New or updated integration test added (service-level unit tests added instead)
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
