### PR TITLE
feat(dms): add replication subnet group lifecycle and tagging

### DIFF
--- a/README.md
+++ b/README.md
@@ -236,7 +236,7 @@ Floci supports local emulation for application services, data services, eventing
 | API and identity | API Gateway REST, API Gateway v2, AppSync, Cognito, ACM, Route53, Route 53 Resolver, Cloud Map |
 | Containers and compute | ECS, EC2, Lightsail, EKS, MWAA, ECR, EFS, CodeBuild, CodeDeploy, CodePipeline, CodeGuru Reviewer, AWS Batch, Auto Scaling, Application Auto Scaling, Elastic Beanstalk, ELB v2, ELB Classic |
 | Data, analytics, and AI | Athena, Glue, Lake Formation, EMR, EMR Serverless, Redshift, Redshift Data API, Firehose, Managed Service for Apache Flink, OpenSearch, S3 Tables, S3 Vectors, Textract, Transcribe, Comprehend, Rekognition, Translate, Bedrock Runtime, Bedrock AgentCore |
-| Databases and caching | RDS, RDS Data API, Neptune, DocumentDB, MemoryDB, ElastiCache |
+| Databases and caching | RDS, RDS Data API, Neptune, DocumentDB, DMS, MemoryDB, ElastiCache |
 | Messaging and transfer | SES, Kinesis, MSK, Amazon MQ, Transfer Family, IoT Core, Amazon Connect |
 | Security and governance | AWS Network Firewall, AWS RAM, Service Quotas, WAF v2, GuardDuty, Amazon Inspector, CloudTrail, CloudFront, Resource Groups Tagging API, Resource Explorer 2, CloudHSM v2, Organizations, AWS Account Management, IAM Access Analyzer, IAM Identity Center (SSO Admin), Identity Store, Amazon Macie, Amazon Detective, Security Hub, Control Catalog, Control Tower, Service Catalog, AWS Marketplace |
 | Cost and billing | AWS Budgets, Pricing, Cost Explorer, Cost and Usage Reports, BCM Data Exports |

--- a/compatibility-tests/sdk-test-java/pom.xml
+++ b/compatibility-tests/sdk-test-java/pom.xml
@@ -223,6 +223,11 @@
             <groupId>software.amazon.awssdk</groupId>
             <artifactId>neptune</artifactId>
         </dependency>
+        <!-- DMS management client -->
+        <dependency>
+            <groupId>software.amazon.awssdk</groupId>
+            <artifactId>databasemigration</artifactId>
+        </dependency>
         <!-- EventBridge client -->
         <dependency>
             <groupId>software.amazon.awssdk</groupId>

--- a/compatibility-tests/sdk-test-java/src/main/java/com/floci/test/TestFixtures.java
+++ b/compatibility-tests/sdk-test-java/src/main/java/com/floci/test/TestFixtures.java
@@ -43,6 +43,7 @@ import software.amazon.awssdk.services.marketplaceagreement.MarketplaceAgreement
 import software.amazon.awssdk.services.marketplaceentitlement.MarketplaceEntitlementClient;
 import software.amazon.awssdk.services.inspector2.Inspector2Client;
 import software.amazon.awssdk.services.securityhub.SecurityHubClient;
+import software.amazon.awssdk.services.databasemigration.DatabaseMigrationClient;
 import software.amazon.awssdk.services.detective.DetectiveClient;
 import software.amazon.awssdk.services.rum.RumClient;
 import software.amazon.awssdk.services.resourceexplorer2.ResourceExplorer2Client;
