### PR TITLE
feat(redshift): implement snapshot copy grant lifecycle

### DIFF
--- a/compatibility-tests/sdk-test-java/src/test/java/com/floci/test/RedshiftOperationsTest.java
+++ b/compatibility-tests/sdk-test-java/src/test/java/com/floci/test/RedshiftOperationsTest.java
@@ -17,11 +17,14 @@ import software.amazon.awssdk.services.redshift.model.CreateClusterResponse;
 import software.amazon.awssdk.services.redshift.model.CreateClusterSnapshotRequest;
 import software.amazon.awssdk.services.redshift.model.CreateClusterSnapshotResponse;
 import software.amazon.awssdk.services.redshift.model.CreateClusterSubnetGroupRequest;
+import software.amazon.awssdk.services.redshift.model.CreateSnapshotCopyGrantRequest;
+import software.amazon.awssdk.services.redshift.model.CreateSnapshotCopyGrantResponse;
 import software.amazon.awssdk.services.redshift.model.CreateTagsRequest;
 import software.amazon.awssdk.services.redshift.model.DeleteClusterParameterGroupRequest;
 import software.amazon.awssdk.services.redshift.model.DeleteClusterRequest;
 import software.amazon.awssdk.services.redshift.model.DeleteClusterSnapshotRequest;
 import software.amazon.awssdk.services.redshift.model.DeleteClusterSubnetGroupRequest;
+import software.amazon.awssdk.services.redshift.model.DeleteSnapshotCopyGrantRequest;
 import software.amazon.awssdk.services.redshift.model.DeleteTagsRequest;
 import software.amazon.awssdk.services.redshift.model.DescribeClusterParameterGroupsRequest;
 import software.amazon.awssdk.services.redshift.model.DescribeClusterParameterGroupsResponse;
@@ -30,12 +33,17 @@ import software.amazon.awssdk.services.redshift.model.DescribeClusterSnapshotsRe
 import software.amazon.awssdk.services.redshift.model.DescribeClusterSubnetGroupsRequest;
 import software.amazon.awssdk.services.redshift.model.DescribeClustersRequest;
 import software.amazon.awssdk.services.redshift.model.DescribeClustersResponse;
+import software.amazon.awssdk.services.redshift.model.DescribeSnapshotCopyGrantsRequest;
+import software.amazon.awssdk.services.redshift.model.DescribeSnapshotCopyGrantsResponse;
 import software.amazon.awssdk.services.redshift.model.DescribeTagsRequest;
 import software.amazon.awssdk.services.redshift.model.ModifyClusterRequest;
 import software.amazon.awssdk.services.redshift.model.RebootClusterRequest;
 import software.amazon.awssdk.services.redshift.model.RestoreFromClusterSnapshotRequest;
 import software.amazon.awssdk.services.redshift.model.RestoreFromClusterSnapshotResponse;
 import software.amazon.awssdk.services.redshift.model.Snapshot;
+import software.amazon.awssdk.services.redshift.model.SnapshotCopyGrant;
+import software.amazon.awssdk.services.redshift.model.SnapshotCopyGrantAlreadyExistsException;
+import software.amazon.awssdk.services.redshift.model.SnapshotCopyGrantNotFoundException;
 import software.amazon.awssdk.services.redshift.model.Tag;
 
 import java.sql.Connection;
@@ -52,6 +60,7 @@ import java.util.logging.Level;
 import java.util.logging.Logger;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 @DisplayName("Redshift Operations")
 @TestMethodOrder(MethodOrderer.OrderAnnotation.class)
@@ -68,6 +77,7 @@ class RedshiftOperationsTest {
     private static final List<String> snapshotsToCleanup = new ArrayList<>();
     private static final List<String> parameterGroupsToCleanup = new ArrayList<>();
     private static final List<String> subnetGroupsToCleanup = new ArrayList<>();
+    private static final List<String> snapshotCopyGrantsToCleanup = new ArrayList<>();
 
     @BeforeAll
     static void setup() {
@@ -111,6 +121,15 @@ class RedshiftOperationsTest {
                             .build());
                 } catch (Exception e) {
                     LOG.log(Level.WARNING, "Failed to clean up Redshift cluster subnet group " + subnetGroupName, e);
+                }
+            }
+            for (String grantName : snapshotCopyGrantsToCleanup) {
+                try {
+                    client.deleteSnapshotCopyGrant(DeleteSnapshotCopyGrantRequest.builder()
+                            .snapshotCopyGrantName(grantName)
+                            .build());
+                } catch (Exception e) {
+                    LOG.log(Level.WARNING, "Failed to clean up Redshift snapshot copy grant " + grantName, e);
                 }
             }
             client.close();
@@ -313,6 +332,72 @@ class RedshiftOperationsTest {
                 .clusterIdentifier(clusterId)
                 .build());
         assertThat(rebooted.cluster().clusterStatus()).isEqualTo("available");