@@ -900,6 +901,14 @@ public final class TestFixtures {
 
     public static RdsClient rdsClient() {
         return RdsClient.builder()
+                .endpointOverride(ENDPOINT)
+                .region(REGION)
+                .credentialsProvider(CREDENTIALS)
+                .build();
+    }
+
+    public static DatabaseMigrationClient databaseMigrationClient() {
+        return DatabaseMigrationClient.builder()
                 .endpointOverride(ENDPOINT)
                 .region(REGION)
                 .credentialsProvider(CREDENTIALS)

--- a/compatibility-tests/sdk-test-java/src/test/java/com/floci/test/DmsTest.java
+++ b/compatibility-tests/sdk-test-java/src/test/java/com/floci/test/DmsTest.java
@@ -1,0 +1,77 @@
+package com.floci.test;
+
+import org.junit.jupiter.api.Test;
+import software.amazon.awssdk.services.databasemigration.DatabaseMigrationClient;
+import software.amazon.awssdk.services.databasemigration.model.DatabaseMigrationException;
+import software.amazon.awssdk.services.databasemigration.model.ReplicationSubnetGroup;
+import software.amazon.awssdk.services.ec2.Ec2Client;
+import software.amazon.awssdk.services.ec2.model.Subnet;
+
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class DmsTest {
+
+    private static final String GROUP_ID = "sdk-compat-subnet-group";
+
+    @Test
+    void replicationSubnetGroupLifecycleUsesAwsSdkWireContract() {
+        List<Subnet> subnets = twoSubnetsInOneVpcAcrossZones();
+        List<String> subnetIds = subnets.stream().map(Subnet::subnetId).toList();
+
+        try (DatabaseMigrationClient dms = TestFixtures.databaseMigrationClient()) {
+            dms.createReplicationSubnetGroup(request -> request
+                    .replicationSubnetGroupIdentifier(GROUP_ID)
+                    .replicationSubnetGroupDescription("sdk compatibility suite")
+                    .subnetIds(subnetIds));
+            try {
+                List<ReplicationSubnetGroup> described = dms.describeReplicationSubnetGroups(request -> request
+                                .filters(filter -> filter.name("replication-subnet-group-id").values(GROUP_ID)))
+                        .replicationSubnetGroups();
+
+                assertEquals(1, described.size());
+                ReplicationSubnetGroup group = described.getFirst();
+                assertEquals(GROUP_ID, group.replicationSubnetGroupIdentifier());
+                assertEquals("Complete", group.subnetGroupStatus());
+                assertEquals(subnets.getFirst().vpcId(), group.vpcId());
+                assertFalse(group.subnets().isEmpty());
+                assertTrue(group.subnets().stream()
+                        .allMatch(subnet -> "Active".equals(subnet.subnetStatus())));
+            } finally {
+                dms.deleteReplicationSubnetGroup(request -> request.replicationSubnetGroupIdentifier(GROUP_ID));
+            }
+
+            DatabaseMigrationException deleted = assertThrows(DatabaseMigrationException.class,
+                    () -> dms.describeReplicationSubnetGroups(request -> request
+                            .filters(filter -> filter.name("replication-subnet-group-id").values(GROUP_ID))));
+            assertEquals("ResourceNotFoundFault", deleted.awsErrorDetails().errorCode());
+        }
+    }
+
+    /**
+     * DMS requires the group's subnets to share a VPC and to cover at least two Availability
+     * Zones, so pick a VPC that satisfies both rather than the first two subnets returned.
+     */
+    private static List<Subnet> twoSubnetsInOneVpcAcrossZones() {
+        try (Ec2Client ec2 = TestFixtures.ec2Client()) {
+            Map<String, Map<String, Subnet>> byVpcAndZone = new LinkedHashMap<>();
+            for (Subnet subnet : ec2.describeSubnets().subnets()) {
+                byVpcAndZone
+                        .computeIfAbsent(subnet.vpcId(), vpc -> new LinkedHashMap<>())
+                        .putIfAbsent(subnet.availabilityZone(), subnet);
+            }
+            return byVpcAndZone.values().stream()
+                    .filter(byZone -> byZone.size() >= 2)
+                    .map(byZone -> byZone.values().stream().limit(2).toList())
+                    .findFirst()
+                    .orElseThrow(() -> new IllegalStateException(
+                            "no VPC has subnets in two Availability Zones"));
+        }
+    }
+}

--- a/compatibility-tests/sdk-test-java/src/test/java/com/floci/test/DmsTest.java
+++ b/compatibility-tests/sdk-test-java/src/test/java/com/floci/test/DmsTest.java
@@ -4,12 +4,15 @@ import org.junit.jupiter.api.Test;
 import software.amazon.awssdk.services.databasemigration.DatabaseMigrationClient;
 import software.amazon.awssdk.services.databasemigration.model.DatabaseMigrationException;
 import software.amazon.awssdk.services.databasemigration.model.ReplicationSubnetGroup;
+import software.amazon.awssdk.services.databasemigration.model.Tag;
 import software.amazon.awssdk.services.ec2.Ec2Client;
 import software.amazon.awssdk.services.ec2.model.Subnet;
+import software.amazon.awssdk.services.sts.StsClient;
 
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.stream.Collectors;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
@@ -29,7 +32,8 @@ class DmsTest {
             dms.createReplicationSubnetGroup(request -> request
                     .replicationSubnetGroupIdentifier(GROUP_ID)
                     .replicationSubnetGroupDescription("sdk compatibility suite")
-                    .subnetIds(subnetIds));
+                    .subnetIds(subnetIds)
+                    .tags(tag -> tag.key("env").value("test")));
             try {
                 List<ReplicationSubnetGroup> described = dms.describeReplicationSubnetGroups(request -> request
                                 .filters(filter -> filter.name("replication-subnet-group-id").values(GROUP_ID)))
@@ -43,6 +47,15 @@ class DmsTest {
                 assertFalse(group.subnets().isEmpty());
                 assertTrue(group.subnets().stream()
                         .allMatch(subnet -> "Active".equals(subnet.subnetStatus())));
+                String arn = "arn:aws:dms:us-east-1:" + callerAccountId() + ":subgrp:" + GROUP_ID;
+                assertEquals(Map.of("env", "test"), tagsOf(dms, arn));
+
+                dms.addTagsToResource(request -> request.resourceArn(arn)
+                        .tags(tag -> tag.key("owner").value("data")));
+                assertEquals(Map.of("env", "test", "owner", "data"), tagsOf(dms, arn));
+
+                dms.removeTagsFromResource(request -> request.resourceArn(arn).tagKeys("env"));
+                assertEquals(Map.of("owner", "data"), tagsOf(dms, arn));
             } finally {
                 dms.deleteReplicationSubnetGroup(request -> request.replicationSubnetGroupIdentifier(GROUP_ID));
             }
@@ -52,6 +65,21 @@ class DmsTest {
                             .filters(filter -> filter.name("replication-subnet-group-id").values(GROUP_ID))));
             assertEquals("ResourceNotFoundFault", deleted.awsErrorDetails().errorCode());
         }
+    }
+
+    /**
+     * DMS does not return the subnet group's ARN, so the tagging calls need it built the way the
+     * Terraform provider builds it. Read the account from STS rather than hardcoding the default.
+     */
+    private static String callerAccountId() {
+        try (StsClient sts = TestFixtures.stsClient()) {
+            return sts.getCallerIdentity().account();
+        }
+    }
+
+    private static Map<String, String> tagsOf(DatabaseMigrationClient dms, String arn) {
+        return dms.listTagsForResource(request -> request.resourceArn(arn)).tagList().stream()
+                .collect(Collectors.toMap(Tag::key, Tag::value));
     }
 
     /**

--- a/docs/services/dms.md
+++ b/docs/services/dms.md
@@ -36,6 +36,11 @@ those subnets actually have.
 - `DescribeReplicationSubnetGroups` supports the `replication-subnet-group-id` filter.
   A filter naming a group that does not exist returns `ResourceNotFoundFault`, which is
   how Terraform detects a group deleted outside its state.
+- A member of the wrong JSON type returns `SerializationException`, as AWS does, rather than
+  being coerced. That covers a `Tags` entry whose `Value` is an object, a filter whose
+  `Values` is not a list, a non-string element in `ResourceArnList`, `SubnetIds` or
+  `TagKeys`, and a non-string identifier. An absent member is still a parameter error,
+  not a serialization one.
 - Groups are scoped per account and Region and persist through `StorageFactory`.
 
 ### Tagging

--- a/docs/services/dms.md
+++ b/docs/services/dms.md
@@ -1,0 +1,54 @@
+# AWS Database Migration Service (DMS)
+
+**Protocol:** AWS JSON 1.1  
+**Signing name:** `dms`
+
+Floci emulates the replication subnet group lifecycle, which is what
+`aws_dms_replication_subnet_group` needs to plan and apply. Subnets are resolved against
+the emulated EC2 service, so the VPC and Availability Zones a group reports are the ones
+those subnets actually have.
+
+## Supported Actions
+
+<!-- floci:actions:start -->
+| Action | Description |
+| --- | --- |
+| `CreateReplicationSubnetGroup` | Creates a replication subnet group from existing EC2 subnets. |
+| `DescribeReplicationSubnetGroups` | Lists replication subnet groups, optionally filtered by identifier. |
+| `DeleteReplicationSubnetGroup` | Deletes the specified replication subnet group. |
+<!-- floci:actions:end -->
+
+## Behaviour
+
+- The identifier is stored as a lowercase string, as AWS does, so a group created as
+  `MyGroup` is described and deleted as `mygroup`.
+- `ReplicationSubnetGroupIdentifier` must not be `default` and is limited to 255
+  alphanumeric characters, periods, underscores, or hyphens.
+- A group must cover at least two Availability Zones. Fewer returns
+  `ReplicationSubnetGroupDoesNotCoverEnoughAZs`, as AWS does.
+- Subnets must exist and must all belong to one VPC. Otherwise `InvalidSubnet`.
+- `SubnetGroupStatus` is immediately `Complete`, every subnet reports `Active`, and
+  `SupportedNetworkTypes` is `["IPV4"]`.
+- `DescribeReplicationSubnetGroups` supports the `replication-subnet-group-id` filter.
+  A filter naming a group that does not exist returns `ResourceNotFoundFault`, which is
+  how Terraform detects a group deleted outside its state.
+- Groups are scoped per account and Region and persist through `StorageFactory`.
+
+## Limitations
+
+- **Only the subnet group lifecycle is implemented.** Replication instances, endpoints,
+  and replication tasks return `UnknownOperationException`.
+- **No tagging actions.** `Tags` on `CreateReplicationSubnetGroup` are accepted and
+  ignored, and `AddTagsToResource`, `ListTagsForResource`, and `RemoveTagsFromResource`
+  are not implemented.
+- **No `ModifyReplicationSubnetGroup`.** A subnet change has to be a delete and recreate.
+- **`DescribeReplicationSubnetGroups` does not paginate.** `MaxRecords` and `Marker` are
+  ignored and every matching group is returned in one response, with no `Marker` set.
+
+See the [AWS DMS API Reference](https://docs.aws.amazon.com/dms/latest/APIReference/Welcome.html).
+
+## Configuration
+
+| Variable | Default | Description |
+|---|---|---|
+| `FLOCI_SERVICES_DMS_ENABLED` | `true` | Enable or disable DMS |

--- a/docs/services/dms.md
+++ b/docs/services/dms.md
@@ -30,8 +30,9 @@ those subnets actually have.
 - A group must cover at least two Availability Zones. Fewer returns
   `ReplicationSubnetGroupDoesNotCoverEnoughAZs`, as AWS does.
 - Subnets must exist and must all belong to one VPC. Otherwise `InvalidSubnet`.
-- `SubnetGroupStatus` is immediately `Complete`, every subnet reports `Active`, and
-  `SupportedNetworkTypes` is `["IPV4"]`.
+- `SubnetGroupStatus` is immediately `Complete`, every subnet reports `Active`,
+  `SupportedNetworkTypes` is `["IPV4"]`, and `IsReadOnly` is always `false`: a read-only
+  group is one DMS manages for a zero-ETL integration, which Floci does not emulate.
 - `DescribeReplicationSubnetGroups` supports the `replication-subnet-group-id` filter.
   A filter naming a group that does not exist returns `ResourceNotFoundFault`, which is
   how Terraform detects a group deleted outside its state.
@@ -52,8 +53,9 @@ back the same way.
   AWS documents it on.
 - Tag keys are 1 to 128 characters, values at most 256, and neither may start with `aws:`
   or `dms:`.
-- An ARN that is unparseable, names a different DMS resource type, names another account,
-  or names a group that does not exist returns `ResourceNotFoundFault`.
+- An ARN that is unparseable, names a different DMS resource type, names another account
+  or Region, or names a group that does not exist returns `ResourceNotFoundFault`. Tagging
+  is not a cross-account or cross-Region operation on AWS and is not one here either.
 - Deleting a group deletes its tags with it.
 
 ## Limitations

--- a/docs/services/dms.md
+++ b/docs/services/dms.md
@@ -16,6 +16,9 @@ those subnets actually have.
 | `CreateReplicationSubnetGroup` | Creates a replication subnet group from existing EC2 subnets. |
 | `DescribeReplicationSubnetGroups` | Lists replication subnet groups, optionally filtered by identifier. |
 | `DeleteReplicationSubnetGroup` | Deletes the specified replication subnet group. |
+| `ListTagsForResource` | Lists the tags on one or more DMS resource ARNs. |
+| `AddTagsToResource` | Merges tags into the resource, overwriting by key. |
+| `RemoveTagsFromResource` | Removes the named tag keys from the resource. |
 <!-- floci:actions:end -->
 
 ## Behaviour
@@ -34,13 +37,32 @@ those subnets actually have.
   how Terraform detects a group deleted outside its state.
 - Groups are scoped per account and Region and persist through `StorageFactory`.
 
+### Tagging
+
+`Tags` on `CreateReplicationSubnetGroup` are stored with the group, and the tagging trio
+works against the group's ARN, which is
+`arn:aws:dms:<region>:<account>:subgrp:<identifier>`. DMS does not return that ARN from
+`DescribeReplicationSubnetGroups`, so Terraform builds it client side and Floci parses it
+back the same way.
+
+- `AddTagsToResource` merges by key, so re-tagging an existing key overwrites its value.
+- `RemoveTagsFromResource` removes the named keys and ignores keys that are not present.
+- `ListTagsForResource` accepts either `ResourceArn` or `ResourceArnList`. Each returned
+  tag carries its `ResourceArn` only for the `ResourceArnList` form, which is the form
+  AWS documents it on.
+- Tag keys are 1 to 128 characters, values at most 256, and neither may start with `aws:`
+  or `dms:`.
+- An ARN that is unparseable, names a different DMS resource type, names another account,
+  or names a group that does not exist returns `ResourceNotFoundFault`.
+- Deleting a group deletes its tags with it.
+
 ## Limitations
 
 - **Only the subnet group lifecycle is implemented.** Replication instances, endpoints,
   and replication tasks return `UnknownOperationException`.
-- **No tagging actions.** `Tags` on `CreateReplicationSubnetGroup` are accepted and
-  ignored, and `AddTagsToResource`, `ListTagsForResource`, and `RemoveTagsFromResource`
-  are not implemented.
+- **Tagging covers replication subnet groups only.** The tagging trio is implemented, but
+  a `ResourceArn` naming a replication instance, endpoint, or task returns
+  `ResourceNotFoundFault` because Floci holds no such resource.
 - **No `ModifyReplicationSubnetGroup`.** A subnet change has to be a delete and recreate.
 - **`DescribeReplicationSubnetGroups` does not paginate.** `MaxRecords` and `Marker` are
   ignored and every matching group is returned in one response, with no `Marker` set.

--- a/docs/services/index.md
+++ b/docs/services/index.md
@@ -65,7 +65,7 @@ Operation counts are exact. For dispatch-table services (Query and JSON 1.1) eac
 | [Lake Formation](lakeformation.md) | `POST /<Action>` | REST JSON | 16 |
 | [Neptune](neptune.md) | `POST /` with `Action=` param + Gremlin TCP proxy | Query + WebSocket | 14 |
 | [DocumentDB](docdb.md) | `POST /` with `Action=` param + MongoDB container | Query + MongoDB wire | 8 |
-| [DMS](dms.md) | `POST /` + `X-Amz-Target: AmazonDMSv20160101.*` | JSON 1.1 | 3 |
+| [DMS](dms.md) | `POST /` + `X-Amz-Target: AmazonDMSv20160101.*` | JSON 1.1 | 6 |
 | [Redshift](redshift.md) | `POST /` with `Action=` param + PostgreSQL container | Query + PostgreSQL wire | 21 |
 | [Redshift Data API](redshift-data.md) | `POST /` + `X-Amz-Target: RedshiftData.*` | JSON 1.1 | 11 |
 | [EMR](emr.md) | `POST /` + `X-Amz-Target: ElasticMapReduce.*` | JSON 1.1 | 24 |

--- a/docs/services/index.md
+++ b/docs/services/index.md
@@ -65,6 +65,7 @@ Operation counts are exact. For dispatch-table services (Query and JSON 1.1) eac
 | [Lake Formation](lakeformation.md) | `POST /<Action>` | REST JSON | 16 |
 | [Neptune](neptune.md) | `POST /` with `Action=` param + Gremlin TCP proxy | Query + WebSocket | 14 |
 | [DocumentDB](docdb.md) | `POST /` with `Action=` param + MongoDB container | Query + MongoDB wire | 8 |
+| [DMS](dms.md) | `POST /` + `X-Amz-Target: AmazonDMSv20160101.*` | JSON 1.1 | 3 |
 | [Redshift](redshift.md) | `POST /` with `Action=` param + PostgreSQL container | Query + PostgreSQL wire | 21 |
 | [Redshift Data API](redshift-data.md) | `POST /` + `X-Amz-Target: RedshiftData.*` | JSON 1.1 | 11 |
 | [EMR](emr.md) | `POST /` + `X-Amz-Target: ElasticMapReduce.*` | JSON 1.1 | 24 |

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -142,6 +142,7 @@ nav:
     - Lake Formation: services/lakeformation.md
     - Neptune: services/neptune.md
     - DocumentDB: services/docdb.md
+    - DMS: services/dms.md
     - Athena: services/athena.md
     - Redshift: services/redshift.md
     - Redshift Data API: services/redshift-data.md

--- a/src/main/java/io/github/hectorvent/floci/config/EmulatorConfig.java
+++ b/src/main/java/io/github/hectorvent/floci/config/EmulatorConfig.java
@@ -745,6 +745,12 @@ public interface EmulatorConfig {
         EfsServiceConfig efs();
         CodeGuruReviewerServiceConfig codegurureviewer();
         MarketplaceServiceConfig marketplace();
+        DmsServiceConfig dms();
+    }
+
+    interface DmsServiceConfig {
+        @WithDefault("true")
+        boolean enabled();
     }
 
     interface ConnectServiceConfig {

--- a/src/main/java/io/github/hectorvent/floci/core/common/AwsJson11Controller.java
+++ b/src/main/java/io/github/hectorvent/floci/core/common/AwsJson11Controller.java
@@ -12,6 +12,7 @@ import io.github.hectorvent.floci.services.cloudhsmv2.CloudHsmV2JsonHandler;
 import io.github.hectorvent.floci.services.codebuild.CodeBuildJsonHandler;
 import io.github.hectorvent.floci.services.codedeploy.CodeDeployJsonHandler;
 import io.github.hectorvent.floci.services.codepipeline.CodePipelineJsonHandler;
+import io.github.hectorvent.floci.services.dms.DmsJsonHandler;
 import io.github.hectorvent.floci.services.ecr.EcrJsonHandler;
 import io.github.hectorvent.floci.services.transfer.TransferHandler;
 import io.github.hectorvent.floci.services.ecs.EcsJsonHandler;
@@ -133,6 +134,7 @@ public class AwsJson11Controller {
     private final BudgetsJsonHandler budgetsJsonHandler;
     private final ServiceQuotasJsonHandler serviceQuotasJsonHandler;
     private final MarketplaceEntitlementController marketplaceEntitlementController;
+    private final DmsJsonHandler dmsJsonHandler;
 
     @Inject
     public AwsJson11Controller(ObjectMapper objectMapper, ResolvedServiceCatalog catalog,
@@ -183,7 +185,8 @@ public class AwsJson11Controller {
                                IdentityStoreJsonHandler identityStoreJsonHandler,
                                BudgetsJsonHandler budgetsJsonHandler,
                                ServiceQuotasJsonHandler serviceQuotasJsonHandler,
-                               MarketplaceEntitlementController marketplaceEntitlementController) {
+                               MarketplaceEntitlementController marketplaceEntitlementController,
+                               DmsJsonHandler dmsJsonHandler) {
         this.objectMapper = objectMapper;
         this.strictBodyReader = objectMapper.reader().with(DeserializationFeature.FAIL_ON_TRAILING_TOKENS);
         this.catalog = catalog;
@@ -239,6 +242,7 @@ public class AwsJson11Controller {
         this.budgetsJsonHandler = budgetsJsonHandler;
         this.serviceQuotasJsonHandler = serviceQuotasJsonHandler;
         this.marketplaceEntitlementController = marketplaceEntitlementController;
+        this.dmsJsonHandler = dmsJsonHandler;
     }
 
     @POST
@@ -332,6 +336,7 @@ public class AwsJson11Controller {
                 case "servicequotas" -> serviceQuotasJsonHandler.handle(
                         action, request, region, regionResolver.getAccountId());
                 case "marketplace" -> marketplaceEntitlementController.handle(action, request, region);
+                case "dms" -> dmsJsonHandler.handle(action, request, region);
                 default -> null;
             };
             // catalog.matchTarget is protocol-agnostic: a JSON 1.0 target

--- a/src/main/java/io/github/hectorvent/floci/core/common/ResolvedServiceCatalog.java
+++ b/src/main/java/io/github/hectorvent/floci/core/common/ResolvedServiceCatalog.java
@@ -646,7 +646,11 @@ public class ResolvedServiceCatalog {
                         "marketplace", config.storage().mode(), 5000L, null, ServiceProtocol.REST_JSON,
                         protocols(ServiceProtocol.REST_JSON, ServiceProtocol.JSON, ServiceProtocol.CBOR),
                         Set.of("AWSMPCommerceService_v20200301.", "AWSMPEntitlementService."), Set.of("aws-marketplace"), Set.of("AWS Marketplace Entitlement Service"),
-                        Set.of(MarketplaceCatalogController.class))
+                        Set.of(MarketplaceCatalogController.class)),
+                descriptor("dms", "dms", config.services().dms().enabled(), true,
+                        "dms", config.storage().mode(), 5000L, null, ServiceProtocol.JSON,
+                        protocols(ServiceProtocol.JSON),
+                        Set.of("AmazonDMSv20160101."), Set.of("dms"), Set.of(), Set.of())
         ));
     }
 

--- a/src/main/java/io/github/hectorvent/floci/services/dms/DmsJsonHandler.java
+++ b/src/main/java/io/github/hectorvent/floci/services/dms/DmsJsonHandler.java
@@ -1,0 +1,67 @@
+package io.github.hectorvent.floci.services.dms;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ArrayNode;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import io.github.hectorvent.floci.services.dms.model.ReplicationSubnetGroup;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
+import jakarta.ws.rs.core.Response;
+
+import java.util.List;
+
+@ApplicationScoped
+public class DmsJsonHandler {
+
+    private final DmsService service;
+    private final ObjectMapper objectMapper;
+
+    @Inject
+    public DmsJsonHandler(DmsService service, ObjectMapper objectMapper) {
+        this.service = service;
+        this.objectMapper = objectMapper;
+    }
+
+    public Response handle(String action, JsonNode request, String region) {
+        return switch (action) {
+            case "CreateReplicationSubnetGroup" -> {
+                ObjectNode response = objectMapper.createObjectNode();
+                response.set("ReplicationSubnetGroup",
+                        subnetGroup(service.createReplicationSubnetGroup(request, region)));
+                yield Response.ok(response).build();
+            }
+            case "DescribeReplicationSubnetGroups" -> {
+                List<ReplicationSubnetGroup> groups = service.describeReplicationSubnetGroups(request, region);
+                ObjectNode response = objectMapper.createObjectNode();
+                ArrayNode items = response.putArray("ReplicationSubnetGroups");
+                groups.forEach(group -> items.add(subnetGroup(group)));
+                yield Response.ok(response).build();
+            }
+            case "DeleteReplicationSubnetGroup" -> {
+                service.deleteReplicationSubnetGroup(request, region);
+                yield Response.ok(objectMapper.createObjectNode()).build();
+            }
+            default -> null;
+        };
+    }
+
+    private ObjectNode subnetGroup(ReplicationSubnetGroup group) {
+        ObjectNode node = objectMapper.createObjectNode();
+        node.put("ReplicationSubnetGroupIdentifier", group.getReplicationSubnetGroupIdentifier());
+        node.put("ReplicationSubnetGroupDescription", group.getReplicationSubnetGroupDescription());
+        node.put("VpcId", group.getVpcId());
+        node.put("SubnetGroupStatus", group.getSubnetGroupStatus());
+        ArrayNode subnets = node.putArray("Subnets");
+        group.getSubnetIds().forEach(subnetId -> {
+            ObjectNode subnet = subnets.addObject();
+            subnet.put("SubnetIdentifier", subnetId);
+            subnet.putObject("SubnetAvailabilityZone")
+                    .put("Name", group.getSubnetAvailabilityZones().get(subnetId));
+            subnet.put("SubnetStatus", "Active");
+        });
+        ArrayNode networkTypes = node.putArray("SupportedNetworkTypes");
+        group.getSupportedNetworkTypes().forEach(networkTypes::add);
+        return node;
+    }
+}

--- a/src/main/java/io/github/hectorvent/floci/services/dms/DmsJsonHandler.java
+++ b/src/main/java/io/github/hectorvent/floci/services/dms/DmsJsonHandler.java
@@ -87,6 +87,9 @@ public class DmsJsonHandler {
         });
         ArrayNode networkTypes = node.putArray("SupportedNetworkTypes");
         group.getSupportedNetworkTypes().forEach(networkTypes::add);
+        // Always false: a read-only group is one DMS manages for a zero-ETL integration, which
+        // Floci does not emulate, so every group here is caller-owned and modifiable.
+        node.put("IsReadOnly", false);
         return node;
     }
 }

--- a/src/main/java/io/github/hectorvent/floci/services/dms/DmsJsonHandler.java
+++ b/src/main/java/io/github/hectorvent/floci/services/dms/DmsJsonHandler.java
@@ -5,6 +5,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ArrayNode;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import io.github.hectorvent.floci.services.dms.model.ReplicationSubnetGroup;
+import io.github.hectorvent.floci.services.dms.model.ResourceTag;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
 import jakarta.ws.rs.core.Response;
@@ -42,8 +43,32 @@ public class DmsJsonHandler {
                 service.deleteReplicationSubnetGroup(request, region);
                 yield Response.ok(objectMapper.createObjectNode()).build();
             }
+            case "ListTagsForResource" -> {
+                ObjectNode response = objectMapper.createObjectNode();
+                ArrayNode tagList = response.putArray("TagList");
+                service.listTagsForResource(request, region).forEach(tag -> tagList.add(tagNode(tag)));
+                yield Response.ok(response).build();
+            }
+            case "AddTagsToResource" -> {
+                service.addTagsToResource(request, region);
+                yield Response.ok(objectMapper.createObjectNode()).build();
+            }
+            case "RemoveTagsFromResource" -> {
+                service.removeTagsFromResource(request, region);
+                yield Response.ok(objectMapper.createObjectNode()).build();
+            }
             default -> null;
         };
+    }
+
+    private ObjectNode tagNode(ResourceTag tag) {
+        ObjectNode node = objectMapper.createObjectNode();
+        node.put("Key", tag.key());
+        node.put("Value", tag.value());
+        if (tag.resourceArn() != null) {
+            node.put("ResourceArn", tag.resourceArn());
+        }
+        return node;
     }
 
     private ObjectNode subnetGroup(ReplicationSubnetGroup group) {

--- a/src/main/java/io/github/hectorvent/floci/services/dms/DmsService.java
+++ b/src/main/java/io/github/hectorvent/floci/services/dms/DmsService.java
@@ -2,11 +2,14 @@ package io.github.hectorvent.floci.services.dms;
 
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.JsonNode;
+import io.github.hectorvent.floci.core.common.AwsArnUtils;
 import io.github.hectorvent.floci.core.common.AwsException;
+import io.github.hectorvent.floci.core.common.RegionResolver;
 import io.github.hectorvent.floci.core.common.Resettable;
 import io.github.hectorvent.floci.core.storage.AccountAwareStorageBackend;
 import io.github.hectorvent.floci.core.storage.StorageFactory;
 import io.github.hectorvent.floci.services.dms.model.ReplicationSubnetGroup;
+import io.github.hectorvent.floci.services.dms.model.ResourceTag;
 import io.github.hectorvent.floci.services.ec2.Ec2Service;
 import io.github.hectorvent.floci.services.ec2.model.Subnet;
 import jakarta.enterprise.context.ApplicationScoped;
@@ -20,6 +23,7 @@ import java.util.Locale;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
+import java.util.function.Consumer;
 import java.util.regex.Pattern;
 
 @ApplicationScoped
@@ -28,15 +32,19 @@ public class DmsService implements Resettable {
     private static final Pattern SUBNET_GROUP_IDENTIFIER = Pattern.compile("[A-Za-z0-9._-]+");
     private static final String SUBNET_GROUP_ID_FILTER = "replication-subnet-group-id";
     private static final int MINIMUM_AVAILABILITY_ZONES = 2;
+    private static final String SUBNET_GROUP_ARN_RESOURCE_TYPE = "subgrp";
+    private static final Set<String> RESERVED_TAG_PREFIXES = Set.of("aws:", "dms:");
 
     private final AccountAwareStorageBackend<ReplicationSubnetGroup> subnetGroups;
     private final Ec2Service ec2Service;
+    private final RegionResolver regionResolver;
 
     @Inject
-    public DmsService(StorageFactory storageFactory, Ec2Service ec2Service) {
+    public DmsService(StorageFactory storageFactory, Ec2Service ec2Service, RegionResolver regionResolver) {
         this.subnetGroups = storageFactory.create("dms", "dms-replication-subnet-groups.json",
                 new TypeReference<Map<String, ReplicationSubnetGroup>>() {});
         this.ec2Service = ec2Service;
+        this.regionResolver = regionResolver;
     }
 
     public synchronized ReplicationSubnetGroup createReplicationSubnetGroup(JsonNode request, String region) {
@@ -53,6 +61,7 @@ public class DmsService implements Resettable {
         }
 
         ReplicationSubnetGroup group = buildSubnetGroup(identifier, description, subnetIds, region);
+        group.setTags(readTags(request.get("Tags")));
         subnetGroups.put(storageKey(region, identifier), group);
         return group;
     }
@@ -77,6 +86,43 @@ public class DmsService implements Resettable {
             throw notFound(identifier);
         }
         subnetGroups.delete(key);
+    }
+
+    public List<ResourceTag> listTagsForResource(JsonNode request, String region) {
+        List<String> arnList = arnList(request);
+        if (!arnList.isEmpty()) {
+            List<ResourceTag> tags = new ArrayList<>();
+            for (String arn : arnList) {
+                resolveByArn(arn, region).getTags()
+                        .forEach((key, value) -> tags.add(new ResourceTag(arn, key, value)));
+            }
+            return tags;
+        }
+        String resourceArn = requireResourceArn(request);
+        return resolveByArn(resourceArn, region).getTags().entrySet().stream()
+                .map(entry -> new ResourceTag(null, entry.getKey(), entry.getValue()))
+                .toList();
+    }
+
+    public synchronized void addTagsToResource(JsonNode request, String region) {
+        String resourceArn = requireResourceArn(request);
+        JsonNode tagsNode = request == null ? null : request.get("Tags");
+        if (tagsNode == null || !tagsNode.isArray()) {
+            throw invalidParameter("The parameter Tags must be provided.");
+        }
+        Map<String, String> added = readTags(tagsNode);
+        updateTags(resourceArn, region, tags -> tags.putAll(added));
+    }
+
+    public synchronized void removeTagsFromResource(JsonNode request, String region) {
+        String resourceArn = requireResourceArn(request);
+        JsonNode keysNode = request == null ? null : request.get("TagKeys");
+        if (keysNode == null || !keysNode.isArray()) {
+            throw invalidParameter("The parameter TagKeys must be provided.");
+        }
+        List<String> keys = new ArrayList<>();
+        keysNode.forEach(key -> keys.add(key.asText()));
+        updateTags(resourceArn, region, tags -> keys.forEach(tags::remove));
     }
 
     @Override
@@ -203,5 +249,99 @@ public class DmsService implements Resettable {
 
     private static String storageKey(String region, String identifier) {
         return region + "::" + identifier;
+    }
+
+    private void updateTags(String resourceArn, String region,
+                            Consumer<Map<String, String>> mutation) {
+        String key = subnetGroupKeyForArn(resourceArn, region);
+        ReplicationSubnetGroup group = subnetGroups.get(key).orElseThrow(() -> notFoundForArn(resourceArn));
+        Map<String, String> tags = new LinkedHashMap<>(group.getTags());
+        mutation.accept(tags);
+        group.setTags(tags);
+        subnetGroups.put(key, group);
+    }
+
+    private ReplicationSubnetGroup resolveByArn(String resourceArn, String region) {
+        return subnetGroups.get(subnetGroupKeyForArn(resourceArn, region))
+                .orElseThrow(() -> notFoundForArn(resourceArn));
+    }
+
+    /**
+     * DescribeReplicationSubnetGroups does not return an ARN, so Terraform builds
+     * {@code arn:aws:dms:<region>:<account>:subgrp:<id>} itself and tags against that. Anything
+     * that is not such an ARN names no DMS resource Floci holds, which is a ResourceNotFoundFault
+     * rather than a parameter error. An ARN naming another account is treated the same way:
+     * storage is scoped to the caller, so resolving it would otherwise reach the caller's own
+     * group of that name.
+     */
+    private String subnetGroupKeyForArn(String resourceArn, String fallbackRegion) {
+        AwsArnUtils.Arn arn;
+        try {
+            arn = AwsArnUtils.parse(resourceArn);
+        } catch (IllegalArgumentException e) {
+            throw notFoundForArn(resourceArn);
+        }
+        String[] resource = arn.resource().split(":", 2);
+        if (!"dms".equals(arn.service()) || resource.length != 2
+                || !SUBNET_GROUP_ARN_RESOURCE_TYPE.equals(resource[0]) || resource[1].isBlank()) {
+            throw notFoundForArn(resourceArn);
+        }
+        if (!arn.accountId().isBlank() && !arn.accountId().equals(regionResolver.getAccountId())) {
+            throw notFoundForArn(resourceArn);
+        }
+        String region = arn.region() == null || arn.region().isBlank() ? fallbackRegion : arn.region();
+        return storageKey(region, resource[1].toLowerCase(Locale.ROOT));
+    }
+
+    private static List<String> arnList(JsonNode request) {
+        JsonNode node = request == null ? null : request.get("ResourceArnList");
+        if (node == null || !node.isArray() || node.isEmpty()) {
+            return List.of();
+        }
+        List<String> arns = new ArrayList<>();
+        node.forEach(element -> arns.add(element.asText()));
+        return arns;
+    }
+
+    private static String requireResourceArn(JsonNode request) {
+        String resourceArn = text(request, "ResourceArn");
+        if (resourceArn == null || resourceArn.isBlank()) {
+            throw invalidParameter("The parameter ResourceArn must be provided and must not be blank.");
+        }
+        return resourceArn;
+    }
+
+    private static Map<String, String> readTags(JsonNode node) {
+        Map<String, String> tags = new LinkedHashMap<>();
+        if (node == null || node.isNull()) {
+            return tags;
+        }
+        if (!node.isArray()) {
+            throw invalidParameter("Tags must be a list of Key and Value pairs.");
+        }
+        node.forEach(element -> {
+            String key = text(element, "Key");
+            JsonNode value = element.get("Value");
+            if (key == null || key.isEmpty() || key.length() > 128 || isReserved(key)) {
+                throw invalidParameter("Tag keys must be 1-128 characters and must not start with"
+                        + " \"aws:\" or \"dms:\".");
+            }
+            String tagValue = value == null || value.isNull() ? "" : value.asText();
+            if (tagValue.length() > 256 || isReserved(tagValue)) {
+                throw invalidParameter("Tag values must be at most 256 characters and must not start"
+                        + " with \"aws:\" or \"dms:\".");
+            }
+            tags.put(key, tagValue);
+        });
+        return tags;
+    }
+
+    private static boolean isReserved(String value) {
+        return RESERVED_TAG_PREFIXES.stream().anyMatch(value::startsWith);
+    }
+
+    private static AwsException notFoundForArn(String resourceArn) {
+        return new AwsException("ResourceNotFoundFault",
+                "Resource " + resourceArn + " not found.", 400);
     }
 }

--- a/src/main/java/io/github/hectorvent/floci/services/dms/DmsService.java
+++ b/src/main/java/io/github/hectorvent/floci/services/dms/DmsService.java
@@ -146,7 +146,12 @@ public class DmsService implements Resettable {
         // that follows a create returns the same subnet ordering every time.
         Map<String, String> availabilityZones = new LinkedHashMap<>();
         for (String subnetId : requested) {
-            availabilityZones.put(subnetId, resolved.get(subnetId).getAvailabilityZone());
+            String availabilityZone = resolved.get(subnetId).getAvailabilityZone();
+            if (availabilityZone == null) {
+                throw new AwsException("InvalidSubnet",
+                        "Subnet " + subnetId + " has no Availability Zone.", 400);
+            }
+            availabilityZones.put(subnetId, availabilityZone);
         }
 
         String vpcId = resolved.get(requested.getFirst()).getVpcId();
@@ -270,11 +275,14 @@ public class DmsService implements Resettable {
      * DescribeReplicationSubnetGroups does not return an ARN, so Terraform builds
      * {@code arn:aws:dms:<region>:<account>:subgrp:<id>} itself and tags against that. Anything
      * that is not such an ARN names no DMS resource Floci holds, which is a ResourceNotFoundFault
-     * rather than a parameter error. An ARN naming another account is treated the same way:
-     * storage is scoped to the caller, so resolving it would otherwise reach the caller's own
-     * group of that name.
+     * rather than a parameter error.
+     *
+     * <p>An ARN naming another account or another Region is treated the same way. Tagging is not a
+     * cross-account or cross-Region operation on AWS, and here it cannot be one either: storage is
+     * scoped to the caller's account and keyed by the caller's Region, so honouring a foreign ARN
+     * would silently reach the caller's own group of that name instead of the one named.
      */
-    private String subnetGroupKeyForArn(String resourceArn, String fallbackRegion) {
+    private String subnetGroupKeyForArn(String resourceArn, String callerRegion) {
         AwsArnUtils.Arn arn;
         try {
             arn = AwsArnUtils.parse(resourceArn);
@@ -289,8 +297,10 @@ public class DmsService implements Resettable {
         if (!arn.accountId().isBlank() && !arn.accountId().equals(regionResolver.getAccountId())) {
             throw notFoundForArn(resourceArn);
         }
-        String region = arn.region() == null || arn.region().isBlank() ? fallbackRegion : arn.region();
-        return storageKey(region, resource[1].toLowerCase(Locale.ROOT));
+        if (arn.region() != null && !arn.region().isBlank() && !arn.region().equals(callerRegion)) {
+            throw notFoundForArn(resourceArn);
+        }
+        return storageKey(callerRegion, resource[1].toLowerCase(Locale.ROOT));
     }
 
     private static List<String> arnList(JsonNode request) {

--- a/src/main/java/io/github/hectorvent/floci/services/dms/DmsService.java
+++ b/src/main/java/io/github/hectorvent/floci/services/dms/DmsService.java
@@ -107,7 +107,7 @@ public class DmsService implements Resettable {
     public synchronized void addTagsToResource(JsonNode request, String region) {
         String resourceArn = requireResourceArn(request);
         JsonNode tagsNode = request == null ? null : request.get("Tags");
-        if (tagsNode == null || !tagsNode.isArray()) {
+        if (tagsNode == null || tagsNode.isNull()) {
             throw invalidParameter("The parameter Tags must be provided.");
         }
         Map<String, String> added = readTags(tagsNode);
@@ -117,11 +117,10 @@ public class DmsService implements Resettable {
     public synchronized void removeTagsFromResource(JsonNode request, String region) {
         String resourceArn = requireResourceArn(request);
         JsonNode keysNode = request == null ? null : request.get("TagKeys");
-        if (keysNode == null || !keysNode.isArray()) {
+        if (keysNode == null || keysNode.isNull()) {
             throw invalidParameter("The parameter TagKeys must be provided.");
         }
-        List<String> keys = new ArrayList<>();
-        keysNode.forEach(key -> keys.add(key.asText()));
+        List<String> keys = stringList(keysNode, "TagKeys");
         updateTags(resourceArn, region, tags -> keys.forEach(tags::remove));
     }
 
@@ -205,35 +204,51 @@ public class DmsService implements Resettable {
 
     private static List<String> requireSubnetIds(JsonNode request) {
         JsonNode node = request == null ? null : request.get("SubnetIds");
-        if (node == null || !node.isArray() || node.isEmpty()) {
+        if (node == null || node.isNull()) {
             throw invalidParameter("The parameter SubnetIds must be provided and must not be empty.");
         }
-        List<String> subnetIds = new ArrayList<>();
-        node.forEach(element -> {
-            if (!element.isTextual() || element.textValue().isBlank()) {
-                throw invalidParameter("The parameter SubnetIds must contain subnet identifiers.");
-            }
-            subnetIds.add(element.textValue());
-        });
+        if (!node.isArray()) {
+            throw serialization("SubnetIds must be a list of strings.");
+        }
+        if (node.isEmpty()) {
+            throw invalidParameter("The parameter SubnetIds must be provided and must not be empty.");
+        }
+        List<String> subnetIds = stringList(node, "SubnetIds");
+        if (subnetIds.stream().anyMatch(String::isBlank)) {
+            throw invalidParameter("The parameter SubnetIds must contain subnet identifiers.");
+        }
         return subnetIds;
     }
 
     private static List<String> identifierFilters(JsonNode request) {
         JsonNode filters = request == null ? null : request.get("Filters");
-        if (filters == null || !filters.isArray()) {
+        if (filters == null || filters.isNull()) {
             return List.of();
+        }
+        if (!filters.isArray()) {
+            throw serialization("Filters must be a list of Name and Values pairs.");
         }
         List<String> identifiers = new ArrayList<>();
         for (JsonNode filter : filters) {
+            if (!filter.isObject()) {
+                throw serialization("Filters must be a list of Name and Values pairs.");
+            }
             String name = text(filter, "Name");
             if (!SUBNET_GROUP_ID_FILTER.equals(name)) {
                 throw invalidParameter("Invalid filter: " + name + ".");
             }
             JsonNode values = filter.get("Values");
-            if (values == null || !values.isArray() || values.isEmpty()) {
+            if (values == null || values.isNull()) {
                 throw invalidParameter("The filter " + SUBNET_GROUP_ID_FILTER + " must have values.");
             }
-            values.forEach(value -> identifiers.add(value.asText().toLowerCase(Locale.ROOT)));
+            if (!values.isArray()) {
+                throw serialization("Filter Values must be a list of strings.");
+            }
+            if (values.isEmpty()) {
+                throw invalidParameter("The filter " + SUBNET_GROUP_ID_FILTER + " must have values.");
+            }
+            stringList(values, "Filter Values")
+                    .forEach(value -> identifiers.add(value.toLowerCase(Locale.ROOT)));
         }
         return identifiers;
     }
@@ -247,9 +262,39 @@ public class DmsService implements Resettable {
         return new AwsException("InvalidParameterValueException", message, 400);
     }
 
+    /**
+     * Reads a string member. Absent or explicitly null yields null; a member of any other JSON type
+     * is a SerializationException, which is what AWS returns when a json-1.1 member will not
+     * deserialize to its modelled type. Coercing it instead (asText on an object yields "") would
+     * silently store a wrong value.
+     */
     private static String text(JsonNode request, String field) {
         JsonNode node = request == null ? null : request.get(field);
-        return node != null && node.isTextual() ? node.textValue() : null;
+        if (node == null || node.isNull()) {
+            return null;
+        }
+        if (!node.isTextual()) {
+            throw serialization(field + " must be a string.");
+        }
+        return node.textValue();
+    }
+
+    private static List<String> stringList(JsonNode array, String field) {
+        if (!array.isArray()) {
+            throw serialization(field + " must be a list of strings.");
+        }
+        List<String> values = new ArrayList<>();
+        for (JsonNode element : array) {
+            if (!element.isTextual()) {
+                throw serialization(field + " must be a list of strings.");
+            }
+            values.add(element.textValue());
+        }
+        return values;
+    }
+
+    private static AwsException serialization(String message) {
+        return new AwsException("SerializationException", message, 400);
     }
 
     private static String storageKey(String region, String identifier) {
@@ -305,12 +350,13 @@ public class DmsService implements Resettable {
 
     private static List<String> arnList(JsonNode request) {
         JsonNode node = request == null ? null : request.get("ResourceArnList");
-        if (node == null || !node.isArray() || node.isEmpty()) {
+        if (node == null || node.isNull()) {
             return List.of();
         }
-        List<String> arns = new ArrayList<>();
-        node.forEach(element -> arns.add(element.asText()));
-        return arns;
+        if (!node.isArray()) {
+            throw serialization("ResourceArnList must be a list of strings.");
+        }
+        return stringList(node, "ResourceArnList");
     }
 
     private static String requireResourceArn(JsonNode request) {
@@ -327,22 +373,25 @@ public class DmsService implements Resettable {
             return tags;
         }
         if (!node.isArray()) {
-            throw invalidParameter("Tags must be a list of Key and Value pairs.");
+            throw serialization("Tags must be a list of Key and Value pairs.");
         }
-        node.forEach(element -> {
+        for (JsonNode element : node) {
+            if (!element.isObject()) {
+                throw serialization("Tags must be a list of Key and Value pairs.");
+            }
             String key = text(element, "Key");
-            JsonNode value = element.get("Value");
+            String value = text(element, "Value");
             if (key == null || key.isEmpty() || key.length() > 128 || isReserved(key)) {
                 throw invalidParameter("Tag keys must be 1-128 characters and must not start with"
                         + " \"aws:\" or \"dms:\".");
             }
-            String tagValue = value == null || value.isNull() ? "" : value.asText();
+            String tagValue = value == null ? "" : value;
             if (tagValue.length() > 256 || isReserved(tagValue)) {
                 throw invalidParameter("Tag values must be at most 256 characters and must not start"
                         + " with \"aws:\" or \"dms:\".");
             }
             tags.put(key, tagValue);
-        });
+        }
         return tags;
     }
 

--- a/src/main/java/io/github/hectorvent/floci/services/dms/DmsService.java
+++ b/src/main/java/io/github/hectorvent/floci/services/dms/DmsService.java
@@ -1,0 +1,207 @@
+package io.github.hectorvent.floci.services.dms;
+
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.JsonNode;
+import io.github.hectorvent.floci.core.common.AwsException;
+import io.github.hectorvent.floci.core.common.Resettable;
+import io.github.hectorvent.floci.core.storage.AccountAwareStorageBackend;
+import io.github.hectorvent.floci.core.storage.StorageFactory;
+import io.github.hectorvent.floci.services.dms.model.ReplicationSubnetGroup;
+import io.github.hectorvent.floci.services.ec2.Ec2Service;
+import io.github.hectorvent.floci.services.ec2.model.Subnet;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
+
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+import java.util.regex.Pattern;
+
+@ApplicationScoped
+public class DmsService implements Resettable {
+
+    private static final Pattern SUBNET_GROUP_IDENTIFIER = Pattern.compile("[A-Za-z0-9._-]+");
+    private static final String SUBNET_GROUP_ID_FILTER = "replication-subnet-group-id";
+    private static final int MINIMUM_AVAILABILITY_ZONES = 2;
+
+    private final AccountAwareStorageBackend<ReplicationSubnetGroup> subnetGroups;
+    private final Ec2Service ec2Service;
+
+    @Inject
+    public DmsService(StorageFactory storageFactory, Ec2Service ec2Service) {
+        this.subnetGroups = storageFactory.create("dms", "dms-replication-subnet-groups.json",
+                new TypeReference<Map<String, ReplicationSubnetGroup>>() {});
+        this.ec2Service = ec2Service;
+    }
+
+    public synchronized ReplicationSubnetGroup createReplicationSubnetGroup(JsonNode request, String region) {
+        String identifier = requireIdentifier(request);
+        String description = text(request, "ReplicationSubnetGroupDescription");
+        if (description == null || description.isBlank()) {
+            throw invalidParameter("The parameter ReplicationSubnetGroupDescription must be provided"
+                    + " and must not be blank.");
+        }
+        List<String> subnetIds = requireSubnetIds(request);
+        if (subnetGroups.get(storageKey(region, identifier)).isPresent()) {
+            throw new AwsException("ResourceAlreadyExistsFault",
+                    "The resource you are attempting to create already exists.", 400);
+        }
+
+        ReplicationSubnetGroup group = buildSubnetGroup(identifier, description, subnetIds, region);
+        subnetGroups.put(storageKey(region, identifier), group);
+        return group;
+    }
+
+    public List<ReplicationSubnetGroup> describeReplicationSubnetGroups(JsonNode request, String region) {
+        List<String> requestedIdentifiers = identifierFilters(request);
+        if (!requestedIdentifiers.isEmpty()) {
+            return requestedIdentifiers.stream()
+                    .map(identifier -> subnetGroups.get(storageKey(region, identifier))
+                            .orElseThrow(() -> notFound(identifier)))
+                    .toList();
+        }
+        return subnetGroups.scan(key -> key.startsWith(region + "::")).stream()
+                .sorted(Comparator.comparing(ReplicationSubnetGroup::getReplicationSubnetGroupIdentifier))
+                .toList();
+    }
+
+    public synchronized void deleteReplicationSubnetGroup(JsonNode request, String region) {
+        String identifier = requireIdentifier(request);
+        String key = storageKey(region, identifier);
+        if (subnetGroups.get(key).isEmpty()) {
+            throw notFound(identifier);
+        }
+        subnetGroups.delete(key);
+    }
+
+    @Override
+    public void clear() {
+        subnetGroups.clear();
+    }
+
+    private ReplicationSubnetGroup buildSubnetGroup(String identifier, String description,
+                                                    List<String> subnetIds, String region) {
+        Map<String, Subnet> resolved = new LinkedHashMap<>();
+        ec2Service.describeSubnets(region, subnetIds, Map.of())
+                .forEach(subnet -> resolved.put(subnet.getSubnetId(), subnet));
+        List<String> requested = subnetIds.stream().distinct().toList();
+        List<String> missing = requested.stream().filter(id -> !resolved.containsKey(id)).toList();
+        if (!missing.isEmpty()) {
+            throw new AwsException("InvalidSubnet",
+                    "The subnet provided is invalid: " + missing + ".", 400);
+        }
+
+        // Response order follows the request rather than storage iteration order, so a describe
+        // that follows a create returns the same subnet ordering every time.
+        Map<String, String> availabilityZones = new LinkedHashMap<>();
+        for (String subnetId : requested) {
+            availabilityZones.put(subnetId, resolved.get(subnetId).getAvailabilityZone());
+        }
+
+        String vpcId = resolved.get(requested.getFirst()).getVpcId();
+        boolean sameVpc = resolved.values().stream()
+                .map(Subnet::getVpcId)
+                .filter(Objects::nonNull)
+                .allMatch(vpcId::equals);
+        if (!sameVpc) {
+            throw new AwsException("InvalidSubnet",
+                    "The subnets provided for replication subnet group " + identifier
+                            + " belong to more than one VPC.", 400);
+        }
+
+        if (Set.copyOf(availabilityZones.values()).size() < MINIMUM_AVAILABILITY_ZONES) {
+            throw new AwsException("ReplicationSubnetGroupDoesNotCoverEnoughAZs",
+                    "The replication subnet group does not cover enough Availability Zones (AZs)."
+                            + " Edit the replication subnet group and add more AZs.", 400);
+        }
+
+        ReplicationSubnetGroup group = new ReplicationSubnetGroup();
+        group.setReplicationSubnetGroupIdentifier(identifier);
+        group.setReplicationSubnetGroupDescription(description);
+        group.setVpcId(vpcId);
+        group.setSubnetGroupStatus("Complete");
+        group.setSubnetIds(requested);
+        group.setSubnetAvailabilityZones(availabilityZones);
+        group.setSupportedNetworkTypes(List.of("IPV4"));
+        return group;
+    }
+
+    /**
+     * AWS stores the identifier as a lowercase string, so every lookup normalises the same way:
+     * a group created as "MyGroup" is described and deleted as "mygroup".
+     */
+    private static String requireIdentifier(JsonNode request) {
+        String value = text(request, "ReplicationSubnetGroupIdentifier");
+        if (value == null || value.isBlank()) {
+            throw invalidParameter("The parameter ReplicationSubnetGroupIdentifier must be provided"
+                    + " and must not be blank.");
+        }
+        String identifier = value.toLowerCase(Locale.ROOT);
+        if (identifier.length() > 255 || !SUBNET_GROUP_IDENTIFIER.matcher(identifier).matches()) {
+            throw invalidParameter("ReplicationSubnetGroupIdentifier must contain no more than 255"
+                    + " alphanumeric characters, periods, underscores, or hyphens.");
+        }
+        if ("default".equals(identifier)) {
+            throw invalidParameter("ReplicationSubnetGroupIdentifier must not be \"default\".");
+        }
+        return identifier;
+    }
+
+    private static List<String> requireSubnetIds(JsonNode request) {
+        JsonNode node = request == null ? null : request.get("SubnetIds");
+        if (node == null || !node.isArray() || node.isEmpty()) {
+            throw invalidParameter("The parameter SubnetIds must be provided and must not be empty.");
+        }
+        List<String> subnetIds = new ArrayList<>();
+        node.forEach(element -> {
+            if (!element.isTextual() || element.textValue().isBlank()) {
+                throw invalidParameter("The parameter SubnetIds must contain subnet identifiers.");
+            }
+            subnetIds.add(element.textValue());
+        });
+        return subnetIds;
+    }
+
+    private static List<String> identifierFilters(JsonNode request) {
+        JsonNode filters = request == null ? null : request.get("Filters");
+        if (filters == null || !filters.isArray()) {
+            return List.of();
+        }
+        List<String> identifiers = new ArrayList<>();
+        for (JsonNode filter : filters) {
+            String name = text(filter, "Name");
+            if (!SUBNET_GROUP_ID_FILTER.equals(name)) {
+                throw invalidParameter("Invalid filter: " + name + ".");
+            }
+            JsonNode values = filter.get("Values");
+            if (values == null || !values.isArray() || values.isEmpty()) {
+                throw invalidParameter("The filter " + SUBNET_GROUP_ID_FILTER + " must have values.");
+            }
+            values.forEach(value -> identifiers.add(value.asText().toLowerCase(Locale.ROOT)));
+        }
+        return identifiers;
+    }
+
+    private static AwsException notFound(String identifier) {
+        return new AwsException("ResourceNotFoundFault",
+                "Replication subnet group " + identifier + " not found.", 400);
+    }
+
+    private static AwsException invalidParameter(String message) {
+        return new AwsException("InvalidParameterValueException", message, 400);
+    }
+
+    private static String text(JsonNode request, String field) {
+        JsonNode node = request == null ? null : request.get(field);
+        return node != null && node.isTextual() ? node.textValue() : null;
+    }
+
+    private static String storageKey(String region, String identifier) {
+        return region + "::" + identifier;
+    }
+}

--- a/src/main/java/io/github/hectorvent/floci/services/dms/model/ReplicationSubnetGroup.java
+++ b/src/main/java/io/github/hectorvent/floci/services/dms/model/ReplicationSubnetGroup.java
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import io.quarkus.runtime.annotations.RegisterForReflection;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
@@ -19,6 +20,7 @@ public class ReplicationSubnetGroup {
     private List<String> subnetIds = new ArrayList<>();
     private Map<String, String> subnetAvailabilityZones = new LinkedHashMap<>();
     private List<String> supportedNetworkTypes = new ArrayList<>();
+    private Map<String, String> tags = new LinkedHashMap<>();
 
     public ReplicationSubnetGroup() {
     }
@@ -81,5 +83,13 @@ public class ReplicationSubnetGroup {
         this.supportedNetworkTypes = supportedNetworkTypes != null
                 ? new ArrayList<>(supportedNetworkTypes)
                 : new ArrayList<>();
+    }
+
+    public Map<String, String> getTags() {
+        return Collections.unmodifiableMap(new LinkedHashMap<>(tags));
+    }
+
+    public void setTags(Map<String, String> tags) {
+        this.tags = tags != null ? new LinkedHashMap<>(tags) : new LinkedHashMap<>();
     }
 }

--- a/src/main/java/io/github/hectorvent/floci/services/dms/model/ReplicationSubnetGroup.java
+++ b/src/main/java/io/github/hectorvent/floci/services/dms/model/ReplicationSubnetGroup.java
@@ -1,0 +1,85 @@
+package io.github.hectorvent.floci.services.dms.model;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import io.quarkus.runtime.annotations.RegisterForReflection;
+
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+@RegisterForReflection
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class ReplicationSubnetGroup {
+
+    private String replicationSubnetGroupIdentifier;
+    private String replicationSubnetGroupDescription;
+    private String vpcId;
+    private String subnetGroupStatus = "Complete";
+    private List<String> subnetIds = new ArrayList<>();
+    private Map<String, String> subnetAvailabilityZones = new LinkedHashMap<>();
+    private List<String> supportedNetworkTypes = new ArrayList<>();
+
+    public ReplicationSubnetGroup() {
+    }
+
+    public String getReplicationSubnetGroupIdentifier() {
+        return replicationSubnetGroupIdentifier;
+    }
+
+    public void setReplicationSubnetGroupIdentifier(String replicationSubnetGroupIdentifier) {
+        this.replicationSubnetGroupIdentifier = replicationSubnetGroupIdentifier;
+    }
+
+    public String getReplicationSubnetGroupDescription() {
+        return replicationSubnetGroupDescription;
+    }
+
+    public void setReplicationSubnetGroupDescription(String replicationSubnetGroupDescription) {
+        this.replicationSubnetGroupDescription = replicationSubnetGroupDescription;
+    }
+
+    public String getVpcId() {
+        return vpcId;
+    }
+
+    public void setVpcId(String vpcId) {
+        this.vpcId = vpcId;
+    }
+
+    public String getSubnetGroupStatus() {
+        return subnetGroupStatus;
+    }
+
+    public void setSubnetGroupStatus(String subnetGroupStatus) {
+        this.subnetGroupStatus = subnetGroupStatus;
+    }
+
+    public List<String> getSubnetIds() {
+        return List.copyOf(subnetIds);
+    }
+
+    public void setSubnetIds(List<String> subnetIds) {
+        this.subnetIds = subnetIds != null ? new ArrayList<>(subnetIds) : new ArrayList<>();
+    }
+
+    public Map<String, String> getSubnetAvailabilityZones() {
+        return Map.copyOf(subnetAvailabilityZones);
+    }
+
+    public void setSubnetAvailabilityZones(Map<String, String> subnetAvailabilityZones) {
+        this.subnetAvailabilityZones = subnetAvailabilityZones != null
+                ? new LinkedHashMap<>(subnetAvailabilityZones)
+                : new LinkedHashMap<>();
+    }
+
+    public List<String> getSupportedNetworkTypes() {
+        return List.copyOf(supportedNetworkTypes);
+    }
+
+    public void setSupportedNetworkTypes(List<String> supportedNetworkTypes) {
+        this.supportedNetworkTypes = supportedNetworkTypes != null
+                ? new ArrayList<>(supportedNetworkTypes)
+                : new ArrayList<>();
+    }
+}

--- a/src/main/java/io/github/hectorvent/floci/services/dms/model/ResourceTag.java
+++ b/src/main/java/io/github/hectorvent/floci/services/dms/model/ResourceTag.java
@@ -1,0 +1,9 @@
+package io.github.hectorvent.floci.services.dms.model;
+
+/**
+ * One tag as DMS returns it from {@code ListTagsForResource}. {@code resourceArn} is null for a
+ * single-ARN request and set when the caller passed {@code ResourceArnList}, which is the only
+ * form where AWS documents the field as part of the response.
+ */
+public record ResourceTag(String resourceArn, String key, String value) {
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -709,3 +709,5 @@ floci:
       enabled: true
     marketplace:
       enabled: true
+    dms:
+      enabled: true

--- a/src/test/java/io/github/hectorvent/floci/services/dms/DmsIntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/dms/DmsIntegrationTest.java
@@ -155,6 +155,29 @@ class DmsIntegrationTest {
     }
 
     @Test
+    void aTagValueOfTheWrongTypeIsASerializationErrorOnTheWire() {
+        dms("CreateReplicationSubnetGroup")
+                .body("{\"ReplicationSubnetGroupIdentifier\":\"tf-object-tag\","
+                        + "\"ReplicationSubnetGroupDescription\":\"terraform managed\","
+                        + "\"SubnetIds\":[\"" + SUBNET_A + "\",\"" + SUBNET_B + "\"],"
+                        + "\"Tags\":[{\"Key\":\"env\",\"Value\":{\"nested\":1}}]}")
+        .when()
+                .post("/")
+        .then()
+                .statusCode(400)
+                .body("__type", equalTo("SerializationException"));
+
+        dms("DescribeReplicationSubnetGroups")
+                .body("{\"Filters\":[{\"Name\":\"replication-subnet-group-id\","
+                        + "\"Values\":[\"tf-object-tag\"]}]}")
+        .when()
+                .post("/")
+        .then()
+                .statusCode(400)
+                .body("__type", equalTo("ResourceNotFoundFault"));
+    }
+
+    @Test
     void unsupportedDmsActionReportsUnknownOperation() {
         dms("CreateReplicationInstance")
                 .body("{}")

--- a/src/test/java/io/github/hectorvent/floci/services/dms/DmsIntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/dms/DmsIntegrationTest.java
@@ -1,0 +1,176 @@
+package io.github.hectorvent.floci.services.dms;
+
+import io.github.hectorvent.floci.testing.RestAssuredJsonUtils;
+import io.quarkus.test.junit.QuarkusTest;
+import io.restassured.specification.RequestSpecification;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+import static io.restassured.RestAssured.given;
+import static org.hamcrest.Matchers.contains;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.everyItem;
+import static org.hamcrest.Matchers.hasSize;
+
+@QuarkusTest
+class DmsIntegrationTest {
+
+    private static final String CONTENT_TYPE = "application/x-amz-json-1.1";
+    private static final String TARGET_PREFIX = "AmazonDMSv20160101.";
+    private static final String AUTH_HEADER =
+            "AWS4-HMAC-SHA256 Credential=AKID/20260101/us-east-1/dms/aws4_request";
+    private static final String SUBNET_A = "subnet-default-us-east-1-a";
+    private static final String SUBNET_B = "subnet-default-us-east-1-b";
+
+    @BeforeAll
+    static void configureRestAssured() {
+        RestAssuredJsonUtils.configureAwsContentTypes();
+    }
+
+    @Test
+    void subnetGroupLifecycleIsReadableThroughDescribe() {
+        dms("CreateReplicationSubnetGroup")
+                .body("{\"ReplicationSubnetGroupIdentifier\":\"Tf-Lifecycle\","
+                        + "\"ReplicationSubnetGroupDescription\":\"terraform managed\","
+                        + "\"SubnetIds\":[\"" + SUBNET_A + "\",\"" + SUBNET_B + "\"]}")
+        .when()
+                .post("/")
+        .then()
+                .statusCode(200)
+                .body("ReplicationSubnetGroup.ReplicationSubnetGroupIdentifier", equalTo("tf-lifecycle"));
+
+        dms("DescribeReplicationSubnetGroups")
+                .body("{\"Filters\":[{\"Name\":\"replication-subnet-group-id\","
+                        + "\"Values\":[\"tf-lifecycle\"]}]}")
+        .when()
+                .post("/")
+        .then()
+                .statusCode(200)
+                .body("ReplicationSubnetGroups", hasSize(1))
+                .body("ReplicationSubnetGroups[0].ReplicationSubnetGroupDescription",
+                        equalTo("terraform managed"))
+                .body("ReplicationSubnetGroups[0].VpcId", equalTo("vpc-default-us-east-1"))
+                .body("ReplicationSubnetGroups[0].SubnetGroupStatus", equalTo("Complete"))
+                .body("ReplicationSubnetGroups[0].Subnets.SubnetIdentifier", contains(SUBNET_A, SUBNET_B))
+                .body("ReplicationSubnetGroups[0].Subnets.find { it.SubnetIdentifier == '"
+                        + SUBNET_A + "' }.SubnetAvailabilityZone.Name", equalTo("us-east-1a"))
+                .body("ReplicationSubnetGroups[0].Subnets.find { it.SubnetIdentifier == '"
+                        + SUBNET_B + "' }.SubnetAvailabilityZone.Name", equalTo("us-east-1b"))
+                .body("ReplicationSubnetGroups[0].Subnets.SubnetStatus", everyItem(equalTo("Active")))
+                .body("ReplicationSubnetGroups[0].SupportedNetworkTypes", contains("IPV4"));
+
+        dms("DeleteReplicationSubnetGroup")
+                .body("{\"ReplicationSubnetGroupIdentifier\":\"tf-lifecycle\"}")
+        .when()
+                .post("/")
+        .then()
+                .statusCode(200);
+
+        dms("DescribeReplicationSubnetGroups")
+                .body("{\"Filters\":[{\"Name\":\"replication-subnet-group-id\","
+                        + "\"Values\":[\"tf-lifecycle\"]}]}")
+        .when()
+                .post("/")
+        .then()
+                .statusCode(400)
+                .body("__type", equalTo("ResourceNotFoundFault"));
+    }
+
+    @Test
+    void createRejectsADuplicateIdentifier() {
+        dms("CreateReplicationSubnetGroup")
+                .body(createBody("tf-duplicate"))
+        .when()
+                .post("/")
+        .then()
+                .statusCode(200);
+
+        dms("CreateReplicationSubnetGroup")
+                .body(createBody("tf-duplicate"))
+        .when()
+                .post("/")
+        .then()
+                .statusCode(400)
+                .body("__type", equalTo("ResourceAlreadyExistsFault"));
+
+        dms("DeleteReplicationSubnetGroup")
+                .body("{\"ReplicationSubnetGroupIdentifier\":\"tf-duplicate\"}")
+        .when()
+                .post("/")
+        .then()
+                .statusCode(200);
+    }
+
+    @Test
+    void createRejectsSubnetsInASingleAvailabilityZone() {
+        dms("CreateReplicationSubnetGroup")
+                .body("{\"ReplicationSubnetGroupIdentifier\":\"tf-one-az\","
+                        + "\"ReplicationSubnetGroupDescription\":\"terraform managed\","
+                        + "\"SubnetIds\":[\"" + SUBNET_A + "\"]}")
+        .when()
+                .post("/")
+        .then()
+                .statusCode(400)
+                .body("__type", equalTo("ReplicationSubnetGroupDoesNotCoverEnoughAZs"));
+    }
+
+    @Test
+    void createRejectsAnUnknownSubnet() {
+        dms("CreateReplicationSubnetGroup")
+                .body("{\"ReplicationSubnetGroupIdentifier\":\"tf-bad-subnet\","
+                        + "\"ReplicationSubnetGroupDescription\":\"terraform managed\","
+                        + "\"SubnetIds\":[\"" + SUBNET_A + "\",\"subnet-does-not-exist\"]}")
+        .when()
+                .post("/")
+        .then()
+                .statusCode(400)
+                .body("__type", equalTo("InvalidSubnet"));
+    }
+
+    @Test
+    void createRejectsAMissingDescription() {
+        dms("CreateReplicationSubnetGroup")
+                .body("{\"ReplicationSubnetGroupIdentifier\":\"tf-no-description\","
+                        + "\"SubnetIds\":[\"" + SUBNET_A + "\",\"" + SUBNET_B + "\"]}")
+        .when()
+                .post("/")
+        .then()
+                .statusCode(400)
+                .body("__type", equalTo("InvalidParameterValueException"));
+    }
+
+    @Test
+    void deleteOfAMissingSubnetGroupFaults() {
+        dms("DeleteReplicationSubnetGroup")
+                .body("{\"ReplicationSubnetGroupIdentifier\":\"tf-absent\"}")
+        .when()
+                .post("/")
+        .then()
+                .statusCode(400)
+                .body("__type", equalTo("ResourceNotFoundFault"));
+    }
+
+    @Test
+    void unsupportedDmsActionReportsUnknownOperation() {
+        dms("CreateReplicationInstance")
+                .body("{}")
+        .when()
+                .post("/")
+        .then()
+                .statusCode(404)
+                .body("__type", equalTo("UnknownOperationException"));
+    }
+
+    private static String createBody(String identifier) {
+        return "{\"ReplicationSubnetGroupIdentifier\":\"" + identifier + "\","
+                + "\"ReplicationSubnetGroupDescription\":\"terraform managed\","
+                + "\"SubnetIds\":[\"" + SUBNET_A + "\",\"" + SUBNET_B + "\"]}";
+    }
+
+    private static RequestSpecification dms(String action) {
+        return given()
+                .contentType(CONTENT_TYPE)
+                .header("X-Amz-Target", TARGET_PREFIX + action)
+                .header("Authorization", AUTH_HEADER);
+    }
+}

--- a/src/test/java/io/github/hectorvent/floci/services/dms/DmsIntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/dms/DmsIntegrationTest.java
@@ -60,7 +60,8 @@ class DmsIntegrationTest {
                 .body("ReplicationSubnetGroups[0].Subnets.find { it.SubnetIdentifier == '"
                         + SUBNET_B + "' }.SubnetAvailabilityZone.Name", equalTo("us-east-1b"))
                 .body("ReplicationSubnetGroups[0].Subnets.SubnetStatus", everyItem(equalTo("Active")))
-                .body("ReplicationSubnetGroups[0].SupportedNetworkTypes", contains("IPV4"));
+                .body("ReplicationSubnetGroups[0].SupportedNetworkTypes", contains("IPV4"))
+                .body("ReplicationSubnetGroups[0].IsReadOnly", equalTo(false));
 
         dms("DeleteReplicationSubnetGroup")
                 .body("{\"ReplicationSubnetGroupIdentifier\":\"tf-lifecycle\"}")

--- a/src/test/java/io/github/hectorvent/floci/services/dms/DmsIntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/dms/DmsIntegrationTest.java
@@ -8,17 +8,20 @@ import org.junit.jupiter.api.Test;
 
 import static io.restassured.RestAssured.given;
 import static org.hamcrest.Matchers.contains;
+import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.everyItem;
 import static org.hamcrest.Matchers.hasSize;
+import static org.hamcrest.Matchers.nullValue;
 
 @QuarkusTest
 class DmsIntegrationTest {
 
     private static final String CONTENT_TYPE = "application/x-amz-json-1.1";
     private static final String TARGET_PREFIX = "AmazonDMSv20160101.";
+    private static final String ACCOUNT_ID = "723679240095";
     private static final String AUTH_HEADER =
-            "AWS4-HMAC-SHA256 Credential=AKID/20260101/us-east-1/dms/aws4_request";
+            "AWS4-HMAC-SHA256 Credential=" + ACCOUNT_ID + "/20260101/us-east-1/dms/aws4_request";
     private static final String SUBNET_A = "subnet-default-us-east-1-a";
     private static final String SUBNET_B = "subnet-default-us-east-1-b";
 
@@ -159,6 +162,85 @@ class DmsIntegrationTest {
         .then()
                 .statusCode(404)
                 .body("__type", equalTo("UnknownOperationException"));
+    }
+
+    @Test
+    void tagsSurviveCreateAndAreReadableThroughListTagsForResource() {
+        dms("CreateReplicationSubnetGroup")
+                .body("{\"ReplicationSubnetGroupIdentifier\":\"tf-tagged\","
+                        + "\"ReplicationSubnetGroupDescription\":\"terraform managed\","
+                        + "\"SubnetIds\":[\"" + SUBNET_A + "\",\"" + SUBNET_B + "\"],"
+                        + "\"Tags\":[{\"Key\":\"env\",\"Value\":\"test\"}]}")
+        .when()
+                .post("/")
+        .then()
+                .statusCode(200);
+
+        dms("ListTagsForResource")
+                .body("{\"ResourceArn\":\"" + arn("tf-tagged") + "\"}")
+        .when()
+                .post("/")
+        .then()
+                .statusCode(200)
+                .body("TagList", hasSize(1))
+                .body("TagList[0].Key", equalTo("env"))
+                .body("TagList[0].Value", equalTo("test"))
+                .body("TagList[0].ResourceArn", nullValue());
+
+        dms("AddTagsToResource")
+                .body("{\"ResourceArn\":\"" + arn("tf-tagged") + "\","
+                        + "\"Tags\":[{\"Key\":\"owner\",\"Value\":\"data\"}]}")
+        .when()
+                .post("/")
+        .then()
+                .statusCode(200);
+
+        dms("ListTagsForResource")
+                .body("{\"ResourceArn\":\"" + arn("tf-tagged") + "\"}")
+        .when()
+                .post("/")
+        .then()
+                .statusCode(200)
+                .body("TagList.Key", containsInAnyOrder("env", "owner"));
+
+        dms("RemoveTagsFromResource")
+                .body("{\"ResourceArn\":\"" + arn("tf-tagged") + "\",\"TagKeys\":[\"env\"]}")
+        .when()
+                .post("/")
+        .then()
+                .statusCode(200);
+
+        dms("ListTagsForResource")
+                .body("{\"ResourceArnList\":[\"" + arn("tf-tagged") + "\"]}")
+        .when()
+                .post("/")
+        .then()
+                .statusCode(200)
+                .body("TagList", hasSize(1))
+                .body("TagList[0].Key", equalTo("owner"))
+                .body("TagList[0].ResourceArn", equalTo(arn("tf-tagged")));
+
+        dms("DeleteReplicationSubnetGroup")
+                .body("{\"ReplicationSubnetGroupIdentifier\":\"tf-tagged\"}")
+        .when()
+                .post("/")
+        .then()
+                .statusCode(200);
+    }
+
+    @Test
+    void listTagsForAnUnknownArnFaults() {
+        dms("ListTagsForResource")
+                .body("{\"ResourceArn\":\"" + arn("tf-never-created") + "\"}")
+        .when()
+                .post("/")
+        .then()
+                .statusCode(400)
+                .body("__type", equalTo("ResourceNotFoundFault"));
+    }
+
+    private static String arn(String identifier) {
+        return "arn:aws:dms:us-east-1:" + ACCOUNT_ID + ":subgrp:" + identifier;
     }
 
     private static String createBody(String identifier) {

--- a/src/test/java/io/github/hectorvent/floci/services/dms/DmsServiceTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/dms/DmsServiceTest.java
@@ -5,9 +5,11 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ArrayNode;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import io.github.hectorvent.floci.core.common.AwsException;
+import io.github.hectorvent.floci.core.common.RegionResolver;
 import io.github.hectorvent.floci.core.storage.AccountAwareStorageBackend;
 import io.github.hectorvent.floci.core.storage.StorageFactory;
 import io.github.hectorvent.floci.services.dms.model.ReplicationSubnetGroup;
+import io.github.hectorvent.floci.services.dms.model.ResourceTag;
 import io.github.hectorvent.floci.services.ec2.Ec2Service;
 import io.github.hectorvent.floci.services.ec2.model.Subnet;
 import org.junit.jupiter.api.BeforeEach;
@@ -48,7 +50,9 @@ class DmsServiceTest {
             List<String> requested = invocation.getArgument(1);
             return requested.stream().map(DmsServiceTest::subnet).filter(java.util.Objects::nonNull).toList();
         });
-        service = new DmsService(storageFactory, ec2Service);
+        RegionResolver regionResolver = mock(RegionResolver.class);
+        when(regionResolver.getAccountId()).thenReturn(ACCOUNT_ID);
+        service = new DmsService(storageFactory, ec2Service, regionResolver);
     }
 
     @Test
@@ -153,6 +157,144 @@ class DmsServiceTest {
         service.clear();
 
         assertTrue(service.describeReplicationSubnetGroups(mapper.createObjectNode(), REGION).isEmpty());
+    }
+
+    @Test
+    void createStoresTagsReadableThroughListTagsForResource() {
+        ObjectNode request = createRequest("tagged", "example", "subnet-a", "subnet-b");
+        tagList(request.putArray("Tags"), "env", "test", "team", "platform");
+        service.createReplicationSubnetGroup(request, REGION);
+
+        assertEquals(Map.of("env", "test", "team", "platform"), tagsOf("tagged"));
+    }
+
+    @Test
+    void addTagsMergesWithExistingTagsAndOverwritesByKey() {
+        ObjectNode request = createRequest("merge-me", "example", "subnet-a", "subnet-b");
+        tagList(request.putArray("Tags"), "env", "test");
+        service.createReplicationSubnetGroup(request, REGION);
+
+        ObjectNode addRequest = mapper.createObjectNode();
+        addRequest.put("ResourceArn", arn("merge-me"));
+        tagList(addRequest.putArray("Tags"), "env", "prod", "owner", "data");
+        service.addTagsToResource(addRequest, REGION);
+
+        assertEquals(Map.of("env", "prod", "owner", "data"), tagsOf("merge-me"));
+    }
+
+    @Test
+    void removeTagsDropsOnlyTheNamedKeys() {
+        ObjectNode request = createRequest("trim-me", "example", "subnet-a", "subnet-b");
+        tagList(request.putArray("Tags"), "env", "test", "owner", "data");
+        service.createReplicationSubnetGroup(request, REGION);
+
+        ObjectNode removeRequest = mapper.createObjectNode();
+        removeRequest.put("ResourceArn", arn("trim-me"));
+        removeRequest.putArray("TagKeys").add("env").add("absent-key");
+        service.removeTagsFromResource(removeRequest, REGION);
+
+        assertEquals(Map.of("owner", "data"), tagsOf("trim-me"));
+    }
+
+    @Test
+    void listTagsByArnListCarriesTheOwningArnOnEachTag() {
+        ObjectNode request = createRequest("arn-list", "example", "subnet-a", "subnet-b");
+        tagList(request.putArray("Tags"), "env", "test");
+        service.createReplicationSubnetGroup(request, REGION);
+
+        ObjectNode listRequest = mapper.createObjectNode();
+        listRequest.putArray("ResourceArnList").add(arn("arn-list"));
+        List<ResourceTag> tags = service.listTagsForResource(listRequest, REGION);
+
+        assertEquals(List.of(new ResourceTag(arn("arn-list"), "env", "test")), tags);
+    }
+
+    @Test
+    void listTagsBySingleArnOmitsTheArnOnEachTag() {
+        ObjectNode request = createRequest("single-arn", "example", "subnet-a", "subnet-b");
+        tagList(request.putArray("Tags"), "env", "test");
+        service.createReplicationSubnetGroup(request, REGION);
+
+        assertEquals(List.of(new ResourceTag(null, "env", "test")),
+                service.listTagsForResource(arnRequest("single-arn"), REGION));
+    }
+
+    @Test
+    void tagOperationsOnAnUnknownArnFault() {
+        String missing = "arn:aws:dms:" + REGION + ":" + ACCOUNT_ID + ":subgrp:not-there";
+        ObjectNode listRequest = mapper.createObjectNode();
+        listRequest.put("ResourceArn", missing);
+
+        AwsException notFound = assertThrows(AwsException.class,
+                () -> service.listTagsForResource(listRequest, REGION));
+        assertEquals("ResourceNotFoundFault", notFound.getErrorCode());
+    }
+
+    @Test
+    void tagOperationsOnAnotherAccountsArnFault() {
+        ObjectNode request = createRequest("other-account", "example", "subnet-a", "subnet-b");
+        tagList(request.putArray("Tags"), "env", "test");
+        service.createReplicationSubnetGroup(request, REGION);
+
+        ObjectNode listRequest = mapper.createObjectNode();
+        listRequest.put("ResourceArn", "arn:aws:dms:" + REGION + ":999999999999:subgrp:other-account");
+
+        AwsException notFound = assertThrows(AwsException.class,
+                () -> service.listTagsForResource(listRequest, REGION));
+        assertEquals("ResourceNotFoundFault", notFound.getErrorCode());
+    }
+
+    @Test
+    void tagOperationsOnANonSubnetGroupArnFault() {
+        ObjectNode listRequest = mapper.createObjectNode();
+        listRequest.put("ResourceArn", "arn:aws:dms:" + REGION + ":" + ACCOUNT_ID + ":rep:Example");
+
+        AwsException notFound = assertThrows(AwsException.class,
+                () -> service.listTagsForResource(listRequest, REGION));
+        assertEquals("ResourceNotFoundFault", notFound.getErrorCode());
+    }
+
+    @Test
+    void reservedTagKeyPrefixesAreRejected() {
+        ObjectNode request = createRequest("reserved-tag", "example", "subnet-a", "subnet-b");
+        tagList(request.putArray("Tags"), "aws:created-by", "someone");
+
+        AwsException reserved = assertThrows(AwsException.class,
+                () -> service.createReplicationSubnetGroup(request, REGION));
+        assertEquals("InvalidParameterValueException", reserved.getErrorCode());
+    }
+
+    @Test
+    void deletingAGroupDropsItsTags() {
+        ObjectNode request = createRequest("tags-die", "example", "subnet-a", "subnet-b");
+        tagList(request.putArray("Tags"), "env", "test");
+        service.createReplicationSubnetGroup(request, REGION);
+        service.deleteReplicationSubnetGroup(identifierRequest("tags-die"), REGION);
+
+        AwsException notFound = assertThrows(AwsException.class,
+                () -> service.listTagsForResource(arnRequest("tags-die"), REGION));
+        assertEquals("ResourceNotFoundFault", notFound.getErrorCode());
+    }
+
+    private Map<String, String> tagsOf(String identifier) {
+        return service.listTagsForResource(arnRequest(identifier), REGION).stream()
+                .collect(java.util.stream.Collectors.toMap(ResourceTag::key, ResourceTag::value));
+    }
+
+    private ObjectNode arnRequest(String identifier) {
+        ObjectNode request = mapper.createObjectNode();
+        request.put("ResourceArn", arn(identifier));
+        return request;
+    }
+
+    private String arn(String identifier) {
+        return "arn:aws:dms:" + REGION + ":" + ACCOUNT_ID + ":subgrp:" + identifier;
+    }
+
+    private static void tagList(ArrayNode tags, String... keysAndValues) {
+        for (int i = 0; i < keysAndValues.length; i += 2) {
+            tags.addObject().put("Key", keysAndValues[i]).put("Value", keysAndValues[i + 1]);
+        }
     }
 
     private ObjectNode createRequest(String identifier, String description, String... subnetIds) {

--- a/src/test/java/io/github/hectorvent/floci/services/dms/DmsServiceTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/dms/DmsServiceTest.java
@@ -304,6 +304,97 @@ class DmsServiceTest {
         assertEquals("ResourceNotFoundFault", notFound.getErrorCode());
     }
 
+    @Test
+    void createRejectsATagValueThatIsNotAString() {
+        ObjectNode request = createRequest("object-tag-value", "example", "subnet-a", "subnet-b");
+        request.putArray("Tags").addObject().put("Key", "env").putObject("Value").put("nested", 1);
+
+        AwsException wrongType = assertThrows(AwsException.class,
+                () -> service.createReplicationSubnetGroup(request, REGION));
+        assertEquals("SerializationException", wrongType.getErrorCode());
+    }
+
+    @Test
+    void createRejectsATagsMemberThatIsNotAList() {
+        ObjectNode request = createRequest("scalar-tags", "example", "subnet-a", "subnet-b");
+        request.put("Tags", "env=test");
+
+        AwsException wrongType = assertThrows(AwsException.class,
+                () -> service.createReplicationSubnetGroup(request, REGION));
+        assertEquals("SerializationException", wrongType.getErrorCode());
+    }
+
+    @Test
+    void createRejectsASubnetIdThatIsNotAString() {
+        ObjectNode request = identifierRequest("numeric-subnet");
+        request.put("ReplicationSubnetGroupDescription", "example");
+        request.putArray("SubnetIds").add("subnet-a").add(42);
+
+        AwsException wrongType = assertThrows(AwsException.class,
+                () -> service.createReplicationSubnetGroup(request, REGION));
+        assertEquals("SerializationException", wrongType.getErrorCode());
+    }
+
+    @Test
+    void describeRejectsFilterValuesThatAreNotAList() {
+        ObjectNode request = mapper.createObjectNode();
+        ObjectNode filter = request.putArray("Filters").addObject();
+        filter.put("Name", "replication-subnet-group-id");
+        filter.put("Values", "tf-example");
+
+        AwsException wrongType = assertThrows(AwsException.class,
+                () -> service.describeReplicationSubnetGroups(request, REGION));
+        assertEquals("SerializationException", wrongType.getErrorCode());
+    }
+
+    @Test
+    void describeRejectsAFilterValueThatIsNotAString() {
+        ObjectNode request = mapper.createObjectNode();
+        ObjectNode filter = request.putArray("Filters").addObject();
+        filter.put("Name", "replication-subnet-group-id");
+        filter.putArray("Values").addObject().put("Value", "tf-example");
+
+        AwsException wrongType = assertThrows(AwsException.class,
+                () -> service.describeReplicationSubnetGroups(request, REGION));
+        assertEquals("SerializationException", wrongType.getErrorCode());
+    }
+
+    @Test
+    void listTagsRejectsAnArnListElementThatIsNotAString() {
+        ObjectNode request = mapper.createObjectNode();
+        request.putArray("ResourceArnList").addObject().put("ResourceArn", arn("whatever"));
+
+        AwsException wrongType = assertThrows(AwsException.class,
+                () -> service.listTagsForResource(request, REGION));
+        assertEquals("SerializationException", wrongType.getErrorCode());
+    }
+
+    @Test
+    void removeTagsRejectsATagKeyThatIsNotAString() {
+        ObjectNode request = createRequest("bad-tag-keys", "example", "subnet-a", "subnet-b");
+        service.createReplicationSubnetGroup(request, REGION);
+
+        ObjectNode removeRequest = mapper.createObjectNode();
+        removeRequest.put("ResourceArn", arn("bad-tag-keys"));
+        removeRequest.putArray("TagKeys").add(7);
+
+        AwsException wrongType = assertThrows(AwsException.class,
+                () -> service.removeTagsFromResource(removeRequest, REGION));
+        assertEquals("SerializationException", wrongType.getErrorCode());
+    }
+
+    @Test
+    void createRejectsAnIdentifierThatIsNotAString() {
+        ObjectNode request = mapper.createObjectNode();
+        request.put("ReplicationSubnetGroupIdentifier", 12345);
+        request.put("ReplicationSubnetGroupDescription", "example");
+        request.putArray("SubnetIds").add("subnet-a").add("subnet-b");
+
+        AwsException wrongType = assertThrows(AwsException.class,
+                () -> service.createReplicationSubnetGroup(request, REGION));
+        assertEquals("SerializationException", wrongType.getErrorCode());
+    }
+
     private Map<String, String> tagsOf(String identifier) {
         return service.listTagsForResource(arnRequest(identifier), REGION).stream()
                 .collect(java.util.stream.Collectors.toMap(ResourceTag::key, ResourceTag::value));

--- a/src/test/java/io/github/hectorvent/floci/services/dms/DmsServiceTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/dms/DmsServiceTest.java
@@ -99,6 +99,20 @@ class DmsServiceTest {
     }
 
     @Test
+    void createRejectsTwoSubnetsSharingOneAvailabilityZone() {
+        AwsException tooFewZones = assertThrows(AwsException.class, () -> service.createReplicationSubnetGroup(
+                createRequest("same-az", "example", "subnet-a", "subnet-a2"), REGION));
+        assertEquals("ReplicationSubnetGroupDoesNotCoverEnoughAZs", tooFewZones.getErrorCode());
+    }
+
+    @Test
+    void createRejectsASubnetWithNoAvailabilityZone() {
+        AwsException noZone = assertThrows(AwsException.class, () -> service.createReplicationSubnetGroup(
+                createRequest("no-az", "example", "subnet-a", "subnet-no-az"), REGION));
+        assertEquals("InvalidSubnet", noZone.getErrorCode());
+    }
+
+    @Test
     void createRejectsSubnetsSpanningVpcs() {
         AwsException crossVpc = assertThrows(AwsException.class, () -> service.createReplicationSubnetGroup(
                 createRequest("cross-vpc", "example", "subnet-a", "subnet-other-vpc"), REGION));
@@ -245,6 +259,20 @@ class DmsServiceTest {
     }
 
     @Test
+    void tagOperationsOnAnotherRegionsArnFault() {
+        ObjectNode request = createRequest("other-region", "example", "subnet-a", "subnet-b");
+        tagList(request.putArray("Tags"), "env", "test");
+        service.createReplicationSubnetGroup(request, REGION);
+
+        ObjectNode listRequest = mapper.createObjectNode();
+        listRequest.put("ResourceArn", "arn:aws:dms:eu-west-1:" + ACCOUNT_ID + ":subgrp:other-region");
+
+        AwsException notFound = assertThrows(AwsException.class,
+                () -> service.listTagsForResource(listRequest, REGION));
+        assertEquals("ResourceNotFoundFault", notFound.getErrorCode());
+    }
+
+    @Test
     void tagOperationsOnANonSubnetGroupArnFault() {
         ObjectNode listRequest = mapper.createObjectNode();
         listRequest.put("ResourceArn", "arn:aws:dms:" + REGION + ":" + ACCOUNT_ID + ":rep:Example");
@@ -327,6 +355,8 @@ class DmsServiceTest {
         return switch (subnetId) {
             case "subnet-a" -> subnet(subnetId, VPC_ID, "us-east-1a");
             case "subnet-b" -> subnet(subnetId, VPC_ID, "us-east-1b");
+            case "subnet-a2" -> subnet(subnetId, VPC_ID, "us-east-1a");
+            case "subnet-no-az" -> subnet(subnetId, VPC_ID, null);
             case "subnet-other-vpc" -> subnet(subnetId, "vpc-0other", "us-east-1b");
             default -> null;
         };

--- a/src/test/java/io/github/hectorvent/floci/services/dms/DmsServiceTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/dms/DmsServiceTest.java
@@ -1,0 +1,201 @@
+package io.github.hectorvent.floci.services.dms;
+
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ArrayNode;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import io.github.hectorvent.floci.core.common.AwsException;
+import io.github.hectorvent.floci.core.storage.AccountAwareStorageBackend;
+import io.github.hectorvent.floci.core.storage.StorageFactory;
+import io.github.hectorvent.floci.services.dms.model.ReplicationSubnetGroup;
+import io.github.hectorvent.floci.services.ec2.Ec2Service;
+import io.github.hectorvent.floci.services.ec2.model.Subnet;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyList;
+import static org.mockito.ArgumentMatchers.anyMap;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+class DmsServiceTest {
+    private static final String REGION = "us-east-1";
+    private static final String ACCOUNT_ID = "123456789012";
+    private static final String VPC_ID = "vpc-0dms";
+
+    private final ObjectMapper mapper = new ObjectMapper();
+    private DmsService service;
+
+    @BeforeEach
+    @SuppressWarnings({"unchecked", "rawtypes"})
+    void setUp() {
+        StorageFactory storageFactory = mock(StorageFactory.class);
+        AccountAwareStorageBackend<ReplicationSubnetGroup> store =
+                AccountAwareStorageBackend.inMemory(ACCOUNT_ID);
+        when(storageFactory.create(eq("dms"), eq("dms-replication-subnet-groups.json"), any(TypeReference.class)))
+                .thenReturn((AccountAwareStorageBackend) store);
+
+        Ec2Service ec2Service = mock(Ec2Service.class);
+        when(ec2Service.describeSubnets(eq(REGION), anyList(), anyMap())).thenAnswer(invocation -> {
+            List<String> requested = invocation.getArgument(1);
+            return requested.stream().map(DmsServiceTest::subnet).filter(java.util.Objects::nonNull).toList();
+        });
+        service = new DmsService(storageFactory, ec2Service);
+    }
+
+    @Test
+    void createStoresGroupUnderLowercasedIdentifier() {
+        service.createReplicationSubnetGroup(
+                createRequest("Tf-Example", "example", "subnet-a", "subnet-b"), REGION);
+
+        List<ReplicationSubnetGroup> described =
+                service.describeReplicationSubnetGroups(filterRequest("tf-example"), REGION);
+
+        assertEquals(1, described.size());
+        ReplicationSubnetGroup group = described.getFirst();
+        assertEquals("tf-example", group.getReplicationSubnetGroupIdentifier());
+        assertEquals("example", group.getReplicationSubnetGroupDescription());
+        assertEquals(VPC_ID, group.getVpcId());
+        assertEquals("Complete", group.getSubnetGroupStatus());
+        assertEquals(List.of("subnet-a", "subnet-b"), group.getSubnetIds());
+        assertEquals(Map.of("subnet-a", "us-east-1a", "subnet-b", "us-east-1b"),
+                group.getSubnetAvailabilityZones());
+        assertEquals(List.of("IPV4"), group.getSupportedNetworkTypes());
+    }
+
+    @Test
+    void createRejectsDuplicateIdentifierRegardlessOfCase() {
+        service.createReplicationSubnetGroup(createRequest("dup", "first", "subnet-a", "subnet-b"), REGION);
+
+        AwsException duplicate = assertThrows(AwsException.class, () -> service.createReplicationSubnetGroup(
+                createRequest("DUP", "second", "subnet-a", "subnet-b"), REGION));
+        assertEquals("ResourceAlreadyExistsFault", duplicate.getErrorCode());
+    }
+
+    @Test
+    void createRejectsUnknownSubnets() {
+        AwsException invalid = assertThrows(AwsException.class, () -> service.createReplicationSubnetGroup(
+                createRequest("bad-subnets", "example", "subnet-a", "subnet-missing"), REGION));
+        assertEquals("InvalidSubnet", invalid.getErrorCode());
+    }
+
+    @Test
+    void createRejectsSubnetsInASingleAvailabilityZone() {
+        AwsException tooFewZones = assertThrows(AwsException.class, () -> service.createReplicationSubnetGroup(
+                createRequest("one-az", "example", "subnet-a"), REGION));
+        assertEquals("ReplicationSubnetGroupDoesNotCoverEnoughAZs", tooFewZones.getErrorCode());
+    }
+
+    @Test
+    void createRejectsSubnetsSpanningVpcs() {
+        AwsException crossVpc = assertThrows(AwsException.class, () -> service.createReplicationSubnetGroup(
+                createRequest("cross-vpc", "example", "subnet-a", "subnet-other-vpc"), REGION));
+        assertEquals("InvalidSubnet", crossVpc.getErrorCode());
+    }
+
+    @Test
+    void createRejectsMissingDescription() {
+        ObjectNode request = createRequest("no-description", null, "subnet-a", "subnet-b");
+        AwsException missing = assertThrows(AwsException.class,
+                () -> service.createReplicationSubnetGroup(request, REGION));
+        assertEquals("InvalidParameterValueException", missing.getErrorCode());
+    }
+
+    @Test
+    void createRejectsReservedDefaultIdentifier() {
+        AwsException reserved = assertThrows(AwsException.class, () -> service.createReplicationSubnetGroup(
+                createRequest("Default", "example", "subnet-a", "subnet-b"), REGION));
+        assertEquals("InvalidParameterValueException", reserved.getErrorCode());
+    }
+
+    @Test
+    void describeIsScopedToTheRequestRegion() {
+        service.createReplicationSubnetGroup(createRequest("scoped", "example", "subnet-a", "subnet-b"), REGION);
+
+        assertTrue(service.describeReplicationSubnetGroups(mapper.createObjectNode(), "eu-west-1").isEmpty());
+    }
+
+    @Test
+    void describeOfMissingGroupFaults() {
+        AwsException notFound = assertThrows(AwsException.class,
+                () -> service.describeReplicationSubnetGroups(filterRequest("absent"), REGION));
+        assertEquals("ResourceNotFoundFault", notFound.getErrorCode());
+    }
+
+    @Test
+    void deleteRemovesTheGroup() {
+        service.createReplicationSubnetGroup(createRequest("doomed", "example", "subnet-a", "subnet-b"), REGION);
+        service.deleteReplicationSubnetGroup(identifierRequest("doomed"), REGION);
+
+        AwsException notFound = assertThrows(AwsException.class,
+                () -> service.describeReplicationSubnetGroups(filterRequest("doomed"), REGION));
+        assertEquals("ResourceNotFoundFault", notFound.getErrorCode());
+    }
+
+    @Test
+    void deleteOfMissingGroupFaults() {
+        AwsException notFound = assertThrows(AwsException.class,
+                () -> service.deleteReplicationSubnetGroup(identifierRequest("absent"), REGION));
+        assertEquals("ResourceNotFoundFault", notFound.getErrorCode());
+    }
+
+    @Test
+    void clearRemovesPersistedState() {
+        service.createReplicationSubnetGroup(createRequest("reset-me", "example", "subnet-a", "subnet-b"), REGION);
+        service.clear();
+
+        assertTrue(service.describeReplicationSubnetGroups(mapper.createObjectNode(), REGION).isEmpty());
+    }
+
+    private ObjectNode createRequest(String identifier, String description, String... subnetIds) {
+        ObjectNode request = identifierRequest(identifier);
+        if (description != null) {
+            request.put("ReplicationSubnetGroupDescription", description);
+        }
+        ArrayNode subnets = request.putArray("SubnetIds");
+        for (String subnetId : subnetIds) {
+            subnets.add(subnetId);
+        }
+        return request;
+    }
+
+    private ObjectNode identifierRequest(String identifier) {
+        ObjectNode request = mapper.createObjectNode();
+        request.put("ReplicationSubnetGroupIdentifier", identifier);
+        return request;
+    }
+
+    private ObjectNode filterRequest(String identifier) {
+        ObjectNode request = mapper.createObjectNode();
+        ObjectNode filter = request.putArray("Filters").addObject();
+        filter.put("Name", "replication-subnet-group-id");
+        filter.putArray("Values").add(identifier);
+        return request;
+    }
+
+    private static Subnet subnet(String subnetId) {
+        return switch (subnetId) {
+            case "subnet-a" -> subnet(subnetId, VPC_ID, "us-east-1a");
+            case "subnet-b" -> subnet(subnetId, VPC_ID, "us-east-1b");
+            case "subnet-other-vpc" -> subnet(subnetId, "vpc-0other", "us-east-1b");
+            default -> null;
+        };
+    }
+
+    private static Subnet subnet(String subnetId, String vpcId, String availabilityZone) {
+        Subnet subnet = new Subnet();
+        subnet.setSubnetId(subnetId);
+        subnet.setVpcId(vpcId);
+        subnet.setAvailabilityZone(availabilityZone);
+        subnet.setRegion(REGION);
+        return subnet;
+    }
+}

--- a/src/test/resources/application.yml
+++ b/src/test/resources/application.yml
@@ -441,3 +441,5 @@ floci:
       enabled: true
     marketplace:
       enabled: true
+    dms:
+      enabled: true

--- a/tools/docs/services.yaml
+++ b/tools/docs/services.yaml
@@ -147,6 +147,10 @@ services:
     doc: docs/services/detective.md
     sources:
       - { path: src/main/java/io/github/hectorvent/floci/services/detective/DetectiveController.java, mode: rest }
+  - service: dms
+    doc: docs/services/dms.md
+    sources:
+      - { path: src/main/java/io/github/hectorvent/floci/services/dms/DmsJsonHandler.java, mode: switch }
   - service: docdb
     doc: docs/services/docdb.md
     sources:


### PR DESCRIPTION
## Summary

Adds a minimal **AWS DMS** service. DMS was entirely absent — every operation answered `UnknownOperationException` — which blocks all DMS examples in Gruntwork's terraform-aws-data-storage module at the first resource.

Two commits, reviewable separately:

1. **Replication subnet group lifecycle** — `CreateReplicationSubnetGroup`, `DescribeReplicationSubnetGroups` (with the model's only documented filter, `replication-subnet-group-id`), `DeleteReplicationSubnetGroup`. Identifier rules per the API model: alphanumeric/period/underscore/hyphen only, stored lowercase, `"default"` refused; ≥2 subnets required (`ReplicationSubnetGroupDoesNotCoverEnoughAZs`); modelled faults `ResourceAlreadyExistsFault` / `ResourceNotFoundFault`.
2. **Resource tagging** — `ListTagsForResource` (both `ResourceArn` and `ResourceArnList` forms, with per-tag `ResourceArn` only on the list form, per the model's wording), `AddTagsToResource` (merge), `RemoveTagsFromResource`; `Tags` accepted on create. Key/value limits and the `aws:`/`dms:` reserved-prefix rule validated per the model. A cross-account ARN guard answers `ResourceNotFoundFault` rather than resolving another account's name.

Registered as a JSON 1.1 service under the `AmazonDMSv20160101.` target prefix / `dms` signing scope (verified against botocore's `service-2.json`).

Notes for reviewers: `InvalidParameterValueException` (used for missing description / bad identifier) is not a modelled DMS shape — real DMS returns it as a non-modelled runtime error, so this matches observed behaviour rather than substituting a modelled fault AWS does not send. The subnet-group ARN format (`arn:aws:dms:<region>:<account>:subgrp:<id>`) has no example in the model; it follows the Terraform provider's client-side construction. `DescribeReplicationSubnetGroups` implements the documented 20-100 `MaxRecords` contract with resumable `Marker` pagination, emitting `Marker` only on non-final pages.

## Type of change

- [ ] Bug fix (`fix:`)
- [x] New feature (`feat:`)
- [ ] Breaking change (`feat!:` or `fix!:`)
- [ ] Docs / chore

## AWS Compatibility

Wire protocol verified against botocore `dms/2016-01-01/service-2.json` (target prefix, error shapes, member casing, tag semantics) and exercised with AWS CLI 2.x. Before this change every DMS call answered `UnknownOperationException`; a standalone reproduction (create → describe → tag → untag → delete) passes on this branch. SDK-level coverage included in `compatibility-tests`.

## Checklist

- [x] `./mvnw test` passes locally — modulo four pre-existing machine-local failures (`CustomDomainTlsIntegrationTest`, `IotMqttWebSocketProxyIntegrationTest`, order-dependent `MacieOrganizationIntegrationTest`, intermittent `RdsAwsIntegrationTest`) that reproduce identically on pristine `upstream/main` on this machine and pass in isolation
- [x] New or updated integration test added
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)