+    }
+
+    @Test
+    @Order(4)
+    void testSnapshotCopyGrantLifecycle() {
+        String grantName = TestFixtures.uniqueName("rs-copy-grant");
+        String otherGrantName = TestFixtures.uniqueName("rs-copy-grant-other");
+
+        CreateSnapshotCopyGrantResponse created = client.createSnapshotCopyGrant(
+                CreateSnapshotCopyGrantRequest.builder()
+                        .snapshotCopyGrantName(grantName)
+                        .kmsKeyId("key-abc")
+                        .tags(Tag.builder().key("env").value("test").build())
+                        .build());
+        snapshotCopyGrantsToCleanup.add(grantName);
+
+        assertThat(created.snapshotCopyGrant().snapshotCopyGrantName()).isEqualTo(grantName);
+        assertThat(created.snapshotCopyGrant().kmsKeyId()).isEqualTo("key-abc");
+        assertThat(created.snapshotCopyGrant().tags())
+                .anyMatch(t -> "env".equals(t.key()) && "test".equals(t.value()));
+
+        // KmsKeyId is optional: AWS substitutes the account's default Redshift key.
+        CreateSnapshotCopyGrantResponse withDefaultKey = client.createSnapshotCopyGrant(
+                CreateSnapshotCopyGrantRequest.builder()
+                        .snapshotCopyGrantName(otherGrantName)
+                        .build());
+        snapshotCopyGrantsToCleanup.add(otherGrantName);
+        assertThat(withDefaultKey.snapshotCopyGrant().kmsKeyId()).isNotBlank();
+
+        assertThatThrownBy(() -> client.createSnapshotCopyGrant(CreateSnapshotCopyGrantRequest.builder()
+                .snapshotCopyGrantName(grantName)
+                .build()))
+                .isInstanceOf(SnapshotCopyGrantAlreadyExistsException.class);
+
+        // Filtered describe returns only the named grant, with its fields intact through
+        // the real unmarshaller.
+        DescribeSnapshotCopyGrantsResponse filtered = client.describeSnapshotCopyGrants(
+                DescribeSnapshotCopyGrantsRequest.builder()
+                        .snapshotCopyGrantName(grantName)
+                        .build());
+        assertThat(filtered.snapshotCopyGrants()).hasSize(1);
+        SnapshotCopyGrant found = filtered.snapshotCopyGrants().get(0);
+        assertThat(found.snapshotCopyGrantName()).isEqualTo(grantName);
+        assertThat(found.kmsKeyId()).isEqualTo("key-abc");
+        assertThat(found.tags()).anyMatch(t -> "env".equals(t.key()) && "test".equals(t.value()));
+
+        DescribeSnapshotCopyGrantsResponse all = client.describeSnapshotCopyGrants(
+                DescribeSnapshotCopyGrantsRequest.builder().build());
+        assertThat(all.snapshotCopyGrants())
+                .extracting(SnapshotCopyGrant::snapshotCopyGrantName)
+                .contains(grantName, otherGrantName);
+
+        client.deleteSnapshotCopyGrant(DeleteSnapshotCopyGrantRequest.builder()
+                .snapshotCopyGrantName(grantName)
+                .build());
+        snapshotCopyGrantsToCleanup.remove(grantName);
+
+        assertThatThrownBy(() -> client.describeSnapshotCopyGrants(DescribeSnapshotCopyGrantsRequest.builder()
+                .snapshotCopyGrantName(grantName)
+                .build()))
+                .isInstanceOf(SnapshotCopyGrantNotFoundException.class);
+
+        assertThatThrownBy(() -> client.deleteSnapshotCopyGrant(DeleteSnapshotCopyGrantRequest.builder()
+                .snapshotCopyGrantName(grantName)
+                .build()))
+                .isInstanceOf(SnapshotCopyGrantNotFoundException.class);
     }
 
     private static Connection awaitPostgresConnection(String host, int port, String username, String password) throws Exception {

--- a/compatibility-tests/sdk-test-java/src/test/java/com/floci/test/RedshiftOperationsTest.java
+++ b/compatibility-tests/sdk-test-java/src/test/java/com/floci/test/RedshiftOperationsTest.java
@@ -400,6 +400,38 @@ class RedshiftOperationsTest {
                 .isInstanceOf(SnapshotCopyGrantNotFoundException.class);
     }
 
+    @Test
+    @Order(5)
+    void testSnapshotCopyGrantPaginator() {
+        String prefix = TestFixtures.uniqueName("rs-page-grant");
+        int total = 21;
+        for (int i = 1; i <= total; i++) {
+            String name = String.format("%s-%02d", prefix, i);
+            client.createSnapshotCopyGrant(CreateSnapshotCopyGrantRequest.builder()
+                    .snapshotCopyGrantName(name)
+                    .build());
+            snapshotCopyGrantsToCleanup.add(name);
+        }
+
+        // MaxRecords below the number of grants forces the SDK's paginator to follow a
+        // Marker, which is the only way to prove the continuation token round-trips.
+        int pages = 0;
+        List<String> paged = new ArrayList<>();
+        for (DescribeSnapshotCopyGrantsResponse page : client.describeSnapshotCopyGrantsPaginator(
+                DescribeSnapshotCopyGrantsRequest.builder().maxRecords(20).build())) {
+            pages++;
+            page.snapshotCopyGrants().stream()
+                    .map(SnapshotCopyGrant::snapshotCopyGrantName)
+                    .filter(name -> name.startsWith(prefix))
+                    .forEach(paged::add);
+        }
+
+        assertThat(pages).isGreaterThan(1);
+        assertThat(paged).hasSize(total);
+        assertThat(paged).doesNotHaveDuplicates();
+        assertThat(paged).isSorted();
+    }
+
     private static Connection awaitPostgresConnection(String host, int port, String username, String password) throws Exception {
         Instant deadline = Instant.now().plus(Duration.ofSeconds(60));
         SQLException last = null;

--- a/docs/services/redshift.md
+++ b/docs/services/redshift.md
@@ -29,13 +29,16 @@ For running SQL without a PostgreSQL wire connection (the way Lambda and Step Fu
 | `DescribeClusterParameters` | Return the parameters of a group, with any values set by `ModifyClusterParameterGroup` |
 | `ModifyClusterParameterGroup` | Update parameter values on a group |
 | `DeleteClusterParameterGroup` | Remove a parameter group |
-| `CreateTags` | Add or overwrite tags on a cluster, snapshot, subnet group or parameter group |
+| `CreateTags` | Add or overwrite tags on a cluster, snapshot, subnet group, parameter group or snapshot copy grant |
 | `DeleteTags` | Remove tags by key from a resource |
 | `DescribeTags` | List tagged resources and their tags |
 | `CreateClusterSubnetGroup` | Register a cluster subnet group (metadata only) |
 | `DescribeClusterSubnetGroups` | List subnet groups, optionally filtered by name |
 | `ModifyClusterSubnetGroup` | Update a subnet group's description or subnet list |
 | `DeleteClusterSubnetGroup` | Remove a subnet group |
+| `CreateSnapshotCopyGrant` | Register a snapshot copy grant, defaulting `KmsKeyId` to the AWS-managed Redshift key |
+| `DescribeSnapshotCopyGrants` | List snapshot copy grants, optionally filtered by name |
+| `DeleteSnapshotCopyGrant` | Remove a snapshot copy grant |
 | `ModifyCluster` | Update node type, parameter group, security groups, or the master password |
 | `RebootCluster` | Restart a cluster's container |
 <!-- floci:actions:end -->

--- a/docs/services/redshift.md
+++ b/docs/services/redshift.md
@@ -37,7 +37,7 @@ For running SQL without a PostgreSQL wire connection (the way Lambda and Step Fu
 | `ModifyClusterSubnetGroup` | Update a subnet group's description or subnet list |
 | `DeleteClusterSubnetGroup` | Remove a subnet group |
 | `CreateSnapshotCopyGrant` | Register a snapshot copy grant, defaulting `KmsKeyId` to the AWS-managed Redshift key |
-| `DescribeSnapshotCopyGrants` | List snapshot copy grants, optionally filtered by name |
+| `DescribeSnapshotCopyGrants` | List snapshot copy grants, optionally filtered by name, paged with `MaxRecords` and `Marker` |
 | `DeleteSnapshotCopyGrant` | Remove a snapshot copy grant |
 | `ModifyCluster` | Update node type, parameter group, security groups, or the master password |
 | `RebootCluster` | Restart a cluster's container |

--- a/src/main/java/io/github/hectorvent/floci/core/common/AwsQueryController.java
+++ b/src/main/java/io/github/hectorvent/floci/core/common/AwsQueryController.java
@@ -605,6 +605,7 @@ public class AwsQueryController {
             "CreateClusterParameterGroup", "DescribeClusterParameterGroups", "DescribeClusterParameters", "DeleteClusterParameterGroup",
             "ModifyClusterParameterGroup",
             "CreateClusterSubnetGroup", "DescribeClusterSubnetGroups", "ModifyClusterSubnetGroup", "DeleteClusterSubnetGroup",
+            "CreateSnapshotCopyGrant", "DescribeSnapshotCopyGrants", "DeleteSnapshotCopyGrant",
             "CreateTags", "DeleteTags", "DescribeTags"
     );
 

--- a/src/main/java/io/github/hectorvent/floci/services/redshift/RedshiftQueryHandler.java
+++ b/src/main/java/io/github/hectorvent/floci/services/redshift/RedshiftQueryHandler.java
@@ -7,6 +7,7 @@ import io.github.hectorvent.floci.services.redshift.model.ClusterParameterGroup;
 import io.github.hectorvent.floci.services.redshift.model.ClusterSubnetGroup;
 import io.github.hectorvent.floci.services.redshift.model.Parameter;
 import io.github.hectorvent.floci.services.redshift.model.Snapshot;
+import io.github.hectorvent.floci.services.redshift.model.SnapshotCopyGrant;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
 import jakarta.ws.rs.core.MediaType;
@@ -372,6 +373,60 @@ public class RedshiftQueryHandler {
                     .build();
             return Response.ok(xml).type(MediaType.APPLICATION_XML).build();
         }
+        case "CreateSnapshotCopyGrant" -> {
+            String name = params.getFirst("SnapshotCopyGrantName");
+            if (name == null || name.isBlank()) {
+                throw new AwsException("InvalidParameterValue", "SnapshotCopyGrantName is required", 400);
+            }
+            String kmsKeyId = params.getFirst("KmsKeyId");
+            SnapshotCopyGrant grant = service.createSnapshotCopyGrant(name, kmsKeyId, parseTags(params));
+            String xml = new XmlBuilder()
+                    .start("CreateSnapshotCopyGrantResponse")
+                      .start("CreateSnapshotCopyGrantResult")
+                        .raw(buildSnapshotCopyGrantXml(grant))
+                      .end("CreateSnapshotCopyGrantResult")
+                      .start("ResponseMetadata")
+                        .elem("RequestId", "test-req-id")
+                      .end("ResponseMetadata")
+                    .end("CreateSnapshotCopyGrantResponse")
+                    .build();
+            return Response.ok(xml).type(MediaType.APPLICATION_XML).build();
+        }
+        case "DescribeSnapshotCopyGrants" -> {
+            String name = params.getFirst("SnapshotCopyGrantName");
+            List<SnapshotCopyGrant> grants = service.describeSnapshotCopyGrants(name);
+            XmlBuilder xmlBuilder = new XmlBuilder()
+                    .start("DescribeSnapshotCopyGrantsResponse")
+                      .start("DescribeSnapshotCopyGrantsResult")
+                        .start("SnapshotCopyGrants");
+            for (SnapshotCopyGrant grant : grants) {
+                xmlBuilder.raw(buildSnapshotCopyGrantXml(grant));
+            }
+            String xml = xmlBuilder
+                        .end("SnapshotCopyGrants")
+                      .end("DescribeSnapshotCopyGrantsResult")
+                      .start("ResponseMetadata")
+                        .elem("RequestId", "test-req-id")
+                      .end("ResponseMetadata")
+                    .end("DescribeSnapshotCopyGrantsResponse")
+                    .build();
+            return Response.ok(xml).type(MediaType.APPLICATION_XML).build();
+        }
+        case "DeleteSnapshotCopyGrant" -> {
+            String name = params.getFirst("SnapshotCopyGrantName");
+            if (name == null || name.isBlank()) {
+                throw new AwsException("InvalidParameterValue", "SnapshotCopyGrantName is required", 400);
+            }
+            service.deleteSnapshotCopyGrant(name);
+            String xml = new XmlBuilder()
+                    .start("DeleteSnapshotCopyGrantResponse")
+                      .start("ResponseMetadata")
+                        .elem("RequestId", "test-req-id")
+                      .end("ResponseMetadata")
+                    .end("DeleteSnapshotCopyGrantResponse")
+                    .build();
+            return Response.ok(xml).type(MediaType.APPLICATION_XML).build();
+        }
         case "ModifyCluster" -> {
             String clusterIdentifier = params.getFirst("ClusterIdentifier");
             if (clusterIdentifier == null || clusterIdentifier.isBlank()) {
@@ -515,6 +570,26 @@ public class RedshiftQueryHandler {
             builder.start("Subnet").elem("SubnetIdentifier", subnetId).end("Subnet");
         }
         return builder.end("Subnets").end("ClusterSubnetGroup").build();
+    }
+
+    private String buildSnapshotCopyGrantXml(SnapshotCopyGrant grant) {
+        XmlBuilder builder = new XmlBuilder()
+            .start("SnapshotCopyGrant")
+            .elem("SnapshotCopyGrantName", grant.getSnapshotCopyGrantName())
+            .elem("KmsKeyId", grant.getKmsKeyId());
+
+        if (grant.getTags() != null && !grant.getTags().isEmpty()) {
+            builder.start("Tags");
+            for (Map.Entry<String, String> tag : grant.getTags().entrySet()) {
+                builder.start("Tag")
+                    .elem("Key", tag.getKey())
+                    .elem("Value", tag.getValue())
+                  .end("Tag");
+            }
+            builder.end("Tags");
+        }
+
+        return builder.end("SnapshotCopyGrant").build();
     }
 
     private String buildParameterXml(Parameter param) {

--- a/src/main/java/io/github/hectorvent/floci/services/redshift/RedshiftQueryHandler.java
+++ b/src/main/java/io/github/hectorvent/floci/services/redshift/RedshiftQueryHandler.java
@@ -1,6 +1,7 @@
 package io.github.hectorvent.floci.services.redshift;
 
 import io.github.hectorvent.floci.core.common.AwsException;
+import io.github.hectorvent.floci.core.common.PaginatedResult;
 import io.github.hectorvent.floci.core.common.XmlBuilder;
 import io.github.hectorvent.floci.services.redshift.model.Cluster;
 import io.github.hectorvent.floci.services.redshift.model.ClusterParameterGroup;
@@ -394,12 +395,19 @@ public class RedshiftQueryHandler {
         }
         case "DescribeSnapshotCopyGrants" -> {
             String name = params.getFirst("SnapshotCopyGrantName");
-            List<SnapshotCopyGrant> grants = service.describeSnapshotCopyGrants(name);
+            Integer maxRecords = parseOptionalInteger(params, "MaxRecords");
+            String marker = params.getFirst("Marker");
+            PaginatedResult<SnapshotCopyGrant> page = service.describeSnapshotCopyGrants(name, maxRecords, marker);
             XmlBuilder xmlBuilder = new XmlBuilder()
                     .start("DescribeSnapshotCopyGrantsResponse")
-                      .start("DescribeSnapshotCopyGrantsResult")
-                        .start("SnapshotCopyGrants");
-            for (SnapshotCopyGrant grant : grants) {
+                      .start("DescribeSnapshotCopyGrantsResult");
+            // AWS returns Marker only while further pages remain, and a paginating client
+            // stops when it is absent.
+            if (page.nextToken() != null) {
+                xmlBuilder.elem("Marker", page.nextToken());
+            }
+            xmlBuilder.start("SnapshotCopyGrants");
+            for (SnapshotCopyGrant grant : page.items()) {
                 xmlBuilder.raw(buildSnapshotCopyGrantXml(grant));
             }
             String xml = xmlBuilder

--- a/src/main/java/io/github/hectorvent/floci/services/redshift/RedshiftService.java
+++ b/src/main/java/io/github/hectorvent/floci/services/redshift/RedshiftService.java
@@ -3,6 +3,8 @@ package io.github.hectorvent.floci.services.redshift;
 import io.github.hectorvent.floci.config.EmulatorConfig;
 import io.github.hectorvent.floci.core.common.AwsArnUtils;
 import io.github.hectorvent.floci.core.common.AwsException;
+import io.github.hectorvent.floci.core.common.PaginatedResult;
+import io.github.hectorvent.floci.core.common.Pagination;
 import io.github.hectorvent.floci.core.common.RegionResolver;
 import io.github.hectorvent.floci.core.common.docker.DockerHostResolver;
 import io.github.hectorvent.floci.core.storage.AccountAwareStorageBackend;
@@ -723,14 +725,40 @@ public class RedshiftService {
         return grant;
     }
 
-    public List<SnapshotCopyGrant> describeSnapshotCopyGrants(String name) {
+    /** Default and maximum page size AWS documents for DescribeSnapshotCopyGrants. */
+    private static final int SNAPSHOT_COPY_GRANT_PAGE_DEFAULT = 100;
+    private static final int SNAPSHOT_COPY_GRANT_PAGE_MAX = 100;
+    private static final int SNAPSHOT_COPY_GRANT_PAGE_MIN = 20;
+
+    /**
+     * Pages grants by name, which is their primary key, so the order is stable across calls
+     * and a marker stays resumable when grants are created or deleted between pages.
+     *
+     * <p>AWS documents SnapshotCopyGrantName and Marker as mutually exclusive, but models no
+     * error for sending both, so this filters first and then paginates rather than rejecting
+     * the combination: a name matches at most one grant, which fits in any page.
+     */
+    public PaginatedResult<SnapshotCopyGrant> describeSnapshotCopyGrants(String name, Integer maxRecords, String marker) {
+        if (maxRecords != null
+                && (maxRecords < SNAPSHOT_COPY_GRANT_PAGE_MIN || maxRecords > SNAPSHOT_COPY_GRANT_PAGE_MAX)) {
+            throw new AwsException("InvalidParameterValue",
+                    "MaxRecords must be between " + SNAPSHOT_COPY_GRANT_PAGE_MIN
+                            + " and " + SNAPSHOT_COPY_GRANT_PAGE_MAX + ".", 400);
+        }
+
+        List<SnapshotCopyGrant> matching;
         if (name != null && !name.isBlank()) {
             SnapshotCopyGrant grant = snapshotCopyGrants.get(name)
                     .orElseThrow(() -> new AwsException("SnapshotCopyGrantNotFoundFault",
                             "Snapshot copy grant " + name + " not found", 404));
-            return List.of(grant);
+            matching = List.of(grant);
+        } else {
+            matching = snapshotCopyGrants.scan(k -> true);
         }
-        return snapshotCopyGrants.scan(k -> true);
+
+        return Pagination.paginate(matching, SnapshotCopyGrant::getSnapshotCopyGrantName,
+                maxRecords, marker, SNAPSHOT_COPY_GRANT_PAGE_DEFAULT, SNAPSHOT_COPY_GRANT_PAGE_MAX,
+                "InvalidParameterValue");
     }
 
     public SnapshotCopyGrant deleteSnapshotCopyGrant(String name) {

--- a/src/main/java/io/github/hectorvent/floci/services/redshift/RedshiftService.java
+++ b/src/main/java/io/github/hectorvent/floci/services/redshift/RedshiftService.java
@@ -17,6 +17,7 @@ import io.github.hectorvent.floci.services.redshift.model.ClusterSubnetGroup;
 import io.github.hectorvent.floci.services.redshift.model.Endpoint;
 import io.github.hectorvent.floci.services.redshift.model.Parameter;
 import io.github.hectorvent.floci.services.redshift.model.Snapshot;
+import io.github.hectorvent.floci.services.redshift.model.SnapshotCopyGrant;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.enterprise.event.Observes;
 import jakarta.inject.Inject;
@@ -46,6 +47,7 @@ public class RedshiftService {
     private final AccountAwareStorageBackend<Snapshot> snapshots;
     private final AccountAwareStorageBackend<ClusterParameterGroup> parameterGroups;
     private final AccountAwareStorageBackend<ClusterSubnetGroup> subnetGroups;
+    private final AccountAwareStorageBackend<SnapshotCopyGrant> snapshotCopyGrants;
     private final RedshiftContainerManager containerManager;
     private final EmulatorConfig config;
     private final RegionResolver regionResolver;
@@ -62,6 +64,7 @@ public class RedshiftService {
         this.snapshots = storageFactory.create("redshift", "redshift-snapshots.json", new TypeReference<Map<String, Snapshot>>() {});
         this.parameterGroups = storageFactory.create("redshift", "redshift-parameter-groups.json", new TypeReference<Map<String, ClusterParameterGroup>>() {});
         this.subnetGroups = storageFactory.create("redshift", "redshift-subnet-groups.json", new TypeReference<Map<String, ClusterSubnetGroup>>() {});
+        this.snapshotCopyGrants = storageFactory.create("redshift", "redshift-snapshot-copy-grants.json", new TypeReference<Map<String, SnapshotCopyGrant>>() {});
         this.containerManager = containerManager;
         this.config = config;
         this.regionResolver = regionResolver;
@@ -694,6 +697,51 @@ public class RedshiftService {
         return group;
     }
 
+    // ── Snapshot Copy Grant Operations ───────────────────────────────────────
+
+    /**
+     * AWS-managed Redshift key an account gets when CreateSnapshotCopyGrant omits KmsKeyId.
+     * Floci has no per-account default key, so the alias ARN stands in for it: the value only
+     * has to round-trip through Describe, which is what Terraform reads back.
+     */
+    private String defaultSnapshotCopyGrantKey() {
+        return regionResolver.buildArn("kms", regionResolver.getRegion(), "alias/aws/redshift");
+    }
+
+    public SnapshotCopyGrant createSnapshotCopyGrant(String name, String kmsKeyId, Map<String, String> tags) {
+        if (snapshotCopyGrants.get(name).isPresent()) {
+            throw new AwsException("SnapshotCopyGrantAlreadyExistsFault",
+                    "Snapshot copy grant " + name + " already exists", 400);
+        }
+        String effectiveKey = (kmsKeyId != null && !kmsKeyId.isBlank()) ? kmsKeyId : defaultSnapshotCopyGrantKey();
+        SnapshotCopyGrant grant = new SnapshotCopyGrant(name, effectiveKey);
+        if (tags != null && !tags.isEmpty()) {
+            grant.setTags(new LinkedHashMap<>(tags));
+        }
+        snapshotCopyGrants.put(name, grant);
+        snapshotCopyGrants.flush();
+        return grant;
+    }
+
+    public List<SnapshotCopyGrant> describeSnapshotCopyGrants(String name) {
+        if (name != null && !name.isBlank()) {
+            SnapshotCopyGrant grant = snapshotCopyGrants.get(name)
+                    .orElseThrow(() -> new AwsException("SnapshotCopyGrantNotFoundFault",
+                            "Snapshot copy grant " + name + " not found", 404));
+            return List.of(grant);
+        }
+        return snapshotCopyGrants.scan(k -> true);
+    }
+
+    public SnapshotCopyGrant deleteSnapshotCopyGrant(String name) {
+        SnapshotCopyGrant grant = snapshotCopyGrants.get(name)
+                .orElseThrow(() -> new AwsException("SnapshotCopyGrantNotFoundFault",
+                        "Snapshot copy grant " + name + " not found", 404));
+        snapshotCopyGrants.delete(name);
+        snapshotCopyGrants.flush();
+        return grant;
+    }
+
     // ── Tagging Operations ───────────────────────────────────────────────────
 
     /** A resolved tag target: its current tags plus a sink that persists an updated map. */
@@ -750,6 +798,12 @@ public class RedshiftService {
                         "subnetgroup", g.getTags(), tagKeysFilter);
             }
         }
+        if (resourceType == null || "snapshotcopygrant".equalsIgnoreCase(resourceType)) {
+            for (SnapshotCopyGrant g : snapshotCopyGrants.scan(k -> true)) {
+                addTaggedResources(result, snapshotCopyGrantArn(g.getSnapshotCopyGrantName()),
+                        "snapshotcopygrant", g.getTags(), tagKeysFilter);
+            }
+        }
         return result;
     }
 
@@ -787,12 +841,17 @@ public class RedshiftService {
         return regionResolver.buildArn("redshift", regionResolver.getRegion(), "subnetgroup:" + name);
     }
 
+    private String snapshotCopyGrantArn(String name) {
+        return regionResolver.buildArn("redshift", regionResolver.getRegion(), "snapshotcopygrant:" + name);
+    }
+
     /**
      * Resolves a tagging ResourceName to its backing resource.
      *
      * Redshift ARNs have the shape {@code arn:aws:redshift:<region>:<account>:<type>:<id>},
      * where {@code <type>} is one of {@code cluster}, {@code snapshot} (id shape
-     * {@code <clusterId>/<snapshotId>}), or {@code parametergroup}. Unlike RDS's tag
+     * {@code <clusterId>/<snapshotId>}), {@code parametergroup}, {@code subnetgroup} or
+     * {@code snapshotcopygrant}. Unlike RDS's tag
      * resolution, there is no bare-name fallback — Redshift tagging is new, so there is no
      * existing caller to stay backward compatible with.
      */
@@ -856,6 +915,15 @@ public class RedshiftService {
                     group.setTags(updated);
                     subnetGroups.put(id, group);
                     subnetGroups.flush();
+                });
+            }
+            case "snapshotcopygrant" -> {
+                SnapshotCopyGrant grant = snapshotCopyGrants.get(id)
+                        .orElseThrow(() -> new AwsException("SnapshotCopyGrantNotFoundFault", "Snapshot copy grant " + id + " not found", 404));
+                yield new TagHandle(grant.getTags(), updated -> {
+                    grant.setTags(updated);
+                    snapshotCopyGrants.put(id, grant);
+                    snapshotCopyGrants.flush();
                 });
             }
             default -> throw new AwsException("InvalidParameterValue",

--- a/src/main/java/io/github/hectorvent/floci/services/redshift/model/SnapshotCopyGrant.java
+++ b/src/main/java/io/github/hectorvent/floci/services/redshift/model/SnapshotCopyGrant.java
@@ -1,0 +1,27 @@
+package io.github.hectorvent.floci.services.redshift.model;
+
+import io.quarkus.runtime.annotations.RegisterForReflection;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+@RegisterForReflection
+public class SnapshotCopyGrant {
+    private String snapshotCopyGrantName;
+    private String kmsKeyId;
+    private Map<String, String> tags = new LinkedHashMap<>();
+
+    public SnapshotCopyGrant() {}
+
+    public SnapshotCopyGrant(String snapshotCopyGrantName, String kmsKeyId) {
+        this.snapshotCopyGrantName = snapshotCopyGrantName;
+        this.kmsKeyId = kmsKeyId;
+    }
+
+    public String getSnapshotCopyGrantName() { return snapshotCopyGrantName; }
+    public void setSnapshotCopyGrantName(String snapshotCopyGrantName) { this.snapshotCopyGrantName = snapshotCopyGrantName; }
+    public String getKmsKeyId() { return kmsKeyId; }
+    public void setKmsKeyId(String kmsKeyId) { this.kmsKeyId = kmsKeyId; }
+    public Map<String, String> getTags() { return tags; }
+    public void setTags(Map<String, String> tags) { this.tags = tags; }
+}

--- a/src/test/java/io/github/hectorvent/floci/services/redshift/RedshiftOperationsTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/redshift/RedshiftOperationsTest.java
@@ -4,6 +4,7 @@ import io.github.hectorvent.floci.services.redshift.container.RedshiftContainerH
 import io.github.hectorvent.floci.services.redshift.container.RedshiftContainerManager;
 import io.quarkus.test.InjectMock;
 import io.quarkus.test.junit.QuarkusTest;
+import io.restassured.path.xml.XmlPath;
 import org.junit.jupiter.api.MethodOrderer;
 import org.junit.jupiter.api.Order;
 import org.junit.jupiter.api.Test;
@@ -11,11 +12,15 @@ import org.junit.jupiter.api.TestMethodOrder;
 
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.List;
 import java.util.Optional;
 
 import static io.restassured.RestAssured.given;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.not;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.doAnswer;
@@ -27,6 +32,11 @@ public class RedshiftOperationsTest {
 
     private static final String AUTH_HEADER =
             "AWS4-HMAC-SHA256 Credential=test/20260822/us-east-1/redshift/aws4_request";
+
+    private static final String GRANT_NAMES_PATH = "DescribeSnapshotCopyGrantsResponse"
+            + ".DescribeSnapshotCopyGrantsResult.SnapshotCopyGrants.SnapshotCopyGrant.SnapshotCopyGrantName";
+    private static final String MARKER_PATH =
+            "DescribeSnapshotCopyGrantsResponse.DescribeSnapshotCopyGrantsResult.Marker";
 
     @InjectMock
     RedshiftContainerManager containerManager;
@@ -417,6 +427,95 @@ public class RedshiftOperationsTest {
             .post("/")
         .then()
             .statusCode(200);
+    }
+
+    @Test
+    @Order(6)
+    void testSnapshotCopyGrantPagination() {
+        // AWS constrains MaxRecords to 20-100, so a two-page walk needs more than 20 grants.
+        int total = 21;
+        for (int i = 1; i <= total; i++) {
+            given()
+                .contentType("application/x-www-form-urlencoded")
+                .header("Authorization", AUTH_HEADER)
+                .formParam("Action", "CreateSnapshotCopyGrant")
+                .formParam("SnapshotCopyGrantName", String.format("pg-grant-%02d", i))
+            .when()
+                .post("/")
+            .then()
+                .statusCode(200);
+        }
+
+        String firstPage = given()
+            .contentType("application/x-www-form-urlencoded")
+            .header("Authorization", AUTH_HEADER)
+            .formParam("Action", "DescribeSnapshotCopyGrants")
+            .formParam("MaxRecords", "20")
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200)
+            .extract().asString();
+
+        List<String> firstNames = new XmlPath(firstPage).getList(GRANT_NAMES_PATH);
+        String marker = new XmlPath(firstPage).getString(MARKER_PATH);
+        assertEquals(20, firstNames.size());
+        assertEquals("pg-grant-01", firstNames.get(0));
+        assertEquals("pg-grant-20", firstNames.get(19));
+        assertNotNull(marker);
+        assertFalse(marker.isBlank(), "a non-final page must carry a Marker");
+
+        String secondPage = given()
+            .contentType("application/x-www-form-urlencoded")
+            .header("Authorization", AUTH_HEADER)
+            .formParam("Action", "DescribeSnapshotCopyGrants")
+            .formParam("MaxRecords", "20")
+            .formParam("Marker", marker)
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200)
+            .extract().asString();
+
+        List<String> secondNames = new XmlPath(secondPage).getList(GRANT_NAMES_PATH);
+        assertEquals(List.of("pg-grant-21"), secondNames);
+        // Asserted on the raw body: an absent GPath node can read back as "" rather than null.
+        assertFalse(secondPage.contains("<Marker>"), "the final page must not carry a Marker");
+
+        // Out-of-range MaxRecords is rejected rather than silently clamped.
+        given()
+            .contentType("application/x-www-form-urlencoded")
+            .header("Authorization", AUTH_HEADER)
+            .formParam("Action", "DescribeSnapshotCopyGrants")
+            .formParam("MaxRecords", "19")
+        .when()
+            .post("/")
+        .then()
+            .statusCode(400)
+            .body(containsString("InvalidParameterValue"));
+
+        given()
+            .contentType("application/x-www-form-urlencoded")
+            .header("Authorization", AUTH_HEADER)
+            .formParam("Action", "DescribeSnapshotCopyGrants")
+            .formParam("MaxRecords", "101")
+        .when()
+            .post("/")
+        .then()
+            .statusCode(400)
+            .body(containsString("InvalidParameterValue"));
+
+        for (int i = 1; i <= total; i++) {
+            given()
+                .contentType("application/x-www-form-urlencoded")
+                .header("Authorization", AUTH_HEADER)
+                .formParam("Action", "DeleteSnapshotCopyGrant")
+                .formParam("SnapshotCopyGrantName", String.format("pg-grant-%02d", i))
+            .when()
+                .post("/")
+            .then()
+                .statusCode(200);
+        }
     }
 
     @Test

--- a/src/test/java/io/github/hectorvent/floci/services/redshift/RedshiftOperationsTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/redshift/RedshiftOperationsTest.java
@@ -15,6 +15,7 @@ import java.util.Optional;
 
 import static io.restassured.RestAssured.given;
 import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.not;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.doAnswer;
@@ -301,6 +302,117 @@ public class RedshiftOperationsTest {
             .header("Authorization", AUTH_HEADER)
             .formParam("Action", "DeleteClusterSubnetGroup")
             .formParam("ClusterSubnetGroupName", "subnet-group-1")
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200);
+    }
+
+    @Test
+    @Order(5)
+    void testSnapshotCopyGrantLifecycle() {
+        given()
+            .contentType("application/x-www-form-urlencoded")
+            .header("Authorization", AUTH_HEADER)
+            .formParam("Action", "CreateSnapshotCopyGrant")
+            .formParam("SnapshotCopyGrantName", "copy-grant-1")
+            .formParam("KmsKeyId", "key-abc")
+            .formParam("Tags.Tag.1.Key", "env")
+            .formParam("Tags.Tag.1.Value", "test")
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200)
+            .contentType("application/xml")
+            .body(containsString("<SnapshotCopyGrantName>copy-grant-1</SnapshotCopyGrantName>"))
+            .body(containsString("<KmsKeyId>key-abc</KmsKeyId>"))
+            .body(containsString("<Key>env</Key>"));
+
+        // A grant created without KmsKeyId gets the account's AWS-managed Redshift key.
+        given()
+            .contentType("application/x-www-form-urlencoded")
+            .header("Authorization", AUTH_HEADER)
+            .formParam("Action", "CreateSnapshotCopyGrant")
+            .formParam("SnapshotCopyGrantName", "copy-grant-2")
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200)
+            .body(containsString("<KmsKeyId>arn:aws:kms:us-east-1:"))
+            .body(containsString(":alias/aws/redshift</KmsKeyId>"));
+
+        given()
+            .contentType("application/x-www-form-urlencoded")
+            .header("Authorization", AUTH_HEADER)
+            .formParam("Action", "CreateSnapshotCopyGrant")
+            .formParam("SnapshotCopyGrantName", "copy-grant-1")
+        .when()
+            .post("/")
+        .then()
+            .statusCode(400)
+            .body(containsString("SnapshotCopyGrantAlreadyExistsFault"));
+
+        // Name filter selects one grant, and omitting it returns both.
+        given()
+            .contentType("application/x-www-form-urlencoded")
+            .header("Authorization", AUTH_HEADER)
+            .formParam("Action", "DescribeSnapshotCopyGrants")
+            .formParam("SnapshotCopyGrantName", "copy-grant-1")
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200)
+            .body(containsString("<SnapshotCopyGrantName>copy-grant-1</SnapshotCopyGrantName>"))
+            .body(not(containsString("<SnapshotCopyGrantName>copy-grant-2</SnapshotCopyGrantName>")));
+
+        given()
+            .contentType("application/x-www-form-urlencoded")
+            .header("Authorization", AUTH_HEADER)
+            .formParam("Action", "DescribeSnapshotCopyGrants")
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200)
+            .body(containsString("<SnapshotCopyGrantName>copy-grant-1</SnapshotCopyGrantName>"))
+            .body(containsString("<SnapshotCopyGrantName>copy-grant-2</SnapshotCopyGrantName>"));
+
+        given()
+            .contentType("application/x-www-form-urlencoded")
+            .header("Authorization", AUTH_HEADER)
+            .formParam("Action", "DeleteSnapshotCopyGrant")
+            .formParam("SnapshotCopyGrantName", "copy-grant-1")
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200);
+
+        given()
+            .contentType("application/x-www-form-urlencoded")
+            .header("Authorization", AUTH_HEADER)
+            .formParam("Action", "DescribeSnapshotCopyGrants")
+            .formParam("SnapshotCopyGrantName", "copy-grant-1")
+        .when()
+            .post("/")
+        .then()
+            .statusCode(404)
+            .body(containsString("SnapshotCopyGrantNotFoundFault"));
+
+        given()
+            .contentType("application/x-www-form-urlencoded")
+            .header("Authorization", AUTH_HEADER)
+            .formParam("Action", "DeleteSnapshotCopyGrant")
+            .formParam("SnapshotCopyGrantName", "copy-grant-1")
+        .when()
+            .post("/")
+        .then()
+            .statusCode(404)
+            .body(containsString("SnapshotCopyGrantNotFoundFault"));
+
+        given()
+            .contentType("application/x-www-form-urlencoded")
+            .header("Authorization", AUTH_HEADER)
+            .formParam("Action", "DeleteSnapshotCopyGrant")
+            .formParam("SnapshotCopyGrantName", "copy-grant-2")
         .when()
             .post("/")
         .then()

--- a/src/test/java/io/github/hectorvent/floci/services/redshift/RedshiftQueryHandlerTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/redshift/RedshiftQueryHandlerTest.java
@@ -1,6 +1,7 @@
 package io.github.hectorvent.floci.services.redshift;
 
 import io.github.hectorvent.floci.core.common.AwsException;
+import io.github.hectorvent.floci.core.common.PaginatedResult;
 import io.github.hectorvent.floci.services.redshift.model.Cluster;
 import io.github.hectorvent.floci.services.redshift.model.ClusterParameterGroup;
 import io.github.hectorvent.floci.services.redshift.model.ClusterSubnetGroup;
@@ -18,6 +19,7 @@ import java.util.List;
 import java.util.Map;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -414,8 +416,8 @@ class RedshiftQueryHandlerTest {
         MultivaluedMap<String, String> params = new MultivaluedHashMap<>();
         params.putSingle("SnapshotCopyGrantName", "grant-1");
 
-        when(service.describeSnapshotCopyGrants("grant-1"))
-                .thenReturn(List.of(new SnapshotCopyGrant("grant-1", "key-abc")));
+        when(service.describeSnapshotCopyGrants(eq("grant-1"), isNull(), isNull()))
+                .thenReturn(new PaginatedResult<>(List.of(new SnapshotCopyGrant("grant-1", "key-abc")), null));
 
         Response response = handler.handle("DescribeSnapshotCopyGrants", params);
 
@@ -424,15 +426,17 @@ class RedshiftQueryHandlerTest {
         assertTrue(xml.contains("<SnapshotCopyGrants>"));
         assertTrue(xml.contains("<SnapshotCopyGrantName>grant-1</SnapshotCopyGrantName>"));
         assertTrue(xml.contains("</SnapshotCopyGrants>"));
+        assertFalse(xml.contains("<Marker>"), "a single full page must not advertise a marker");
     }
 
     @Test
     void testDescribeSnapshotCopyGrantsWithoutNameListsAll() {
         MultivaluedMap<String, String> params = new MultivaluedHashMap<>();
 
-        when(service.describeSnapshotCopyGrants(isNull())).thenReturn(List.of(
-                new SnapshotCopyGrant("grant-a", "key-a"),
-                new SnapshotCopyGrant("grant-b", "key-b")));
+        when(service.describeSnapshotCopyGrants(isNull(), isNull(), isNull()))
+                .thenReturn(new PaginatedResult<>(List.of(
+                        new SnapshotCopyGrant("grant-a", "key-a"),
+                        new SnapshotCopyGrant("grant-b", "key-b")), null));
 
         Response response = handler.handle("DescribeSnapshotCopyGrants", params);
 
@@ -440,6 +444,47 @@ class RedshiftQueryHandlerTest {
         String xml = (String) response.getEntity();
         assertTrue(xml.contains("<SnapshotCopyGrantName>grant-a</SnapshotCopyGrantName>"));
         assertTrue(xml.contains("<SnapshotCopyGrantName>grant-b</SnapshotCopyGrantName>"));
+    }
+
+    @Test
+    void testDescribeSnapshotCopyGrantsForwardsMaxRecordsAndMarker() {
+        MultivaluedMap<String, String> params = new MultivaluedHashMap<>();
+        params.putSingle("MaxRecords", "20");
+        params.putSingle("Marker", "Z3JhbnQtMjA");
+
+        when(service.describeSnapshotCopyGrants(isNull(), eq(20), eq("Z3JhbnQtMjA")))
+                .thenReturn(new PaginatedResult<>(List.of(new SnapshotCopyGrant("grant-21", "key-a")), null));
+
+        Response response = handler.handle("DescribeSnapshotCopyGrants", params);
+
+        assertEquals(200, response.getStatus());
+        verify(service).describeSnapshotCopyGrants(isNull(), eq(20), eq("Z3JhbnQtMjA"));
+    }
+
+    @Test
+    void testDescribeSnapshotCopyGrantsEmitsMarkerWhenMorePagesRemain() {
+        MultivaluedMap<String, String> params = new MultivaluedHashMap<>();
+        params.putSingle("MaxRecords", "20");
+
+        when(service.describeSnapshotCopyGrants(isNull(), eq(20), isNull()))
+                .thenReturn(new PaginatedResult<>(
+                        List.of(new SnapshotCopyGrant("grant-01", "key-a")), "Z3JhbnQtMjA"));
+
+        Response response = handler.handle("DescribeSnapshotCopyGrants", params);
+
+        String xml = (String) response.getEntity();
+        assertTrue(xml.contains("<Marker>Z3JhbnQtMjA</Marker>"));
+    }
+
+    @Test
+    void testDescribeSnapshotCopyGrantsRejectsNonNumericMaxRecords() {
+        MultivaluedMap<String, String> params = new MultivaluedHashMap<>();
+        params.putSingle("MaxRecords", "many");
+
+        AwsException ex = assertThrows(
+                AwsException.class,
+                () -> handler.handle("DescribeSnapshotCopyGrants", params));
+        assertEquals("InvalidParameterValue", ex.getErrorCode());
     }
 
     @Test

--- a/src/test/java/io/github/hectorvent/floci/services/redshift/RedshiftQueryHandlerTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/redshift/RedshiftQueryHandlerTest.java
@@ -7,6 +7,7 @@ import io.github.hectorvent.floci.services.redshift.model.ClusterSubnetGroup;
 import io.github.hectorvent.floci.services.redshift.model.Endpoint;
 import io.github.hectorvent.floci.services.redshift.model.Parameter;
 import io.github.hectorvent.floci.services.redshift.model.Snapshot;
+import io.github.hectorvent.floci.services.redshift.model.SnapshotCopyGrant;
 import jakarta.ws.rs.core.MultivaluedHashMap;
 import jakarta.ws.rs.core.MultivaluedMap;
 import jakarta.ws.rs.core.Response;
@@ -351,6 +352,121 @@ class RedshiftQueryHandlerTest {
                 AwsException.class,
                 () -> handler.handle("ModifyCluster", params));
         assertEquals("InvalidParameterValue", ex.getErrorCode());
+    }
+
+    @Test
+    void testCreateSnapshotCopyGrant() {
+        MultivaluedMap<String, String> params = new MultivaluedHashMap<>();
+        params.putSingle("SnapshotCopyGrantName", "grant-1");
+        params.putSingle("KmsKeyId", "key-abc");
+
+        when(service.createSnapshotCopyGrant(eq("grant-1"), eq("key-abc"), any()))
+                .thenReturn(new SnapshotCopyGrant("grant-1", "key-abc"));
+
+        Response response = handler.handle("CreateSnapshotCopyGrant", params);
+
+        assertEquals(200, response.getStatus());
+        String xml = (String) response.getEntity();
+        assertTrue(xml.contains("<CreateSnapshotCopyGrantResult>"));
+        assertTrue(xml.contains("<SnapshotCopyGrantName>grant-1</SnapshotCopyGrantName>"));
+        assertTrue(xml.contains("<KmsKeyId>key-abc</KmsKeyId>"));
+        assertTrue(xml.contains("<RequestId>test-req-id</RequestId>"));
+    }
+
+    @Test
+    void testCreateSnapshotCopyGrantAcceptsNamedMemberTags() {
+        // Real Redshift SDK sends "Tags.Tag.N.Key/.Value" on CreateSnapshotCopyGrant.
+        MultivaluedMap<String, String> params = new MultivaluedHashMap<>();
+        params.putSingle("SnapshotCopyGrantName", "grant-1");
+        params.putSingle("Tags.Tag.1.Key", "env");
+        params.putSingle("Tags.Tag.1.Value", "prod");
+
+        SnapshotCopyGrant grant = new SnapshotCopyGrant("grant-1", "key-abc");
+        grant.setTags(Map.of("env", "prod"));
+        when(service.createSnapshotCopyGrant(any(), any(), any())).thenReturn(grant);
+
+        Response response = handler.handle("CreateSnapshotCopyGrant", params);
+        assertEquals(200, response.getStatus());
+
+        @SuppressWarnings("unchecked")
+        ArgumentCaptor<Map<String, String>> captor = ArgumentCaptor.forClass(Map.class);
+        verify(service).createSnapshotCopyGrant(eq("grant-1"), isNull(), captor.capture());
+        assertEquals(Map.of("env", "prod"), captor.getValue());
+
+        String xml = (String) response.getEntity();
+        assertTrue(xml.contains("<Key>env</Key>"));
+        assertTrue(xml.contains("<Value>prod</Value>"));
+    }
+
+    @Test
+    void testCreateSnapshotCopyGrantRequiresName() {
+        MultivaluedMap<String, String> params = new MultivaluedHashMap<>();
+        params.putSingle("KmsKeyId", "key-abc");
+
+        AwsException ex = assertThrows(
+                AwsException.class,
+                () -> handler.handle("CreateSnapshotCopyGrant", params));
+        assertEquals("InvalidParameterValue", ex.getErrorCode());
+    }
+
+    @Test
+    void testDescribeSnapshotCopyGrants() {
+        MultivaluedMap<String, String> params = new MultivaluedHashMap<>();
+        params.putSingle("SnapshotCopyGrantName", "grant-1");
+
+        when(service.describeSnapshotCopyGrants("grant-1"))
+                .thenReturn(List.of(new SnapshotCopyGrant("grant-1", "key-abc")));
+
+        Response response = handler.handle("DescribeSnapshotCopyGrants", params);
+
+        assertEquals(200, response.getStatus());
+        String xml = (String) response.getEntity();
+        assertTrue(xml.contains("<SnapshotCopyGrants>"));
+        assertTrue(xml.contains("<SnapshotCopyGrantName>grant-1</SnapshotCopyGrantName>"));
+        assertTrue(xml.contains("</SnapshotCopyGrants>"));
+    }
+
+    @Test
+    void testDescribeSnapshotCopyGrantsWithoutNameListsAll() {
+        MultivaluedMap<String, String> params = new MultivaluedHashMap<>();
+
+        when(service.describeSnapshotCopyGrants(isNull())).thenReturn(List.of(
+                new SnapshotCopyGrant("grant-a", "key-a"),
+                new SnapshotCopyGrant("grant-b", "key-b")));
+
+        Response response = handler.handle("DescribeSnapshotCopyGrants", params);
+
+        assertEquals(200, response.getStatus());
+        String xml = (String) response.getEntity();
+        assertTrue(xml.contains("<SnapshotCopyGrantName>grant-a</SnapshotCopyGrantName>"));
+        assertTrue(xml.contains("<SnapshotCopyGrantName>grant-b</SnapshotCopyGrantName>"));
+    }
+
+    @Test
+    void testDeleteSnapshotCopyGrant() {
+        MultivaluedMap<String, String> params = new MultivaluedHashMap<>();
+        params.putSingle("SnapshotCopyGrantName", "grant-1");
+
+        when(service.deleteSnapshotCopyGrant("grant-1"))
+                .thenReturn(new SnapshotCopyGrant("grant-1", "key-abc"));
+
+        Response response = handler.handle("DeleteSnapshotCopyGrant", params);
+
+        assertEquals(200, response.getStatus());
+        verify(service).deleteSnapshotCopyGrant("grant-1");
+        String xml = (String) response.getEntity();
+        assertTrue(xml.contains("<DeleteSnapshotCopyGrantResponse>"));
+    }
+
+    @Test
+    void testDeleteSnapshotCopyGrantRequiresName() {
+        MultivaluedMap<String, String> params = new MultivaluedHashMap<>();
+
+        AwsException ex = assertThrows(
+                AwsException.class,
+                () -> handler.handle("DeleteSnapshotCopyGrant", params));
+        assertEquals("InvalidParameterValue", ex.getErrorCode());
+        verify(service, never()).deleteSnapshotCopyGrant(any());
     }
 
     @Test

--- a/src/test/java/io/github/hectorvent/floci/services/redshift/RedshiftServiceTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/redshift/RedshiftServiceTest.java
@@ -2,6 +2,7 @@ package io.github.hectorvent.floci.services.redshift;
 
 import io.github.hectorvent.floci.config.EmulatorConfig;
 import io.github.hectorvent.floci.core.common.AwsException;
+import io.github.hectorvent.floci.core.common.PaginatedResult;
 import io.github.hectorvent.floci.core.common.RegionResolver;
 import io.github.hectorvent.floci.core.common.docker.DockerHostResolver;
 import io.github.hectorvent.floci.core.storage.AccountAwareStorageBackend;
@@ -31,6 +32,7 @@ import java.util.Optional;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.*;
@@ -1146,7 +1148,7 @@ class RedshiftServiceTest {
         SnapshotCopyGrant grant = new SnapshotCopyGrant("my-grant", "key-abc");
         when(snapshotCopyGrantBackend.get("my-grant")).thenReturn(Optional.of(grant));
 
-        List<SnapshotCopyGrant> list = service.describeSnapshotCopyGrants("my-grant");
+        List<SnapshotCopyGrant> list = service.describeSnapshotCopyGrants("my-grant", null, null).items();
 
         assertEquals(1, list.size());
         assertEquals("my-grant", list.get(0).getSnapshotCopyGrantName());
@@ -1159,17 +1161,87 @@ class RedshiftServiceTest {
                 new SnapshotCopyGrant("grant-a", "key-a"),
                 new SnapshotCopyGrant("grant-b", "key-b")));
 
-        List<SnapshotCopyGrant> list = service.describeSnapshotCopyGrants(null);
+        PaginatedResult<SnapshotCopyGrant> page = service.describeSnapshotCopyGrants(null, null, null);
 
-        assertEquals(2, list.size());
+        assertEquals(2, page.items().size());
+        assertNull(page.nextToken());
     }
 
     @Test
     void testDescribeSnapshotCopyGrantsNotFound() {
         when(snapshotCopyGrantBackend.get("missing")).thenReturn(Optional.empty());
 
-        AwsException ex = assertThrows(AwsException.class, () -> service.describeSnapshotCopyGrants("missing"));
+        AwsException ex = assertThrows(AwsException.class,
+                () -> service.describeSnapshotCopyGrants("missing", null, null));
         assertEquals("SnapshotCopyGrantNotFoundFault", ex.getErrorCode());
+    }
+
+    @Test
+    void testDescribeSnapshotCopyGrantsPagesInNameOrder() {
+        // 25 grants created out of order: paging must follow name order, not insertion order.
+        List<SnapshotCopyGrant> stored = new ArrayList<>();
+        for (int i = 25; i >= 1; i--) {
+            stored.add(new SnapshotCopyGrant(String.format("grant-%02d", i), "key-" + i));
+        }
+        when(snapshotCopyGrantBackend.scan(any())).thenReturn(stored);
+
+        PaginatedResult<SnapshotCopyGrant> first = service.describeSnapshotCopyGrants(null, 20, null);
+
+        assertEquals(20, first.items().size());
+        assertEquals("grant-01", first.items().get(0).getSnapshotCopyGrantName());
+        assertEquals("grant-20", first.items().get(19).getSnapshotCopyGrantName());
+        assertNotNull(first.nextToken());
+
+        PaginatedResult<SnapshotCopyGrant> second =
+                service.describeSnapshotCopyGrants(null, 20, first.nextToken());
+
+        assertEquals(5, second.items().size());
+        assertEquals("grant-21", second.items().get(0).getSnapshotCopyGrantName());
+        assertEquals("grant-25", second.items().get(4).getSnapshotCopyGrantName());
+        assertNull(second.nextToken(), "last page must not carry a marker");
+    }
+
+    @Test
+    void testDescribeSnapshotCopyGrantsOmitsMarkerWhenPageExactlyFits() {
+        List<SnapshotCopyGrant> stored = new ArrayList<>();
+        for (int i = 1; i <= 20; i++) {
+            stored.add(new SnapshotCopyGrant(String.format("grant-%02d", i), "key-" + i));
+        }
+        when(snapshotCopyGrantBackend.scan(any())).thenReturn(stored);
+
+        PaginatedResult<SnapshotCopyGrant> page = service.describeSnapshotCopyGrants(null, 20, null);
+
+        assertEquals(20, page.items().size());
+        assertNull(page.nextToken());
+    }
+
+    @Test
+    void testDescribeSnapshotCopyGrantsRejectsMaxRecordsBelowMinimum() {
+        AwsException ex = assertThrows(AwsException.class,
+                () -> service.describeSnapshotCopyGrants(null, 19, null));
+        assertEquals("InvalidParameterValue", ex.getErrorCode());
+        verify(snapshotCopyGrantBackend, never()).scan(any());
+    }
+
+    @Test
+    void testDescribeSnapshotCopyGrantsRejectsMaxRecordsAboveMaximum() {
+        AwsException ex = assertThrows(AwsException.class,
+                () -> service.describeSnapshotCopyGrants(null, 101, null));
+        assertEquals("InvalidParameterValue", ex.getErrorCode());
+    }
+
+    @Test
+    void testDescribeSnapshotCopyGrantsAcceptsMarkerAlongsideName() {
+        // AWS documents the two as mutually exclusive but models no error, so Floci filters
+        // by name and then paginates rather than rejecting the pair.
+        SnapshotCopyGrant grant = new SnapshotCopyGrant("my-grant", "key-abc");
+        when(snapshotCopyGrantBackend.get("my-grant")).thenReturn(Optional.of(grant));
+
+        PaginatedResult<SnapshotCopyGrant> page =
+                service.describeSnapshotCopyGrants("my-grant", null, null);
+
+        assertEquals(1, page.items().size());
+        assertNull(page.nextToken());
     }
 
     @Test

--- a/src/test/java/io/github/hectorvent/floci/services/redshift/RedshiftServiceTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/redshift/RedshiftServiceTest.java
@@ -14,6 +14,7 @@ import io.github.hectorvent.floci.services.redshift.model.ClusterSubnetGroup;
 import io.github.hectorvent.floci.services.redshift.model.Endpoint;
 import io.github.hectorvent.floci.services.redshift.model.Parameter;
 import io.github.hectorvent.floci.services.redshift.model.Snapshot;
+import io.github.hectorvent.floci.services.redshift.model.SnapshotCopyGrant;
 import io.github.hectorvent.floci.services.redshift.proxy.RedshiftProxyManager;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -42,6 +43,7 @@ class RedshiftServiceTest {
     private AccountAwareStorageBackend<String> snapshotDumpBackend;
     private AccountAwareStorageBackend<ClusterParameterGroup> parameterGroupBackend;
     private AccountAwareStorageBackend<ClusterSubnetGroup> subnetGroupBackend;
+    private AccountAwareStorageBackend<SnapshotCopyGrant> snapshotCopyGrantBackend;
     private RedshiftContainerManager cm;
     private RegionResolver regionResolver;
     private RedshiftProxyManager proxyManager;
@@ -57,6 +59,7 @@ class RedshiftServiceTest {
         snapshotDumpBackend = mock(AccountAwareStorageBackend.class);
         parameterGroupBackend = mock(AccountAwareStorageBackend.class);
         subnetGroupBackend = mock(AccountAwareStorageBackend.class);
+        snapshotCopyGrantBackend = mock(AccountAwareStorageBackend.class);
         cm = mock(RedshiftContainerManager.class);
         proxyManager = mock(RedshiftProxyManager.class);
         dockerHostResolver = mock(DockerHostResolver.class);
@@ -81,6 +84,7 @@ class RedshiftServiceTest {
         when(sf.<Snapshot>create(eq("redshift"), eq("redshift-snapshots.json"), any())).thenReturn(snapshotBackend);
         when(sf.<ClusterParameterGroup>create(eq("redshift"), eq("redshift-parameter-groups.json"), any())).thenReturn(parameterGroupBackend);
         when(sf.<ClusterSubnetGroup>create(eq("redshift"), eq("redshift-subnet-groups.json"), any())).thenReturn(subnetGroupBackend);
+        when(sf.<SnapshotCopyGrant>create(eq("redshift"), eq("redshift-snapshot-copy-grants.json"), any())).thenReturn(snapshotCopyGrantBackend);
         when(clusterBackend.accountId()).thenReturn("111111111111");
 
         regionResolver = new RegionResolver("us-east-1", "111111111111");
@@ -1095,6 +1099,110 @@ class RedshiftServiceTest {
         when(subnetGroupBackend.get("missing")).thenReturn(Optional.empty());
 
         assertThrows(AwsException.class, () -> service.deleteClusterSubnetGroup("missing"));
+    }
+
+    @Test
+    void testCreateSnapshotCopyGrant() {
+        when(snapshotCopyGrantBackend.get("my-grant")).thenReturn(Optional.empty());
+
+        SnapshotCopyGrant grant = service.createSnapshotCopyGrant("my-grant", "key-abc", Map.of());
+
+        assertEquals("my-grant", grant.getSnapshotCopyGrantName());
+        assertEquals("key-abc", grant.getKmsKeyId());
+        verify(snapshotCopyGrantBackend).put(eq("my-grant"), any(SnapshotCopyGrant.class));
+        verify(snapshotCopyGrantBackend).flush();
+    }
+
+    @Test
+    void testCreateSnapshotCopyGrantDefaultsKmsKeyId() {
+        when(snapshotCopyGrantBackend.get("my-grant")).thenReturn(Optional.empty());
+
+        SnapshotCopyGrant grant = service.createSnapshotCopyGrant("my-grant", null, Map.of());
+
+        assertEquals("arn:aws:kms:us-east-1:111111111111:alias/aws/redshift", grant.getKmsKeyId());
+    }
+
+    @Test
+    void testCreateSnapshotCopyGrantStoresTags() {
+        when(snapshotCopyGrantBackend.get("my-grant")).thenReturn(Optional.empty());
+
+        SnapshotCopyGrant grant = service.createSnapshotCopyGrant("my-grant", "key-abc", Map.of("env", "prod"));
+
+        assertEquals(Map.of("env", "prod"), grant.getTags());
+    }
+
+    @Test
+    void testCreateSnapshotCopyGrantAlreadyExists() {
+        when(snapshotCopyGrantBackend.get("existing")).thenReturn(Optional.of(new SnapshotCopyGrant()));
+
+        AwsException ex = assertThrows(AwsException.class, () ->
+                service.createSnapshotCopyGrant("existing", "key-abc", Map.of()));
+        assertEquals("SnapshotCopyGrantAlreadyExistsFault", ex.getErrorCode());
+        verify(snapshotCopyGrantBackend, never()).put(any(), any());
+    }
+
+    @Test
+    void testDescribeSnapshotCopyGrantsByName() {
+        SnapshotCopyGrant grant = new SnapshotCopyGrant("my-grant", "key-abc");
+        when(snapshotCopyGrantBackend.get("my-grant")).thenReturn(Optional.of(grant));
+
+        List<SnapshotCopyGrant> list = service.describeSnapshotCopyGrants("my-grant");
+
+        assertEquals(1, list.size());
+        assertEquals("my-grant", list.get(0).getSnapshotCopyGrantName());
+        verify(snapshotCopyGrantBackend, never()).scan(any());
+    }
+
+    @Test
+    void testDescribeSnapshotCopyGrantsReturnsAllWhenNameOmitted() {
+        when(snapshotCopyGrantBackend.scan(any())).thenReturn(List.of(
+                new SnapshotCopyGrant("grant-a", "key-a"),
+                new SnapshotCopyGrant("grant-b", "key-b")));
+
+        List<SnapshotCopyGrant> list = service.describeSnapshotCopyGrants(null);
+
+        assertEquals(2, list.size());
+    }
+
+    @Test
+    void testDescribeSnapshotCopyGrantsNotFound() {
+        when(snapshotCopyGrantBackend.get("missing")).thenReturn(Optional.empty());
+
+        AwsException ex = assertThrows(AwsException.class, () -> service.describeSnapshotCopyGrants("missing"));
+        assertEquals("SnapshotCopyGrantNotFoundFault", ex.getErrorCode());
+    }
+
+    @Test
+    void testDeleteSnapshotCopyGrant() {
+        SnapshotCopyGrant grant = new SnapshotCopyGrant("my-grant", "key-abc");
+        when(snapshotCopyGrantBackend.get("my-grant")).thenReturn(Optional.of(grant));
+
+        SnapshotCopyGrant deleted = service.deleteSnapshotCopyGrant("my-grant");
+
+        assertEquals("my-grant", deleted.getSnapshotCopyGrantName());
+        verify(snapshotCopyGrantBackend).delete("my-grant");
+        verify(snapshotCopyGrantBackend).flush();
+    }
+
+    @Test
+    void testDeleteSnapshotCopyGrantNotFound() {
+        when(snapshotCopyGrantBackend.get("missing")).thenReturn(Optional.empty());
+
+        AwsException ex = assertThrows(AwsException.class, () -> service.deleteSnapshotCopyGrant("missing"));
+        assertEquals("SnapshotCopyGrantNotFoundFault", ex.getErrorCode());
+        verify(snapshotCopyGrantBackend, never()).delete(any());
+    }
+
+    @Test
+    void testCreateTagsOnSnapshotCopyGrant() {
+        SnapshotCopyGrant grant = new SnapshotCopyGrant("my-grant", "key-abc");
+        when(snapshotCopyGrantBackend.get("my-grant")).thenReturn(Optional.of(grant));
+
+        service.createTags("arn:aws:redshift:us-east-1:111111111111:snapshotcopygrant:my-grant",
+                Map.of("env", "prod"));
+
+        assertEquals(Map.of("env", "prod"),
+                service.listTagsForResource("arn:aws:redshift:us-east-1:111111111111:snapshotcopygrant:my-grant"));
     }
 
     private static String extractResourceId(String arn) {


### PR DESCRIPTION
## Summary

Implements the Redshift **snapshot copy grant** lifecycle, which previously answered `InvalidAction`:

- `CreateSnapshotCopyGrant` — named grant with optional `KmsKeyId` (defaulted to the account's default key ARN when omitted) and `Tags` (accepting the real SDK's `Tags.Tag.N` form); duplicate names answer `SnapshotCopyGrantAlreadyExistsFault` (400).
- `DescribeSnapshotCopyGrants` — optional `SnapshotCopyGrantName` filter; missing name answers `SnapshotCopyGrantNotFoundFault` (404).
- `DeleteSnapshotCopyGrant` — removes the grant; missing name answers `SnapshotCopyGrantNotFoundFault` (404).

Follows the existing `ClusterSubnetGroup` idiom in `RedshiftQueryHandler`/`RedshiftService` (hand-rolled envelope and `test-req-id` RequestId, deliberately consistent with the file's 24 existing action arms). All three actions are registered in the unsigned-request fallback set, and the generated docs table is refreshed.

This unblocks Terraform's `aws_redshift_snapshot_copy_grant` and the cross-region snapshot examples in Gruntwork's terraform-aws-data-storage module.

## Type of change

- [ ] Bug fix (`fix:`)
- [x] New feature (`feat:`)
- [ ] Breaking change (`feat!:` or `fix!:`)
- [ ] Docs / chore

## AWS Compatibility

Wire protocol verified with AWS CLI 2.x against the Redshift Query API (2012-12-01): request parameter names captured from a real CLI invocation (including the `Tags.Tag.N` list form, not `Tags.member.N`), response element names and fault codes per the Redshift API reference. Before this change the operation answered `InvalidAction`; a standalone reproduction (create → describe → delete round trip) passes on this branch.

## Checklist

- [x] `./mvnw test` passes locally — modulo four pre-existing machine-local failures (`CustomDomainTlsIntegrationTest`, `IotMqttWebSocketProxyIntegrationTest`, order-dependent `MacieOrganizationIntegrationTest`, intermittent `RdsAwsIntegrationTest`) that reproduce identically on pristine `upstream/main` on this machine and pass in isolation
- [x] New or updated integration test added
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)

